### PR TITLE
add support for the Spring Cloud Data Flow shell

### DIFF
--- a/initializr-service/application.yml
+++ b/initializr-service/application.yml
@@ -504,6 +504,11 @@ initializr:
           description: Local Data Flow Server implementation
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-dataflow-server-local
+        - name: Data Flow Shell
+          id: cloud-dataflow-shell
+          description: Data Flow Shell
+          groupId: org.springframework.cloud
+          artifactId: spring-cloud-dataflow-shell
     - name: Cloud Cluster
       bom: cloud-bom
       versionRange: 1.3.0.M4


### PR DESCRIPTION
add support for the Spring Cloud Data Flow shell. Choose the checkbox here, type `@EnableDataFlowShell` and watch as a shell (that you can use to talk to the Data Flow Server) spins up