### PR TITLE
Add support for Spring Cloud Services starters

### DIFF
--- a/initializr-service/application.yml
+++ b/initializr-service/application.yml
@@ -36,6 +36,14 @@ initializr:
         version: 1.0.0.BUILD-SNAPSHOT
         additionalBoms: [cloud-bom]
         repositories: spring-snapshots,spring-milestones
+      scs-bom:
+        groupId: io.pivotal.spring.cloud
+        artifactId: spring-cloud-services-dependencies
+        mappings:
+          - versionRange: "[1.3.0.M2,1.3.5.RELEASE]"
+            version: 1.1.0.BUILD-SNAPSHOT
+            repositories: spring-snapshots,spring-milestones
+        additionalBoms: [cloud-bom]
     kotlin:
       version: 1.0.2
   dependencies:
@@ -551,6 +559,25 @@ initializr:
           description: Leadership election and global state with Etcd and spring-cloud-cluster-etcd
           groupId: org.springframework.cloud
           artifactId: spring-cloud-cluster-etcd
+    - name: Spring Cloud Services for Pivotal Cloud Foundry
+      bom: scs-bom
+      versionRange: 1.3.0.RELEASE
+      content:
+        - name: Config Client (Spring Cloud Services)
+          id: scs-config-client
+          description: Config client for Spring Cloud Services on Pivotal Cloud Foundry
+          groupId: io.pivotal.spring.cloud
+          artifactId: spring-cloud-services-starter-config-client
+        - name: Service Registry (Spring Cloud Services)
+          id: scs-service-registry
+          description: Eureka service discovery for Spring Cloud Services on Pivotal Cloud Foundry
+          groupId: io.pivotal.spring.cloud
+          artifactId: spring-cloud-services-starter-service-registry
+        - name: Circuit Breaker (Spring Cloud Services)
+          id: scs-circuit-breaker
+          description: Hystrix circuit breaker for Spring Cloud Services on Pivotal Cloud Foundry
+          groupId: io.pivotal.spring.cloud
+          artifactId: spring-cloud-services-starter-circuit-breaker
     - name: Social
       content:
         - name: Facebook


### PR DESCRIPTION
SCS starters inherit from Spring Cloud Angel.SR4, so they do not support Spring Boot 1.3 yet. We need to limit the version to 1.2.x. Please confirm that I've done that correctly. Thanks.