### PR TITLE
Bump the Kotlin version to the latest stable hotfix 1.0.1-2

### DIFF
--- a/initializr-service/application.yml
+++ b/initializr-service/application.yml
@@ -38,7 +38,7 @@ initializr:
         additionalBoms: [cloud-bom]
         repositories: spring-snapshots,spring-milestones
     kotlin:
-      version: 1.0.0
+      version: 1.0.1-2
   dependencies:
     - name: Core
       content:


### PR DESCRIPTION
- 1.0.0 has issues with latest versions of Gradle
- Old plugin causes the following error message: 'org.gradle.api.internal.file.DefaultSourceDirectorySet.<init>(Ljava/lang/String;Lorg/gradle/api/internal/file/FileResolver;)V'