### PR TITLE
Update manifest to use new buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ applications:
 - name: initializr
   memory: 1024M
   instances: 1
-  url: initializr.cfapps.io
+  host: initializr
+  domain: cfapps.io
   path: .
-  command: java -jar ./spring/lib/*.jar run --cp . --local app.groovy -- --server.port=$PORT
-#  buildpack: https://github.com/dsyer/cloudfoundry-buildpack-java
+  buildpack: https://github.com/cloudfoundry/java-buildpack

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,0 @@
-java.runtime.version=1.6


### PR DESCRIPTION
Previously the manifest for this application was configured such that
it used a custom command to start itself (based on Spring Boot).  This
change removes that custom command and substitutes in the new Java
buildpack which takes care of all of the things that command
previously did.  A byproduct of this is that as improvements are made
to the main buildpack they will automatically get included in future
pushes of the application.  An example of this is that now, if a New
Relic service is bound to the application, the application will
automatically be configured to use it.

A couple of notes about the commit:
1.  To suppress the warnings about `url` being removed in later versions of the `cf` gem, I've updated the manifest to use the split `host` and `domain` hash keys.  A `gem update cf` will bring a copy of `cf` up to date with this new manifest structure.  If for some reason this can't be done, simply skip those lines (or tell me to resubmit the pull request) when merging.
2.  Every time I've attempted to push this application to http://run.pivotal.io I've encountered an error:

```
Reading logs/stderr.log... OK
java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.springframework.boot.cli.runner.SpringApplicationRunner$RunThread.run(SpringApplicationRunner.java:141)
Caused by: java.lang.NullPointerException
    at java.util.Hashtable.put(Hashtable.java:542)
    at java.util.Hashtable.putAll(Hashtable.java:615)
    at org.springframework.boot.context.initializer.VcapApplicationContextInitializer.getPropertiesFromApplication(VcapApplicationContextInitializer.java:142)
    at org.springframework.boot.context.initializer.VcapApplicationContextInitializer.initialize(VcapApplicationContextInitializer.java:113)
    at org.springframework.boot.SpringApplication.applyInitializers(SpringApplication.java:357)
    at org.springframework.boot.SpringApplication.run(SpringApplication.java:266)
    at org.springframework.boot.SpringApplication.run(SpringApplication.java:678)
    ... 5 more
```

I don't believe that this is due to anything I've done, but you might want to do some testing (pushing the app before this is merged) to determine if there is some different behavior.

[#54518830]
