### PR TITLE
Remove explicit Gradle wrapper task

### DIFF
--- a/initializr-generator/src/main/resources/templates/starter-build.gradle
+++ b/initializr-generator/src/main/resources/templates/starter-build.gradle
@@ -62,7 +62,3 @@ eclipse {
 		 containers 'org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-${javaVersion}'
 	}
 }
-
-task wrapper(type: Wrapper) {
-	gradleVersion = '2.12'
-}


### PR DESCRIPTION
As described in [Gradle's user guide](https://docs.gradle.org/current/userguide/gradle_wrapper.html#N1037C), explicit ```wrapper``` task is not required (since Gradle 2.4).

This also has an advantage of not needing to modify build script when upgrading the Gradle to a new version.

I've signed the CLA.