### PR TITLE
Add metrics exporter to shared redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tmp*
 initializer-service/spring
 grapes
 spring.zip
+*.jar
 repository/
 .idea
 *.iml

--- a/initializr-service/app.groovy
+++ b/initializr-service/app.groovy
@@ -3,6 +3,7 @@ package app
 import io.spring.initializr.web.LegacyStsController
 
 @Grab('io.spring.initalizr:initializr:1.0.0.BUILD-SNAPSHOT')
+@Grab('spring-boot-starter-redis')
 class InitializerService {
 
 	@Bean

--- a/initializr/pom.xml
+++ b/initializr/pom.xml
@@ -25,6 +25,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-redis</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-groovy-templates</artifactId>
 		</dependency>
 		<dependency>

--- a/initializr/src/main/groovy/io/spring/initializr/config/InitializrMetricsExporterAutoConfiguration.groovy
+++ b/initializr/src/main/groovy/io/spring/initializr/config/InitializrMetricsExporterAutoConfiguration.groovy
@@ -26,6 +26,7 @@ import org.springframework.boot.actuate.metrics.writer.MetricWriter
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext
@@ -46,7 +47,7 @@ import org.springframework.util.ObjectUtils
 @ConditionalOnExpression('${initializr.metrics.rateMillis:5000}>0')
 @EnableScheduling
 @EnableConfigurationProperties(MetricsProperties)
-@AutoConfigureAfter(RedisAutoConfiguration)
+@AutoConfigureAfter(value=RedisAutoConfiguration, name="org.springframework.boot.actuate.autoconfigure.MetricExportAutoConfiguration")
 class InitializrMetricsExporterAutoConfiguration {
 
 	@Autowired
@@ -73,6 +74,7 @@ class InitializrMetricsExporterAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(name="metricWritersMetricExporter")
 	Exporter exporter(InMemoryMetricRepository reader) {
 		new MetricCopyExporter(reader, writer()) {
 					@Override

--- a/initializr/src/main/groovy/io/spring/initializr/config/InitializrMetricsExporterAutoConfiguration.groovy
+++ b/initializr/src/main/groovy/io/spring/initializr/config/InitializrMetricsExporterAutoConfiguration.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.config
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.actuate.metrics.export.Exporter
+import org.springframework.boot.actuate.metrics.export.MetricCopyExporter
+import org.springframework.boot.actuate.metrics.repository.InMemoryMetricRepository
+import org.springframework.boot.actuate.metrics.repository.MetricRepository
+import org.springframework.boot.actuate.metrics.repository.redis.RedisMetricRepository
+import org.springframework.boot.actuate.metrics.writer.MetricWriter
+import org.springframework.boot.autoconfigure.AutoConfigureAfter
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.util.ObjectUtils
+
+/**
+ * @author Dave Syer
+ *
+ */
+@Configuration
+@ConditionalOnBean(RedisConnectionFactory)
+@ConditionalOnExpression('${initializr.metrics.rateMillis:5000}>0')
+@EnableScheduling
+@EnableConfigurationProperties(MetricsProperties)
+@AutoConfigureAfter(RedisAutoConfiguration)
+class InitializrMetricsExporterAutoConfiguration {
+
+	@Autowired
+	RedisConnectionFactory connectionFactory
+
+	@Autowired
+	MetricsProperties metrics
+
+	@Autowired
+	ApplicationContext context
+
+	@Bean
+	MetricWriter writer() {
+		new RedisMetricRepository(connectionFactory,
+				metrics.prefix + metrics.getId(context.getId()) + '.'
+				+ ObjectUtils.getIdentityHexString(context) + '.',
+				metrics.key)
+	}
+
+	@Bean
+	@Primary
+	MetricRepository reader() {
+		new InMemoryMetricRepository()
+	}
+
+	@Bean
+	Exporter exporter(InMemoryMetricRepository reader) {
+		new MetricCopyExporter(reader, writer()) {
+					@Override
+					@Scheduled(fixedRateString = '${initializr.metrics.rateMillis:5000}')
+					void export() {
+						super.export()
+					}
+				}
+	}
+
+}

--- a/initializr/src/main/groovy/io/spring/initializr/config/MetricsProperties.groovy
+++ b/initializr/src/main/groovy/io/spring/initializr/config/MetricsProperties.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.config
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@ConfigurationProperties('initializr.metrics')
+class MetricsProperties {
+
+	/**
+	 * Prefix for redis keys holding metrics in data store.
+	 */
+	String prefix = 'spring.metrics.collector.'
+
+	/**
+	 * Redis key holding index to metrics keys in data store.
+	 */
+	String key = 'keys.spring.metrics.collector'
+
+	/**
+	 * Identifier for application in metrics keys. Keys will be exported in the form
+	 * '[id].[hex].[name]' (where '[id]' is this value, '[hex]' is unique per application
+	 * context, and '[name]' is the "natural" name for the metric.
+	 */
+	@Value('${spring.application.name:${vcap.application.name:application}}')
+	String id
+
+	/**
+	 * The rate (in milliseconds) at which metrics are exported to Redis. If the value is
+	 * <=0 then the export is disabled.
+	 */
+	long rateMillis = 5000L
+
+	boolean isEnabled() {
+		rateMillis > 0
+	}
+
+	String getPrefix() {
+		if (prefix.endsWith('.')) {
+			return prefix
+		}
+		prefix + '.'
+	}
+
+	String getId(String defaultValue) {
+		if (id) return id
+		defaultValue
+	}
+}

--- a/initializr/src/main/groovy/io/spring/initializr/config/MetricsProperties.groovy
+++ b/initializr/src/main/groovy/io/spring/initializr/config/MetricsProperties.groovy
@@ -48,6 +48,7 @@ class MetricsProperties {
 	 * The rate (in milliseconds) at which metrics are exported to Redis. If the value is
 	 * <=0 then the export is disabled.
 	 */
+	@Value('${spring.metrics.export.default.delayMillis:5000}')
 	long rateMillis = 5000L
 
 	boolean isEnabled() {

--- a/initializr/src/main/groovy/io/spring/initializr/metadata/InitializrConfiguration.groovy
+++ b/initializr/src/main/groovy/io/spring/initializr/metadata/InitializrConfiguration.groovy
@@ -30,7 +30,7 @@ class InitializrConfiguration {
 	}
 
 	/**
-	 * Generate a suitable application mame based on the specified name. If no suitable
+	 * Generate a suitable application name based on the specified name. If no suitable
 	 * application name can be generated from the specified {@code name}, the
 	 * {@link Env#fallbackApplicationName} is used instead.
 	 * <p>No suitable application name can be generated if the name is {@code null} or

--- a/initializr/src/main/groovy/io/spring/initializr/metadata/InitializrProperties.groovy
+++ b/initializr/src/main/groovy/io/spring/initializr/metadata/InitializrProperties.groovy
@@ -20,13 +20,15 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
 /**
  * Configuration of the initializr service.
  *
  * @author Stephane Nicoll
  * @since 1.0
  */
-@ConfigurationProperties(prefix = 'initializr', ignoreUnknownFields = false)
+@ConfigurationProperties(prefix = 'initializr')
 @JsonIgnoreProperties(["dependencies", "types", "packagings", "javaVersions", "languages", "bootVersions", "defaults"])
 class InitializrProperties extends InitializrConfiguration {
 

--- a/initializr/src/main/resources/META-INF/spring.factories
+++ b/initializr/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,3 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=io.spring.initializr.config.InitializrAutoConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+io.spring.initializr.config.InitializrAutoConfiguration,\
+io.spring.initializr.config.InitializrMetricsExporterAutoConfiguration

--- a/initializr/src/test/groovy/io/spring/initializr/metrics/MetricsExportTests.groovy
+++ b/initializr/src/test/groovy/io/spring/initializr/metrics/MetricsExportTests.groovy
@@ -45,7 +45,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
  */
 @RunWith(SpringJUnit4ClassRunner)
 @SpringApplicationConfiguration(classes = Config)
-@IntegrationTest(['initializr.metrics.rateMillis:500','initializr.metrics.prefix:test.prefix','initializr.metrics.key:key.test'])
+@IntegrationTest(['spring.metrics.export.default.delayMillis:500','initializr.metrics.prefix:test.prefix','initializr.metrics.key:key.test'])
 public class MetricsExportTests {
 
 	@Rule
@@ -63,7 +63,7 @@ public class MetricsExportTests {
 	@Before
 	void init() {
 		repository = (RedisMetricRepository) writer
-		repository.findAll().forEach {
+		repository.findAll().each {
 			repository.reset(it.name)
 		}
 		assertTrue("Metrics not empty", repository.findAll().size()==0)

--- a/initializr/src/test/groovy/io/spring/initializr/metrics/MetricsExportTests.groovy
+++ b/initializr/src/test/groovy/io/spring/initializr/metrics/MetricsExportTests.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.metrics;
+
+import static org.junit.Assert.*
+import io.spring.initializr.generator.ProjectGenerationMetricsListener
+import io.spring.initializr.generator.ProjectRequest
+import io.spring.initializr.metadata.DefaultMetadataElement
+import io.spring.initializr.metadata.InitializrMetadata
+import io.spring.initializr.metadata.InitializrMetadataProvider
+import io.spring.initializr.support.DefaultInitializrMetadataProvider
+import io.spring.initializr.test.RedisRunning
+
+import org.junit.Before;
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.actuate.metrics.repository.redis.RedisMetricRepository
+import org.springframework.boot.actuate.metrics.writer.MetricWriter
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.test.IntegrationTest
+import org.springframework.boot.test.SpringApplicationConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+
+/**
+ * @author Dave Syer
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner)
+@SpringApplicationConfiguration(classes = Config)
+@IntegrationTest(['initializr.metrics.rateMillis:500','initializr.metrics.prefix:test.prefix','initializr.metrics.key:key.test'])
+public class MetricsExportTests {
+
+	@Rule
+	public RedisRunning running = new RedisRunning()
+	
+	@Autowired
+	ProjectGenerationMetricsListener listener
+	
+	@Autowired
+	@Qualifier("writer")
+	MetricWriter writer
+	
+	RedisMetricRepository repository
+	
+	@Before
+	void init() {
+		repository = (RedisMetricRepository) writer
+		repository.findAll().forEach {
+			repository.reset(it.name)
+		}
+		assertTrue("Metrics not empty", repository.findAll().size()==0)
+	}
+
+	@Test
+	void exportAndCheckMetricsExist() {
+		listener.onGeneratedProject(new ProjectRequest())
+		Thread.sleep(1000L)		
+		assertTrue("No metrics exported", repository.findAll().size()>0)
+	}
+
+	@EnableAutoConfiguration
+	static class Config {
+
+		@Bean
+		InitializrMetadataProvider initializrMetadataProvider(InitializrMetadata metadata) {
+			new DefaultInitializrMetadataProvider(metadata) {
+						@Override
+						protected List<DefaultMetadataElement> fetchBootVersions() {
+							null // Disable metadata fetching from spring.io
+						}
+					}
+		}
+	}
+}

--- a/initializr/src/test/groovy/io/spring/initializr/test/RedisRunning.groovy
+++ b/initializr/src/test/groovy/io/spring/initializr/test/RedisRunning.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.test
+
+import org.junit.Assume
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory
+
+/**
+ * @author Dave Syer
+ *
+ */
+class RedisRunning extends TestWatcher {
+	
+	JedisConnectionFactory connectionFactory; 
+
+	@Override
+	Statement apply(Statement base, Description description) {
+		if (connectionFactory==null) {
+			connectionFactory = new JedisConnectionFactory()
+			connectionFactory.afterPropertiesSet()
+		}
+		try {
+			connectionFactory.connection
+		} catch (Exception e) {
+			Assume.assumeNoException('Cannot connect to Redis (so skipping tests)', e)
+		}
+		super.apply(base, description)
+	}
+
+}

--- a/initializr/src/test/groovy/io/spring/initializr/web/AbstractInitializrControllerIntegrationTests.groovy
+++ b/initializr/src/test/groovy/io/spring/initializr/web/AbstractInitializrControllerIntegrationTests.groovy
@@ -16,18 +16,20 @@
 
 package io.spring.initializr.web
 
-import java.nio.charset.Charset
-
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
 import io.spring.initializr.metadata.DefaultMetadataElement
 import io.spring.initializr.metadata.InitializrMetadata
-import io.spring.initializr.support.DefaultInitializrMetadataProvider
 import io.spring.initializr.metadata.InitializrMetadataProvider
+import io.spring.initializr.support.DefaultInitializrMetadataProvider
 import io.spring.initializr.test.ProjectAssert
+
+import java.nio.charset.Charset
+
 import org.json.JSONObject
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
-
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.test.IntegrationTest
@@ -44,14 +46,11 @@ import org.springframework.test.context.web.WebAppConfiguration
 import org.springframework.util.StreamUtils
 import org.springframework.web.client.RestTemplate
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertTrue
-
 /**
  * @author Stephane Nicoll
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = Config.class)
+@RunWith(SpringJUnit4ClassRunner)
+@SpringApplicationConfiguration(classes = Config)
 @WebAppConfiguration
 @IntegrationTest('server.port=0')
 abstract class AbstractInitializrControllerIntegrationTests {


### PR DESCRIPTION
If a `RedisConnectionFactory` is detected the system will now export
metrics to redis every 5s (`initializr.metrics.rateMillis`). Metric
names are prefixed with `<id>.<hex>`. where `<id>` defaults to the
application name (`initializr.metrics.id`) and `<hex>` is unique. An
aggregator app can then pick up the values and (for instance)
continue counters across restarts and across a cluster.