### PR TITLE
Fix maven warning

### DIFF
--- a/templates/starter-pom.xml
+++ b/templates/starter-pom.xml
@@ -14,6 +14,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>${bootVersion}</version>
+		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
 	<dependencies><% styles.each { %>
@@ -29,6 +30,7 @@
 	</dependencies>
 
 	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>${packageName}.Application</start-class>
 		<java.version>1.7</java.version>
 	</properties>


### PR DESCRIPTION
This commit fixes a warning displayed by Maven due to the fact that
no relativePath is set and maven defaults to the parent directory. As
the parent is never going to be available in such directory and we use
the maven repository to fetch it, this commit sets an unknown relative
path explicitly.

Also fixing to UTF-8 encoding which is a sane default. Fixing the
encoding removes some warning when copying filtered resources.
