### PR TITLE
Tweak CSS

### DIFF
--- a/initializr/src/main/resources/static/css/spring.css
+++ b/initializr/src/main/resources/static/css/spring.css
@@ -3,6 +3,10 @@ body, h1, h2, h3 {
     font-family: "Varela Round",sans-serif;
 }
 
+.top10 {
+    margin-top: 10%;
+}
+
 .initializr-header {
     color: #f1f1f1;
     background-color: #34302d;
@@ -24,4 +28,10 @@ body, h1, h2, h3 {
     line-height: 30px;
     margin-bottom: 20px;
     text-transform: uppercase;
+}
+
+kbd.curl {
+    color: #333;
+    background-color: #ddd;
+    font-weight: 700;
 }

--- a/initializr/src/main/resources/templates/home.html
+++ b/initializr/src/main/resources/templates/home.html
@@ -114,7 +114,7 @@
             <div class="col-sm-6">
                 <h3>Project dependencies</h3>
                 <% dependencies.each { %>
-                <div class="form-group col-sm-6">
+                <div class="form-group col-xs-6">
                 <h4>${it.name}</h4>
                     <% it.content.each { %>
                     <div class="checkbox">
@@ -134,30 +134,30 @@
                 </button>
             </p>
         </div>
-        <div class="page-header">
+        <div class="page-header top10">
             <h1>Spring CLI <small>Quickly prototype with Spring</small></h1>
         </div>
         <div class="row">
             <div class="col-sm-offset-1 col-sm-5">
                 <h3>Spring CLI Zip</h3>
                 <p>
-                    Download the spring CLI as a zip distribution (unpack and run bin/spring on a command line).
-                </p>
-                <p>
                     <a href="/spring.zip" class="btn btn-lg btn-primary" role="button">
                         <span class="glyphicon glyphicon-download-alt"></span> Download Spring CLI Zip
                     </a>
                 </p>
+                <p>
+                    Download the spring CLI as a zip distribution (unpack and run bin/spring on a command line).
+                </p>
             </div>
             <div class="col-sm-5">
                 <h3>Spring CLI Installer</h3>
-                <p>Installer for the spring CLI command on Un*x-like system (should work on Linux, Mac or Cygwin).</p>
-                <p>You can <kbd>curl http://start.spring.io/install.sh | sh</kbd>, or download the script and run it.</p>
                 <p>
                     <a href="/install.sh" class="btn btn-lg btn-primary" role="button">
                         <span class="glyphicon glyphicon-download-alt"></span> Download Spring Installer
                     </a>
                 </p>
+                <p>Installer for the spring CLI command on Un*x-like system (should work on Linux, Mac or Cygwin).</p>
+                <p>You can <kbd class="curl">curl http://start.spring.io/install.sh | sh</kbd>, or download the script and run it.</p>
             </div>
         </div>
     </form>


### PR DESCRIPTION
Love the new CSS but I think a few tweaks could make it even better:

* The project dependencies section could remain a fixed size on the right
* The Spring CLI section could do with a little more separation from the project settings
* If the Download buttons were above the text they would align with each other
* The "curl" text could do with some more spacing an looks a bit aggressive all in black.

Here's a mock up

![screen shot 2014-08-28 at 9 55 16 am](https://cloud.githubusercontent.com/assets/519772/4079367/7c1945a0-2ed4-11e4-8f78-d4a020469fa3.png)
