### PR TITLE
Move <properties> element before <dependencies> one

### DIFF
--- a/initializr/src/main/resources/templates/starter-pom.xml
+++ b/initializr/src/main/resources/templates/starter-pom.xml
@@ -18,6 +18,12 @@
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<start-class>${packageName}.Application</start-class>
+		<java.version>${javaVersion}</java.version>
+	</properties>
+
 	<dependencies><% resolvedDependencies.each { %>
 		<dependency>
 			<groupId>${it.groupId}</groupId>
@@ -39,12 +45,6 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<start-class>${packageName}.Application</start-class>
-		<java.version>${javaVersion}</java.version>
-	</properties>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
I think `<properties>` element should be at the top of the pom.xml file since it is a short one (even with `<properties>` before, we still see the `<dependencies>` one) likely to be often customized (in order to specify the spring version for example).
