### PR TITLE
Fix pom alignment

### DIFF
--- a/templates/starter-pom.xml
+++ b/templates/starter-pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This commit fixes an alignment issue for the test scope added for the
spring-boot-starter-test module.
