### PR TITLE
adding a Dataflow server local

### DIFF
--- a/initializr-service/application.yml
+++ b/initializr-service/application.yml
@@ -406,7 +406,7 @@ initializr:
           artifactId: spring-cloud-starter-consul-bus
         - name: Stream Rabbit
           id: cloud-stream-binder-rabbit
-          description: Messaging microservices with RabbitMQ 
+          description: Messaging microservices with RabbitMQ
           versionRange: 1.3.0.M4
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-stream-rabbit
@@ -441,6 +441,16 @@ initializr:
           description: Messaging on AWS with SQS and spring-cloud-aws-messaging
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-aws-messaging
+    - name: Cloud Dataflow
+      bom: cloud-bom
+      versionRange: "1.1.0.BUILD-SNAPSHOT"
+      content:
+        - name: Local Dataflow Server
+          id: cloud-dataflow-server-local
+          description: Local Dataflow Server implementation
+          versionRange: 1.0.0.SNAPSHOT
+          groupId: org.springframework.cloud
+          artifactId: spring-cloud-starter-dataflow-server-local
     - name: Cloud Cluster
       bom: cloud-bom
       versionRange: "1.3.0.M4"
@@ -626,4 +636,3 @@ initializr:
     - name: 1.1.12
       id: 1.1.12.RELEASE
       default: false
-

--- a/initializr-service/application.yml
+++ b/initializr-service/application.yml
@@ -441,13 +441,13 @@ initializr:
           description: Messaging on AWS with SQS and spring-cloud-aws-messaging
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-aws-messaging
-    - name: Cloud Dataflow
+    - name: Cloud Data Flow
       bom: cloud-bom
       versionRange: "1.1.0.BUILD-SNAPSHOT"
       content:
-        - name: Local Dataflow Server
+        - name: Local Data Flow Server
           id: cloud-dataflow-server-local
-          description: Local Dataflow Server implementation
+          description: Local Data Flow Server implementation
           versionRange: 1.0.0.SNAPSHOT
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-dataflow-server-local

--- a/initializr-service/application.yml
+++ b/initializr-service/application.yml
@@ -443,12 +443,12 @@ initializr:
           artifactId: spring-cloud-starter-aws-messaging
     - name: Cloud Data Flow
       bom: cloud-bom
-      versionRange: "1.1.0.BUILD-SNAPSHOT"
+      versionRange: "1.0.0.BUILD-SNAPSHOT"
       content:
         - name: Local Data Flow Server
           id: cloud-dataflow-server-local
           description: Local Data Flow Server implementation
-          versionRange: 1.0.0.SNAPSHOT
+          versionRange: 1.0.0.BUILD-SNAPSHOT
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-dataflow-server-local
     - name: Cloud Cluster


### PR DESCRIPTION
adds the `org.springframework.cloud:spring-cloud-starter-dataflow-server-local` dependency to a generated build from the Spring Initializr 