### PR TITLE
Support dashed names in search box

### DIFF
--- a/initializr/src/main/resources/static/js/start.js
+++ b/initializr/src/main/resources/static/js/start.js
@@ -181,7 +181,7 @@ $(function () {
     });
     var starters = new Bloodhound({
         datumTokenizer: Bloodhound.tokenizers.obj.nonword('name', 'description', 'keywords', 'group'),
-        queryTokenizer: Bloodhound.tokenizers.whitespace,
+        queryTokenizer: Bloodhound.tokenizers.nonword,
         identify: function (obj) {
             return obj.id;
         },


### PR DESCRIPTION
See the suggestion in https://twitter.com/rmannibucau/status/714551786099642369 of changing `tokenizers.obj.nonword(...)` to `tkz.obj.whitespace`
