### PR TITLE
Upgrade to 1.1.0.RELEASE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ spring
 grapes
 spring.zip
 repository/
+*.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You need Java (1.6 or better) and a bash-like shell.
 
 If you are on a Mac and using [homebrew](http://brew.sh/), all you need to do to install it is:
 
-    $ brew install spring-boot-cli
+    $ brew tap pivotal/tap && brew install springboot
 
 It will install `/usr/local/bin/spring`. You can jump right to [running the app](#running_the_app).
 

--- a/app.groovy
+++ b/app.groovy
@@ -10,7 +10,7 @@ class MainController {
   @Value('${info.home:http://localhost:8080/}')
   private String home
 
-  @Value('${info.spring-boot.version:1.0.1.RELEASE}')
+  @Value('${info.spring-boot.version:1.1.0.RELEASE}')
   private String bootVersion
 
   @Value('${TMPDIR:.}')
@@ -39,7 +39,19 @@ class MainController {
     model["styles"] << [name:"Rest Repositories", value:"data-rest"]
     model["styles"] << [name:"Remote Shell", value:"remote-shell"]
     model["styles"] << [name:"Mobile", value:"mobile"]
-    model["types"] = [[name:"Maven POM", value:"pom.xml", selected: false], 
+    model["styles"] << [name:"Elasticsearch", value:"data-elasticsearch"]
+    model["styles"] << [name:"Gemfire", value:"data-gemfire"]
+    model["styles"] << [name:"Solr", value:"data-solr"]
+    model["styles"] << [name:"Freemarker", value:"freemarker"]
+    model["styles"] << [name:"Groovy Templates", value:"groovy-templates"]
+    model["styles"] << [name:"Velocity", value:"velocity"]
+    model["styles"] << [name:"HornetQ", value:"hornetq"]
+    model["styles"] << [name:"Social Facebook", value:"social-facebook"]
+    model["styles"] << [name:"Social LinkedIn", value:"social-linkedin"]
+    model["styles"] << [name:"Social Twitter", value:"social-twitter"]
+    model["styles"] << [name:"WebSocket", value:"websocket"]
+    model["styles"] << [name:"SOAP", value:"ws"]
+    model["types"] = [[name:"Maven POM", value:"pom.xml", selected: false],
                       [name:"Maven Project", value:"starter.zip", selected: true], 
                       [name:"Gradle Build", value:"build.gradle", selected: false]]
 

--- a/application.properties
+++ b/application.properties
@@ -1,5 +1,5 @@
 info.project.name: Spring Start
 info.project.version: 0.0.1
 # remember to update static/install.sh as well:
-info.spring-boot.version: 1.0.2.RELEASE
+info.spring-boot.version: 1.1.0.RELEASE
 

--- a/templates/starter-build.gradle
+++ b/templates/starter-build.gradle
@@ -31,8 +31,8 @@ repositories {
 }
 
 dependencies {<% styles.each { %>
-    compile("org.springframework.boot:spring-boot-starter${it}:\${springBootVersion}")<% } %>
-    testCompile("org.springframework.boot:spring-boot-starter-test:\${springBootVersion}")
+    compile("org.springframework.boot:spring-boot-starter${it}")<% } %>
+    testCompile("org.springframework.boot:spring-boot-starter-test")
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
- Upgrade default version to 1.1.0.RELEASE
- Add all the new starters added since previous release
- fix build.gradle dropping version numbers on all the dependents
