### PR TITLE
spring cloud starter dataflow server local

### DIFF
--- a/initializr-service/application.yml
+++ b/initializr-service/application.yml
@@ -19,6 +19,14 @@ initializr:
         groupId: com.vaadin
         artifactId: vaadin-bom
         version: 7.5.5
+      cloud-dataflow-bom:
+        groupId: org.springframework.cloud
+        artifactId: spring-cloud-dataflow-dependencies
+        version: 1.0.0.BUILD-SNAPSHOT
+        mappings:
+          - versionRange: 1.3.2.BUILD-SNAPSHOT
+            version:  1.0.0.BUILD-SNAPSHOT
+            repositories: spring-snapshots,spring-milestones
       cloud-bom:
         groupId: org.springframework.cloud
         artifactId: spring-cloud-starter-parent
@@ -406,7 +414,7 @@ initializr:
           artifactId: spring-cloud-starter-consul-bus
         - name: Stream Rabbit
           id: cloud-stream-binder-rabbit
-          description: Messaging microservices with RabbitMQ 
+          description: Messaging microservices with RabbitMQ
           versionRange: 1.3.0.M4
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-stream-rabbit
@@ -441,6 +449,16 @@ initializr:
           description: Messaging on AWS with SQS and spring-cloud-aws-messaging
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-aws-messaging
+    - name: Cloud Data Flow
+      bom: cloud-dataflow-bom
+      versionRange: "1.0.0.BUILD-SNAPSHOT"
+      content:
+        - name: Local Data Flow Server
+          id: cloud-dataflow-server-local
+          description: Local Data Flow Server implementation
+          versionRange: 1.0.0.BUILD-SNAPSHOT
+          groupId: org.springframework.cloud
+          artifactId: spring-cloud-starter-dataflow-server-local
     - name: Cloud Cluster
       bom: cloud-bom
       versionRange: "1.3.0.M4"
@@ -626,4 +644,3 @@ initializr:
     - name: 1.1.12
       id: 1.1.12.RELEASE
       default: false
-


### PR DESCRIPTION
depends on https://github.com/spring-cloud/spring-cloud-dataflow/pull/354 (which simply changes `packaging` == `pom` to `packaging` == `jar` but works otherwise. 

this supersedes #186 (which can be closed since it's easier to just deal with this one)