### PR TITLE
Add option to create Spring Boot CLI apps based on checkboxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ spring.zip
 repository/
 .idea
 *.iml
+out

--- a/initializr-service/application.yml
+++ b/initializr-service/application.yml
@@ -29,6 +29,8 @@ initializr:
             - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-using-jdbc-template[Using JdbcTemplate]
             - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-intialize-a-database-using-spring-jdbc[Initializing a database using Spring JDBC]
             - http://spring.io/guides/gs/relational-data-access/[Accessing Relational Data using JDBC with Spring]
+          springBootCliAppAttrs:
+            - "JdbcTemplate jdbcTemplate //or declare a NamedParameterJdbcTemplate or a DataSource"
         - name: JPA
           id: data-jpa
           description: Support for the Java Persistence API including spring-data-jpa, spring-orm and Hibernate
@@ -77,23 +79,31 @@ initializr:
             - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-initialize-a-spring-batch-database[Initialize a Spring Batch datanbase]
             - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-batch-applications[Batch applications]
             - http://spring.io/guides/gs/batch-processing/[Creating a Batch Service]
+          springBootCliAnnotations:
+            - "@EnableBatchProcessing"
         - name: Integration
           id: integration
           description: Support for common spring-integration modules
           refdocs:
             - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-integration[Spring Integration]
+          springBootCliAnnotations:
+            - "@EnableIntegration //or define a @MessageEndpoint"
         - name: JMS
           id: hornetq
           description: Support for Java Message Service API via HornetQ
           refdocs:
             - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-jms[JMS Messaging]
             - http://spring.io/guides/gs/messaging-jms/[Messaging with JMS]
+          springBootCliAnnotations:
+            - "@EnableJmsMessaging"
         - name: AMQP
           id: amqp
           description: Support for the Advanced Message Queuing Protocol via spring-rabbit
           refdocs:
             - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-messaging[Messaging]
             - http://spring.io/guides/gs/messaging-rabbitmq/[Messaging with RabbitMQ]
+          springBootCliAnnotations:
+            - "@EnableRabbitMessaging"
     - name: Web
       content:
         - name: Web
@@ -105,12 +115,16 @@ initializr:
             - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-developing-web-applications[Developing web applications]
             - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-reload-java-classes-without-restarting[Reload Java classes without restarting the container]
             - http://spring.io/guides?filter=web[Guides for web apps]
+          springBootCliAnnotations:
+            - "@Controller //or @RestController"
         - name: Websocket
           id: websocket
           description: Support for websocket development with Tomcat
           refdocs:
             - http://spring.io/guides/gs/messaging-stomp-websocket/[Using WebSocket to build an interactive web application]
             - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-create-websocket-endpoints-using-serverendpoint[Create WebSocket endpoints using @ServerEndpoint]
+          springBootCliAnnotations:
+            - "@EnableWebSocket //or @EnableWebSocketMessageBroker"
         - name: WS
           id: ws
           description: Support for Spring Web Services
@@ -125,6 +139,8 @@ initializr:
           description: Support for spring-mobile
           refdocs:
             - http://spring.io/guides/gs/serving-mobile-web-content/[Serving Mobile Web Content with Spring MVC]
+          springBootCliAnnotations:
+            - "@EnableDeviceResolver"
     - name: Template Engines
       content:
         - name: Freemarker
@@ -154,6 +170,8 @@ initializr:
             - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-spring-mvc-template-engines[Template engines]
             - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-reload-groovy-template-content[Reload Groovy templates without restarting the container]
             - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-customize-view-resolvers[Customize ViewResolvers]
+          springBootCliAnnotations:
+            - "@EnableGroovyTemplates"
         - name: Thymeleaf
           id: thymeleaf
           description: Support for the Thymeleaf templating engine, including integration with Spring
@@ -171,16 +189,22 @@ initializr:
           refdocs:
             - http://spring.io/guides/gs/register-facebook-app/[Registering an Application with Facebook]
             - http://spring.io/guides/gs/accessing-facebook/[Accessing Facebook Data]
+          springBootCliAppAttrs:
+            - "Facebook facebookOperations"
         - name: LinkedIn
           id: social-linkedin
           description: Support for spring-social-linkedin
           refdocs:
+          springBootCliAppAttrs:
+            - "LinkedIn linkedInOperations"
         - name: Twitter
           id: social-twitter
           description: Support for spring-social-twitter
           refdocs:
             - http://spring.io/guides/gs/register-twitter-app/[Registering an Application with Twitter]
             - http://spring.io/guides/gs/accessing-twitter/[Accessing Twitter Data]
+          springBootCliAppAttrs:
+            - "Twitter twitterOperations"
     - name: Ops
       content:
         - name: Actuator

--- a/initializr-service/application.yml
+++ b/initializr-service/application.yml
@@ -13,48 +13,87 @@ initializr:
         - name: Security
           id: security
           description: Support for spring-security
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-security[Securing your app]
+            - http://spring.io/guides/gs/securing-web/[Securing a Web Application]
         - name: AOP
           id: aop
           description: Support for aspect-oriented programming including spring-aop and AspectJ
+          refdocs:
     - name: Data
       content:
         - name: JDBC
           id: jdbc
           description: Support for JDBC databases
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-using-jdbc-template[Using JdbcTemplate]
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-intialize-a-database-using-spring-jdbc[Initializing a database using Spring JDBC]
+            - http://spring.io/guides/gs/relational-data-access/[Accessing Relational Data using JDBC with Spring]
         - name: JPA
           id: data-jpa
           description: Support for the Java Persistence API including spring-data-jpa, spring-orm and Hibernate
           aliases:
             - jpa
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-jpa-and-spring-data[JPA and 'Spring Data']
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-data-access[Data Access]
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-initialize-a-database-using-jpa[Initialize a database using JPA]
+            - http://spring.io/guides/gs/accessing-data-jpa/[Accessing Data with JPA]
         - name: MongoDB
           id: data-mongodb
           description: Support for the MongoDB NoSQL Database, including spring-data-mongodb
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-mongodb[Working with NoSQL - MongoDB]
+            - http://spring.io/guides/gs/accessing-data-mongodb/[Accessing MongoDB Data]
         - name: Redis
           id: redis
           description: Support for the REDIS key-value data store, including spring-redis
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-redis[Working with NoSQL - Redis]
+            - http://spring.io/guides/gs/messaging-redis/[Messaging with Redis]
         - name: Gemfire
           id: data-gemfire
           description: Support for the GemFire distributed data store including spring-data-gemfire
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-gemfire[Working with NoSQL - GemFire]
+            - http://spring.io/guides/gs/accessing-data-gemfire/[Accessing Data with GemFire]
+            - http://spring.io/guides/gs/caching-gemfire/[Caching with GemFire]
         - name: Solr
           id: data-solr
           description: Support for the Apache Solr search platform, including spring-data-solr
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-solr[Working with NoSQL - Solr]
         - name: Elasticsearch
           id: data-elasticsearch
           description: Support for the Elasticsearch search and analytics engine including spring-data-elasticsearch
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-elasticsearch[Working with NoSQL - Elasticsearch]
     - name: I/O
       content:
         - name: Batch
           id: batch
           description: Support for Spring Batch including HSQLDB database
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-initialize-a-spring-batch-database[Initialize a Spring Batch datanbase]
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-batch-applications[Batch applications]
+            - http://spring.io/guides/gs/batch-processing/[Creating a Batch Service]
         - name: Integration
           id: integration
           description: Support for common spring-integration modules
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-integration[Spring Integration]
         - name: JMS
           id: hornetq
           description: Support for Java Message Service API via HornetQ
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-jms[JMS Messaging]
+            - http://spring.io/guides/gs/messaging-jms/[Messaging with JMS]
         - name: AMQP
           id: amqp
           description: Support for the Advanced Message Queuing Protocol via spring-rabbit
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-messaging[Messaging]
+            - http://spring.io/guides/gs/messaging-rabbitmq/[Messaging with RabbitMQ]
     - name: Web
       content:
         - name: Web
@@ -62,18 +101,30 @@ initializr:
           description: Support for full-stack web development, including Tomcat and spring-webmvc
           facets:
             - web
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-developing-web-applications[Developing web applications]
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-reload-java-classes-without-restarting[Reload Java classes without restarting the container]
+            - http://spring.io/guides?filter=web[Guides for web apps]
         - name: Websocket
           id: websocket
           description: Support for websocket development with Tomcat
+          refdocs:
+            - http://spring.io/guides/gs/messaging-stomp-websocket/[Using WebSocket to build an interactive web application]
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-create-websocket-endpoints-using-serverendpoint[Create WebSocket endpoints using @ServerEndpoint]
         - name: WS
           id: ws
           description: Support for Spring Web Services
+          refdocs:
+            - http://spring.io/guides?filter=soap[Spring WS-based guides]
         - name: Rest Repositories
           id: data-rest
           description: Support for exposing Spring Data repositories over REST via spring-data-rest-webmvc
+          refdocs:
         - name: Mobile
           id: mobile
           description: Support for spring-mobile
+          refdocs:
+            - http://spring.io/guides/gs/serving-mobile-web-content/[Serving Mobile Web Content with Spring MVC]
     - name: Template Engines
       content:
         - name: Freemarker
@@ -81,40 +132,68 @@ initializr:
           description: Support for the FreeMarker templating engine
           facets:
             - web
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-spring-mvc-template-engines[Template engines]
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-reload-freemarker-content[Reload Freemarker templates without restarting the container]
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-customize-view-resolvers[Customize ViewResolvers]
         - name: Velocity
           id: velocity
           description: Support for the Velocity templating engine
           facets:
             - web
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-spring-mvc-template-engines[Template engines]
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-reload-velocity-content[Reload Velocity templates without restarting the container]
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-customize-view-resolvers[Customize ViewResolvers]
         - name: Groovy Templates
           id: groovy-templates
           description: Support for the Groovy templating engine
           facets:
             - web
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-spring-mvc-template-engines[Template engines]
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-reload-groovy-template-content[Reload Groovy templates without restarting the container]
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-customize-view-resolvers[Customize ViewResolvers]
         - name: Thymeleaf
           id: thymeleaf
           description: Support for the Thymeleaf templating engine, including integration with Spring
           facets:
             - web
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-spring-mvc-template-engines[Template engines]
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-reload-thymeleaf-content[Reload Thymeleaf templates without restarting the container]
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-customize-view-resolvers[Customize ViewResolvers]
     - name: Social
       content:
         - name: Facebook
           id: social-facebook
           description: Support for spring-social-facebook
+          refdocs:
+            - http://spring.io/guides/gs/register-facebook-app/[Registering an Application with Facebook]
+            - http://spring.io/guides/gs/accessing-facebook/[Accessing Facebook Data]
         - name: LinkedIn
           id: social-linkedin
           description: Support for spring-social-linkedin
+          refdocs:
         - name: Twitter
           id: social-twitter
           description: Support for spring-social-twitter
+          refdocs:
+            - http://spring.io/guides/gs/register-twitter-app/[Registering an Application with Twitter]
+            - http://spring.io/guides/gs/accessing-twitter/[Accessing Twitter Data]
     - name: Ops
       content:
         - name: Actuator
           id: actuator
           description: Production ready features to help you monitor and manage your application
+          refdocs:
+            - "http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready[Spring Boot Actuator: Production-ready features]"
+            - http://spring.io/guides/gs/actuator-service/[Building a RESTful Web Service with Spring Boot Actuator]
         - name: Remote Shell
           id: remote-shell
           description: Support for CRaSH
+          refdocs:
+            - http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-remote-shell[Monitoring and management using a remote shell]
   types:
     - name: Maven POM
       id: maven-build
@@ -145,6 +224,13 @@ initializr:
       sts-id: gradle.zip
       tags:
         build: gradle
+        format: project
+      default: false
+      action: /starter.zip
+    - name: Spring Boot CLI Project
+      id: spring-boot-cli-project
+      tags:
+        build: spring-boot-cli
         format: project
       default: false
       action: /starter.zip

--- a/initializr/src/main/groovy/io/spring/initializr/InitializrMetadata.groovy
+++ b/initializr/src/main/groovy/io/spring/initializr/InitializrMetadata.groovy
@@ -235,6 +235,11 @@ class InitializrMetadata {
 		// Associated set of doc links for the dependency
 		List<String> refdocs = []
 
+		// Annotation to switch on behavior for Spring Boot CLI instead of @Grab statements
+		List<String> springBootCliAnnotations = []
+
+		List<String> springBootCliAppAttrs = []
+
 		/**
 		 * Specify if the dependency has its coordinates set, i.e. {@code groupId}
 		 * and {@code artifactId}.

--- a/initializr/src/main/groovy/io/spring/initializr/InitializrMetadata.groovy
+++ b/initializr/src/main/groovy/io/spring/initializr/InitializrMetadata.groovy
@@ -232,6 +232,9 @@ class InitializrMetadata {
 
 		String description
 
+		// Associated set of doc links for the dependency
+		List<String> refdocs = []
+
 		/**
 		 * Specify if the dependency has its coordinates set, i.e. {@code groupId}
 		 * and {@code artifactId}.
@@ -365,5 +368,6 @@ class InitializrMetadata {
 		String getName() {
 			(name ?: id)
 		}
+
 	}
 }

--- a/initializr/src/main/groovy/io/spring/initializr/ProjectGenerator.groovy
+++ b/initializr/src/main/groovy/io/spring/initializr/ProjectGenerator.groovy
@@ -136,7 +136,6 @@ class ProjectGenerator {
 	 */
 	private File doGenerateSpringBootCliStructure(File dir, def model, ProjectRequest request) {
 		model.externalLibraries = []
-		model.shortcutLibraries = []
 		model.annotations = []
 		model.applicationAttributes = []
 		println(model)
@@ -164,13 +163,13 @@ class ProjectGenerator {
 			} else if (it.name.equals('AMQP')) {
 				model.annotations << "@EnableRabbitMessaging"
 			} else if (it.name.equals('Freemarker')) {
-				model.shortcutLibraries << "freemarker"
+				model.externalLibraries << it
 			} else if (it.name.equals('Velocity')) {
 				model.externalLibraries << it
 			} else if (it.name.equals('Groovy Templates')) {
 				model.annotations << "@EnableGroovyTemplates"
 			} else if (it.name.equals('Thymeleaf')) {
-				model.shortcutLibraries << 'thymeleaf-spring4'
+				model.externalLibraries << it
 				thymeleaf = true
 			} else if (it.name.equals('JDBC')) {
 				model.applicationAttributes << "JdbcTemplate jdbcTemplate //or declare a NamedParameterJdbcTemplate or a DataSource"

--- a/initializr/src/main/groovy/io/spring/initializr/ProjectGenerator.groovy
+++ b/initializr/src/main/groovy/io/spring/initializr/ProjectGenerator.groovy
@@ -135,11 +135,6 @@ class ProjectGenerator {
 	 * a directory containing the project.
 	 */
 	private File doGenerateSpringBootCliStructure(File dir, def model, ProjectRequest request) {
-		model.externalLibraries = []
-		model.annotations = []
-		model.applicationAttributes = []
-		println(model)
-
 		boolean thymeleaf = false
 		boolean springSecurity = false
 		boolean springDataRest = false
@@ -152,88 +147,40 @@ class ProjectGenerator {
 
 		model.resolvedDependencies.each {
 			if (it.name.equals('Security')) {
-				model.externalLibraries << it
 				springSecurity = true
-			} else if (it.name.equals('Batch')) {
-				model.annotations << "@EnableBatchProcessing"
-			} else if (it.name.equals('Integration')) {
-				model.annotations << "@EnableIntegration //or define a @MessageEndpoint"
-			} else if (it.name.equals('JMS')) {
-				model.annotations << "@EnableJmsMessaging"
-			} else if (it.name.equals('AMQP')) {
-				model.annotations << "@EnableRabbitMessaging"
-			} else if (it.name.equals('Freemarker')) {
-				model.externalLibraries << it
-			} else if (it.name.equals('Velocity')) {
-				model.externalLibraries << it
-			} else if (it.name.equals('Groovy Templates')) {
-				model.annotations << "@EnableGroovyTemplates"
 			} else if (it.name.equals('Thymeleaf')) {
-				model.externalLibraries << it
 				thymeleaf = true
-			} else if (it.name.equals('JDBC')) {
-				model.applicationAttributes << "JdbcTemplate jdbcTemplate //or declare a NamedParameterJdbcTemplate or a DataSource"
 			} else if (it.name.equals('JPA')) {
-				model.externalLibraries << it
 				springDataJpa = true
 			} else if (it.name.equals('MongoDB')) {
-				model.externalLibraries << it
 				springDataMongo = true
 			} else if (it.name.equals('Redis')) {
-				model.externalLibraries << it
 				springDataRedis = true
 			} else if (it.name.equals('Gemfire')) {
-				model.externalLibraries << it
 				springDataGemfire = true
 			} else if (it.name.equals('Solr')) {
-				model.externalLibraries << it
 				springDataSolr = true
 			} else if (it.name.equals('Elasticsearch')) {
-				model.externalLibraries << it
 				springDataElasticsearch = true
-			} else if (it.name.equals('Web')) {
-				model.annotations << "@Controller //or @RestController"
-			} else if (it.name.equals('Websocket')) {
-				model.annotations << "@EnableWebSocket //or @EnableWebSocketMessageBroker"
-			} else if (it.name.equals('WS')) {
-				model.externalLibraries << it
 			} else if (it.name.equals('Rest Repositories')) {
-				model.externalLibraries << it
 				springDataRest = true
-			} else if (it.name.equals('Mobile')) {
-				model.annotations << "@EnableDeviceResolver"
-			} else if (it.name.equals('Facebook')) {
-				model.applicationAttributes << "Facebook facebookOperations"
-			} else if (it.name.equals('LinkedIn')) {
-				model.applicationAttributes << "LinkedIn linkedInOperations"
-			} else if (it.name.equals('Twitter')) {
-				model.applicationAttributes << "Twitter twitterOperations"
-			} else if (it.name.equals('Actuator')) {
-				model.externalLibraries << it
-			} else if (it.name.equals('Remote Shell')) {
-				model.externalLibraries << it
-			} else { // catch any unknown check boxes
-				model.externalLibraries << it
 			}
 		}
 
 		// Synergistic combinations
 		if (thymeleaf && springSecurity) {
-			model.externalLibraries << [groupId: "org.thymeleaf.extras", artifactId: "thymeleaf-extras-springsecurity3"]
+			// Figure out how to add [groupId: "org.thymeleaf.extras", artifactId: "thymeleaf-extras-springsecurity3"]
 		}
 		if (springDataRest) {
-			model.resolvedDependencies.each {
-				if (it.name.equals('Rest Repositories')) {
-					if (springDataJpa) {
-						it.refdocs << "http://spring.io/guides/gs/accessing-data-rest/[Accessing JPA Data with REST]"
-					}
-					if (springDataMongo) {
-						it.refdocs << "http://spring.io/guides/gs/accessing-mongodb-data-rest/[Accessing MongoDB Data with REST]"
-					}
-					if (springDataGemfire) {
-						it.refdocs << "http://spring.io/guides/gs/accessing-gemfire-data-rest/[Accessing GemFire Data with REST]"
-					}
-				}
+			def restRepositoriesDeps = model.resolvedDependencies.find{it.name == "Rest Repositories"}
+			if (springDataJpa) {
+				restRepositoriesDeps.refdocs << "http://spring.io/guides/gs/accessing-data-rest/[Accessing JPA Data with REST]"
+			}
+			if (springDataMongo) {
+				restRepositoriesDeps.refdocs << "http://spring.io/guides/gs/accessing-mongodb-data-rest/[Accessing MongoDB Data with REST]"
+			}
+			if (springDataGemfire) {
+				restRepositoriesDeps.refdocs << "http://spring.io/guides/gs/accessing-gemfire-data-rest/[Accessing GemFire Data with REST]"
 			}
 		}
 

--- a/initializr/src/main/resources/templates/README.adoc
+++ b/initializr/src/main/resources/templates/README.adoc
@@ -1,0 +1,29 @@
+== My cool new Spring Boot app!
+
+This app uses Spring Boot. You have picked:
+<% resolvedDependencies.each { %>
+* ${it.name}<% } %>
+
+These modules manifest as various http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using-boot-starter-poms["starters"] in your build file.
+
+=== Getting Help
+
+Some key bits of documentation regarding your choices:
+<% resolvedDependencies.each {  it.refdocs.each { %>
+* ${it}<% } } %>
+<% if (build.equals('gradle')) {%>* http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#build-tool-plugins-gradle-plugin[Spring Boot Gradle Plugin]<%} else if (build.equals('maven')) {%>* http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#build-tool-plugins-maven-plugin[Spring Boot Maven Plugin]<%}%>
+
+Other general sources of help:
+
+* http://stackoverflow.com/questions/tagged/spring-boot[Stack Overflow]
+* http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/[Spring Boot general reference guide]
+* http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-testing[Spring Boot Testing]
+* http://projects.spring.io/spring-boot/[Spring Boot project page]
+
+=== What do I do with this file?
+
+This file is a helper to get started. Once your project is up and running, feel free to clean it out and plug in details
+about your application. It's written in asciidoctor, which is nicely supported by GitHub if you commit it as README.adoc.
+
+Happy coding!
+-- The Spring Boot team

--- a/initializr/src/main/resources/templates/spring-boot-cli-README.adoc
+++ b/initializr/src/main/resources/templates/spring-boot-cli-README.adoc
@@ -1,0 +1,42 @@
+== My cool new Spring Boot CLI app!
+
+This app uses Spring Boot CLI. You have picked:
+<% resolvedDependencies.each { %>
+* ${it.name}<% } %>
+
+These various options manifest in different ways. Sometimes with `@Grab` statements, and sometimes through the usage of other things, like annotations.
+
+=== Installing Spring Boot CLI
+
+Check out http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#getting-started-installing-the-cli[Installing the Spring Boot CLI] for more details on how to install it and run your new app!
+
+=== Using the right version of `spring`
+
+Got http://gvmtool.net/[GVM]? You can easily ask gvm to switch to the version of `spring` this app was originally built with.
+
+```
+\$ gvm use springboot ${bootVersion}
+\$ spring run app.groovy
+```
+
+=== Getting Help
+
+Some key bits of documentation regarding your choices:
+<% resolvedDependencies.each {  it.refdocs.each { %>
+* ${it}<% } } %>
+
+Other general sources of help:
+
+* http://stackoverflow.com/questions/tagged/spring-boot[Stack Overflow]
+* http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#cli[Spring Boot ref docs - CLI section]
+* http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#cli-testing[Writing tests for Spring Boot CLI]
+* http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/[Spring Boot general reference guide]
+* http://projects.spring.io/spring-boot/[Spring Boot project page]
+
+=== What do I do with this file?
+
+This file is a helper to get started. Once your project is up and running, feel free to clean it out and plug in details
+about your application. It's written in asciidoctor, which is nicely supported by GitHub if you commit it as README.adoc.
+
+Happy coding!
+-- The Spring Boot team

--- a/initializr/src/main/resources/templates/spring-boot-cli-app.groovy
+++ b/initializr/src/main/resources/templates/spring-boot-cli-app.groovy
@@ -1,0 +1,23 @@
+package ${packageName}
+
+/**
+ * ${name}
+ * ${description}
+ *
+ * Artifact: ${artifactId}
+ * Group: ${groupId}
+ *
+ * Built with the following features: <% resolvedDependencies.each { %>
+ * - ${it.name}<% } %>
+ *
+ * @author Spring Initializr
+ */
+<% shortcutLibraries.each { %>
+@Grab('${it}')<% } %><% externalLibraries.each { %>
+@Grab('${it.artifactId}')<% } %><% annotations.each { %>
+${it}<% } %>
+class App {
+	<% applicationAttributes.each { %>
+	${it}<% } %>
+
+}

--- a/initializr/src/main/resources/templates/spring-boot-cli-app.groovy
+++ b/initializr/src/main/resources/templates/spring-boot-cli-app.groovy
@@ -12,12 +12,23 @@ package ${packageName}
  *
  * @author Spring Initializr
  */
-<% shortcutLibraries.each { %>
-@Grab('${it}')<% } %><% externalLibraries.each { %>
-@Grab('${it.artifactId}')<% } %><% annotations.each { %>
-${it}<% } %>
+<% resolvedDependencies.each {
+	if (it?.springBootCliAnnotations?.size() > 0) {} else {%>
+@Grab('${it.artifactId}')<%
+	}
+}
+resolvedDependencies.each {
+	if (it?.springBootCliAnnotations?.size() > 0) {
+		it.springBootCliAnnotations.each {%>
+${it}<%
+		}
+	}
+} %>
 class App {
-	<% applicationAttributes.each { %>
-	${it}<% } %>
+	<% resolvedDependencies.each {
+		it.springBootCliAppAttrs.each {%>
+	${it}<%
+		}
+	} %>
 
 }


### PR DESCRIPTION
Currently, user can create maven/gradle projects/build files. Another useful option would be to create a Spring Boot CLI app.

Some things, like Web, might entail:
```java
@Controller // or use @RestController
class MyController {
}
```
But if the user picks Thymeleaf, we need this:
```java
@Grab("thymeleaf-spring4")
@Controller
class MyController {
}
```
And so on. Some things might manifest in other ways. And for checkboxes we don't yet have a decision, perhaps a comment like this:
```java
// You picked <foo>, but we don't yet support that here
...
```