### PR TITLE
revert version of Zipkin UI so that it works with the any recent version of Spring Cloud

### DIFF
--- a/initializr-service/application.yml
+++ b/initializr-service/application.yml
@@ -449,7 +449,6 @@ initializr:
           groupId: io.zipkin
           artifactId: zipkin-ui
           scope: runtime
-          versionRange: 1.3.4.BUILD-SNAPSHOT
           starter: false
         - name: Zipkin Server
           id: zipkin-server


### PR DESCRIPTION
revert version of Zipkin UI so that it works with the any recent version of Spring Cloud