### PR TITLE
Update generated build.gradle for Boot 1.3 to use latest plugin id

### DIFF
--- a/initializr/src/main/resources/templates/starter-build.gradle
+++ b/initializr/src/main/resources/templates/starter-build.gradle
@@ -16,10 +16,9 @@ buildscript {
 apply plugin: '${language}'<% if (packaging=='war') {  %>
 apply plugin: 'eclipse-wtp'<% } else { %>
 apply plugin: 'eclipse'<% } %>
-apply plugin: 'idea' <% if (bootOneThreeAvailable) { %>
-apply plugin: 'org.springframework.boot.spring-boot' <% } else { %>
-apply plugin: 'spring-boot'
-apply plugin: 'io.spring.dependency-management'<% } %><% if (packaging=='war') {  %>
+apply plugin: 'idea'
+apply plugin: 'spring-boot' <% if (!bootOneThreeAvailable) { %>
+apply plugin: 'io.spring.dependency-management' <% } %><% if (packaging=='war') {  %>
 apply plugin: 'war'
 <% } %>
 

--- a/initializr/src/test/groovy/io/spring/initializr/generator/ProjectGeneratorTests.groovy
+++ b/initializr/src/test/groovy/io/spring/initializr/generator/ProjectGeneratorTests.groovy
@@ -311,7 +311,6 @@ class ProjectGeneratorTests {
 				.contains('classpath("io.spring.gradle:dependency-management-plugin:0.5.0.RELEASE")')
 				.contains("apply plugin: 'spring-boot'")
 				.contains("apply plugin: 'io.spring.dependency-management'")
-				.doesNotContain("apply plugin: 'org.springframework.boot.spring-boot'")
 	}
 
 	@Test
@@ -320,9 +319,8 @@ class ProjectGeneratorTests {
 		request.bootVersion = '1.3.0.BUILD-SNAPSHOT'
 		generateGradleBuild(request)
 				.contains("springBootVersion = '1.3.0.BUILD-SNAPSHOT'")
-				.contains("apply plugin: 'org.springframework.boot.spring-boot'")
+				.contains("apply plugin: 'spring-boot'")
 				.doesNotContain('classpath("io.spring.gradle:dependency-management-plugin:0.5.0.RELEASE")')
-				.doesNotContain("apply plugin: 'spring-boot'")
 				.doesNotContain("apply plugin: 'io.spring.dependency-management'")
 	}
 


### PR DESCRIPTION
Spring Boot 1.3 snapshots had changed the id of the Gradle plugin from
spring-boot to org.springframework.boot.spring-boot. This change has
since been reverted.

This commit updates the Initializr to revert back to using the old id,
spring-boot. Some custom Spring Boot 1.3 logic remains: the dependency
management plugin is not applied to a Boot 1.3 project as Spring Boot
1.3 applies it automatically.