### PR TITLE
Update for Brixton.RC1

### DIFF
--- a/initializr-service/application.yml
+++ b/initializr-service/application.yml
@@ -26,7 +26,7 @@ initializr:
           - versionRange: "[1.2.3.RELEASE,1.3.0.M1)"
             version: Angel.SR6
           - versionRange: "[1.3.0.M2,1.3.3.RELEASE]"
-            version: Brixton.M5
+            version: Brixton.RC1
             repositories: spring-snapshots,spring-milestones
           - versionRange: 1.3.4.BUILD-SNAPSHOT
             version: Brixton.BUILD-SNAPSHOT
@@ -448,12 +448,6 @@ initializr:
           description: A simple control bus with AMQP and spring-cloud-bus-amqp
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-bus-amqp
-        - name: Cloud Bus Redis
-          id: cloud-bus-redis
-          description: A simple control bus with Redis and spring-cloud-bus
-          versionRange: "(1.3.0.M5,9999.9.9.RELEASE]"
-          groupId: org.springframework.cloud
-          artifactId: spring-cloud-starter-bus-redis
         - name: Cloud Bus Kafka
           id: cloud-bus-kafka
           description: A simple control bus with Kafka and spring-cloud-bus


### PR DESCRIPTION
RC1 removed `spring-cloud-starter-bus-redis` because s-c-stream is not supporting redis in production.