### PR TITLE
Switch to https for build files

### DIFF
--- a/initializr/src/main/resources/templates/starter-build.gradle
+++ b/initializr/src/main/resources/templates/starter-build.gradle
@@ -4,8 +4,8 @@ buildscript {
     }
     repositories {
         mavenCentral()<% if (!bootVersion.contains("RELEASE")) { %>
-        maven { url "http://repo.spring.io/snapshot" }
-        maven { url "http://repo.spring.io/milestone" }
+        maven { url "https://repo.spring.io/snapshot" }
+        maven { url "https://repo.spring.io/milestone" }
 <% } %>
     }
     dependencies {
@@ -30,8 +30,8 @@ targetCompatibility = ${javaVersion}
 
 repositories {
     mavenCentral()<% if (!bootVersion.contains("RELEASE")) { %>
-    maven { url "http://repo.spring.io/snapshot" }
-    maven { url "http://repo.spring.io/milestone" }
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" }
 <% } %>
 }
 

--- a/initializr/src/main/resources/templates/starter-pom.xml
+++ b/initializr/src/main/resources/templates/starter-pom.xml
@@ -83,7 +83,7 @@
 		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -91,7 +91,7 @@
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/milestone</url>
+			<url>https://repo.spring.io/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -101,7 +101,7 @@
 		<pluginRepository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -109,7 +109,7 @@
 		<pluginRepository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/milestone</url>
+			<url>https://repo.spring.io/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>


### PR DESCRIPTION
This updates the template gradle/maven build files to use https://repo instead of http://repo
