### PR TITLE
Use spaces in the starter-build.gradle template consistently.

### DIFF
--- a/initializr/src/main/resources/templates/starter-build.gradle
+++ b/initializr/src/main/resources/templates/starter-build.gradle
@@ -41,12 +41,12 @@ repositories {
 <% } %>
 dependencies {<% compileDependencies.each { %>
     compile("${it.groupId}:${it.artifactId}")<% } %><% if (language=='groovy') { %>
-	compile("org.codehaus.groovy:groovy")<% } %><% runtimeDependencies.each { %>
-	runtime("${it.groupId}:${it.artifactId}")<% } %><% if (packaging=='war') { %>
+    compile("org.codehaus.groovy:groovy")<% } %><% runtimeDependencies.each { %>
+    runtime("${it.groupId}:${it.artifactId}")<% } %><% if (packaging=='war') { %>
     providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")<% } %><% providedDependencies.each { %>
-	providedRuntime("${it.groupId}:${it.artifactId}")<% } %>
+    providedRuntime("${it.groupId}:${it.artifactId}")<% } %>
     testCompile("org.springframework.boot:spring-boot-starter-test") <% testDependencies.each { %>
-	testCompile("${it.groupId}:${it.artifactId}")<% } %>
+    testCompile("${it.groupId}:${it.artifactId}")<% } %>
 }
 
 eclipse {


### PR DESCRIPTION
The template adds tabs for some dependencies and spaces for others which generates an inconsisten build.gradle. I've replaces the tabs with 4 spaces since most lines had spaces.

Since the version is still SNAPSHOT I didn't increase it, hope that's ok this way?