### PR TITLE
Add a link to the GitHub project

### DIFF
--- a/initializr/src/main/resources/templates/home.html
+++ b/initializr/src/main/resources/templates/home.html
@@ -18,6 +18,11 @@
                 <h1>Spring Initializr</h1>
                 <p>Bootstrap your application now</p>
             </div>
+            <a href="https://github.com/spring-io/initializr" target="_blank">
+                <img style="position: absolute; top: 0; right: 0; border: 0;"
+                     src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67"
+                     alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png">
+            </a>
         </div>
     </div>
     <form id="form" class="form-horizontal" action="/starter.zip" method="get" role="form">


### PR DESCRIPTION
The project is small and easy to customize/run so I think it is better to encourage people to fork and submit pull requests rather than just giving a link to the bug tracker.
This also tells people that they can fork this project to create their own initializr instance.

Closes gh-52.
