### PR TITLE
Allow using a custom parent pom with the initializr

### DIFF
--- a/initializr-generator/src/main/groovy/io/spring/initializr/generator/ProjectGenerator.groovy
+++ b/initializr-generator/src/main/groovy/io/spring/initializr/generator/ProjectGenerator.groovy
@@ -206,9 +206,11 @@ class ProjectGenerator {
 		def dependencyIds = dependencies.collect { it.id }
 		log.info("Processing request{type=$request.type, dependencies=$dependencyIds}")
 
-		if (metadata.configuration.env.customParentPomGAV) {
-			model['useCustomparentPom'] = true
-			def gavParts = metadata.configuration.env.customParentPomGAV.split(':')
+
+		def useCustomParent = metadata.configuration.env.customParentPomGAV
+		model['useCustomParentPom'] = useCustomParent != null
+		if (useCustomParent) {
+			def gavParts = useCustomParent.split(':')
 			model['customParentPomGroup'] = gavParts[0]
 			model['customParentPomArtifact'] = gavParts[1]
 			model['customParentPomVersion'] = gavParts[2]

--- a/initializr-generator/src/main/groovy/io/spring/initializr/generator/ProjectGenerator.groovy
+++ b/initializr-generator/src/main/groovy/io/spring/initializr/generator/ProjectGenerator.groovy
@@ -206,6 +206,14 @@ class ProjectGenerator {
 		def dependencyIds = dependencies.collect { it.id }
 		log.info("Processing request{type=$request.type, dependencies=$dependencyIds}")
 
+		if (metadata.configuration.env.customParentPomGAV) {
+			model['useCustomparentPom'] = true
+			def gavParts = metadata.configuration.env.customParentPomGAV.split(':')
+			model['customParentPomGroup'] = gavParts[0]
+			model['customParentPomArtifact'] = gavParts[1]
+			model['customParentPomVersion'] = gavParts[2]
+		}
+
 		request.properties.each { model[it.key] = it.value }
 
 		model['compileDependencies'] = filterDependencies(dependencies, Dependency.SCOPE_COMPILE)

--- a/initializr-generator/src/main/groovy/io/spring/initializr/generator/ProjectGenerator.groovy
+++ b/initializr-generator/src/main/groovy/io/spring/initializr/generator/ProjectGenerator.groovy
@@ -18,6 +18,7 @@ package io.spring.initializr.generator
 
 import groovy.util.logging.Slf4j
 import io.spring.initializr.InitializrException
+import io.spring.initializr.metadata.BillOfMaterials
 import io.spring.initializr.metadata.Dependency
 import io.spring.initializr.metadata.InitializrMetadataProvider
 import io.spring.initializr.util.Version
@@ -199,6 +200,15 @@ class ProjectGenerator {
 		def model = [:]
 		def metadata = metadataProvider.get()
 
+		def useCustomParent = metadata.configuration.env.customParentPomGAV
+		model['useCustomParentPom'] = useCustomParent != null
+		if (useCustomParent) {
+			def gavParts = useCustomParent.split(':')
+			model['customParentPomGroup'] = gavParts[0]
+			model['customParentPomArtifact'] = gavParts[1]
+			model['customParentPomVersion'] = gavParts[2]
+			request.boms.put("spring-boot", new BillOfMaterials(groupId: "org.springframework.boot", artifactId: "spring-boot-dependencies", version: request.bootVersion))
+		}
 		request.resolve(metadata)
 
 		// request resolved so we can log what has been requested
@@ -207,14 +217,6 @@ class ProjectGenerator {
 		log.info("Processing request{type=$request.type, dependencies=$dependencyIds}")
 
 
-		def useCustomParent = metadata.configuration.env.customParentPomGAV
-		model['useCustomParentPom'] = useCustomParent != null
-		if (useCustomParent) {
-			def gavParts = useCustomParent.split(':')
-			model['customParentPomGroup'] = gavParts[0]
-			model['customParentPomArtifact'] = gavParts[1]
-			model['customParentPomVersion'] = gavParts[2]
-		}
 
 		request.properties.each { model[it.key] = it.value }
 

--- a/initializr-generator/src/main/groovy/io/spring/initializr/generator/ProjectGenerator.groovy
+++ b/initializr-generator/src/main/groovy/io/spring/initializr/generator/ProjectGenerator.groovy
@@ -216,8 +216,6 @@ class ProjectGenerator {
 		def dependencyIds = dependencies.collect { it.id }
 		log.info("Processing request{type=$request.type, dependencies=$dependencyIds}")
 
-
-
 		request.properties.each { model[it.key] = it.value }
 
 		model['compileDependencies'] = filterDependencies(dependencies, Dependency.SCOPE_COMPILE)

--- a/initializr-generator/src/main/groovy/io/spring/initializr/metadata/InitializrConfiguration.groovy
+++ b/initializr-generator/src/main/groovy/io/spring/initializr/metadata/InitializrConfiguration.groovy
@@ -203,9 +203,8 @@ class InitializrConfiguration {
 		}
 
 		/**
-		 * validate that the GAV has 3 components
-		 * @param s
-         */
+		 * validate that the GAV has 3 components in the format expected
+		 */
 		void validateGAV(String gav) {
 			if (gav.split(':').length != 3)
 				throw new InvalidInitializrMetadataException("The group:artifact:version of ${gav} is not a valid GAV (does not have exactly 3 components")

--- a/initializr-generator/src/main/groovy/io/spring/initializr/metadata/InitializrConfiguration.groovy
+++ b/initializr-generator/src/main/groovy/io/spring/initializr/metadata/InitializrConfiguration.groovy
@@ -123,6 +123,14 @@ class InitializrConfiguration {
 		String springBootMetadataUrl = 'https://spring.io/project_metadata/spring-boot'
 
 		/**
+		 * The group / artifact / version of a custom parent pom to use for generated projects.
+		 * This is only enabled if a value is expliclty provided.
+		 *
+		 * The value must be specified in "groupid:artifactId:versionNumber" format
+		 */
+		String customParentPomGAV
+
+		/**
 		 * Tracking code for Google Analytics. Only enabled if a value is explicitly provided.
 		 */
 		String googleAnalyticsTrackingCode
@@ -186,15 +194,28 @@ class InitializrConfiguration {
 		}
 
 		void validate() {
+			if (customParentPomGAV) {
+				validateGAV(customParentPomGAV);
+			}
 			boms.each {
 				it.value.validate()
 			}
+		}
+
+		/**
+		 * validate that the GAV has 3 components
+		 * @param s
+         */
+		void validateGAV(String gav) {
+			if (gav.split(':').length != 3)
+				throw new InvalidInitializrMetadataException("The group:artifact:version of ${gav} is not a valid GAV (does not have exactly 3 components")
 		}
 
 		void merge(Env other) {
 			artifactRepository = other.artifactRepository
 			springBootMetadataUrl = other.springBootMetadataUrl
 			googleAnalyticsTrackingCode = other.googleAnalyticsTrackingCode
+			customParentPomGAV = other.customParentPomGAV
 			fallbackApplicationName = other.fallbackApplicationName
 			invalidApplicationNames = other.invalidApplicationNames
 			forceSsl = other.forceSsl

--- a/initializr-generator/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/initializr-generator/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -133,6 +133,12 @@
       "defaultValue": true
     },
     {
+      "name": "initializr.env.custom-parent-pom-gav",
+      "type": "java.lang.String",
+      "description": "The group:artifactId:version of a custom parent pom to use when generating a project",
+      "sourceType": "io.spring.initializr.metadata.InitializrConfiguration$Env"
+    },
+    {
       "name": "initializr.env.google-analytics-tracking-code",
       "type": "java.lang.String",
       "description": "Tracking code for Google Analytics.",

--- a/initializr-generator/src/main/resources/templates/starter-pom.xml
+++ b/initializr-generator/src/main/resources/templates/starter-pom.xml
@@ -12,16 +12,24 @@
 	<description>${description}</description>
 
 	<parent>
+		<% if (useCustomParentPom) { %>
+		<groupId><% customParentPomGroup %></groupId>
+		<artifactId><% customParentPomArtifact %></artifactId>
+		<artifactId><% customParentPomVersion %></artifactId>
+		<% } else { %>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>${bootVersion}</version>
+		<% } %>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
+
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>${javaVersion}</java.version><% if (language=='kotlin') { %>
-		<kotlin.version>${kotlinVersion}</kotlin.version><% } %>
+		<kotlin.version>${kotlinVersion}</kotlin.version><% } %><% if (useCustomParentPom) { %>
+        <spring-boot.version>${bootVersion}</spring-boot.version><%}%>
 	</properties>
 
 	<dependencies><% compileDependencies.each { %>

--- a/initializr-generator/src/main/resources/templates/starter-pom.xml
+++ b/initializr-generator/src/main/resources/templates/starter-pom.xml
@@ -13,9 +13,9 @@
 
 	<parent>
 		<% if (useCustomParentPom) { %>
-		<groupId><% customParentPomGroup %></groupId>
-		<artifactId><% customParentPomArtifact %></artifactId>
-		<artifactId><% customParentPomVersion %></artifactId>
+		<groupId>${customParentPomGroup}</groupId>
+		<artifactId>${customParentPomArtifact}</artifactId>
+		<version>${customParentPomVersion}</version>
 		<% } else { %>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>

--- a/initializr-generator/src/main/resources/templates/starter-pom.xml
+++ b/initializr-generator/src/main/resources/templates/starter-pom.xml
@@ -24,7 +24,6 @@
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
-
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>${javaVersion}</java.version><% if (language=='kotlin') { %>

--- a/initializr-generator/src/main/resources/templates/starter-pom.xml
+++ b/initializr-generator/src/main/resources/templates/starter-pom.xml
@@ -29,7 +29,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>${javaVersion}</java.version><% if (language=='kotlin') { %>
 		<kotlin.version>${kotlinVersion}</kotlin.version><% } %><% if (useCustomParentPom) { %>
-        <spring-boot.version>${bootVersion}</spring-boot.version><%}%>
+		<spring-boot.version>${bootVersion}</spring-boot.version><%}%>
 	</properties>
 
 	<dependencies><% compileDependencies.each { %>

--- a/initializr-generator/src/test/groovy/io/spring/initializr/generator/ProjectGeneratorTests.groovy
+++ b/initializr-generator/src/test/groovy/io/spring/initializr/generator/ProjectGeneratorTests.groovy
@@ -286,6 +286,24 @@ class ProjectGeneratorTests extends AbstractProjectGeneratorTests {
 	}
 
 	@Test
+	void defaultMavenPomHasSpringBootParent() {
+		def metadata = InitializrMetadataTestBuilder.withDefaults().build()
+		applyMetadata(metadata)
+		def request = createProjectRequest('whatever', 'web')
+		generateMavenPom(request).hasParent("org.springframework.boot", "spring-boot-starter-parent", request.bootVersion)
+	}
+
+	@Test
+	void mavenPomWithCustomParentPom() {
+		def customGAV = "com.foo:foo-parent:1.0.0-SNAPSHOT"
+		def metadata = InitializrMetadataTestBuilder.withDefaults()
+				.addCustomParentPomGAV(customGAV).build()
+		applyMetadata(metadata)
+		def request = createProjectRequest('whatever', 'web')
+		generateMavenPom(request).hasParent("com.foo", "foo-parent", "1.0.0-SNAPSHOT")
+	}
+
+	@Test
 	void gradleBuildWithBootSnapshot() {
 		def request = createProjectRequest('web')
 		request.bootVersion = '1.0.1.BUILD-SNAPSHOT'

--- a/initializr-generator/src/test/groovy/io/spring/initializr/test/generator/PomAssert.groovy
+++ b/initializr-generator/src/test/groovy/io/spring/initializr/test/generator/PomAssert.groovy
@@ -97,8 +97,13 @@ class PomAssert {
 	}
 
 	PomAssert hasBootVersion(String bootVersion) {
-		assertEquals bootVersion, eng.evaluate(createRootNodeXPath('parent/pom:version'), doc)
-		this
+		// if using a custom parent, the bootVersion would come from a bom, not the parent
+		if (!eng.evaluate(createRootNodeXPath('parent/pom:artifactId'), doc).equals("spring-boot-starter-parent")) {
+			hasBom("org.springframework.boot", "spring-boot-dependencies", bootVersion)
+		} else {
+			assertEquals bootVersion, eng.evaluate(createRootNodeXPath('parent/pom:version'), doc)
+			this
+		}
 	}
 
 	PomAssert hasJavaVersion(String javaVersion) {
@@ -134,6 +139,13 @@ class PomAssert {
 
 	PomAssert hasDependency(String groupId, String artifactId, String version) {
 		hasDependency(new Dependency(groupId: groupId, artifactId: artifactId, version: version))
+	}
+
+	PomAssert hasParent(String groupId, String artifactId, String version) {
+		assertEquals version, eng.evaluate(createRootNodeXPath('parent/pom:version'), doc)
+		assertEquals groupId, eng.evaluate(createRootNodeXPath('parent/pom:groupId'), doc)
+		assertEquals artifactId, eng.evaluate(createRootNodeXPath('parent/pom:artifactId'), doc)
+		this
 	}
 
 	PomAssert hasDependency(Dependency expected) {

--- a/initializr-generator/src/test/groovy/io/spring/initializr/test/generator/PomAssert.groovy
+++ b/initializr-generator/src/test/groovy/io/spring/initializr/test/generator/PomAssert.groovy
@@ -97,13 +97,13 @@ class PomAssert {
 	}
 
 	PomAssert hasBootVersion(String bootVersion) {
-		// if using a custom parent, the bootVersion would come from a bom, not the parent
+		// when using a custom parent, the bootVersion comes from a bom entry and not the parent pom version
 		if (!eng.evaluate(createRootNodeXPath('parent/pom:artifactId'), doc).equals("spring-boot-starter-parent")) {
 			hasBom("org.springframework.boot", "spring-boot-dependencies", bootVersion)
 		} else {
 			assertEquals bootVersion, eng.evaluate(createRootNodeXPath('parent/pom:version'), doc)
-			this
 		}
+		this
 	}
 
 	PomAssert hasJavaVersion(String javaVersion) {

--- a/initializr-generator/src/test/groovy/io/spring/initializr/test/metadata/InitializrMetadataTestBuilder.groovy
+++ b/initializr-generator/src/test/groovy/io/spring/initializr/test/metadata/InitializrMetadataTestBuilder.groovy
@@ -152,6 +152,13 @@ class InitializrMetadataTestBuilder {
 		this
 	}
 
+	InitializrMetadataTestBuilder addCustomParentPomGAV(String customGAV) {
+		builder.withCustomizer {
+			it.configuration.env.customParentPomGAV = customGAV
+		}
+		this
+	}
+
 	InitializrMetadataTestBuilder addRepository(String id, String name, String url, boolean snapshotsEnabled) {
 		builder.withCustomizer {
 			Repository repo = new Repository(

--- a/initializr-web/src/test/resources/metadata/config/test-default.json
+++ b/initializr-web/src/test/resources/metadata/config/test-default.json
@@ -36,6 +36,7 @@
     "kotlin": {
       "version": null
     },
+    "customParentPomGAV": null,
     "googleAnalyticsTrackingCode": null,
     "invalidApplicationNames": [
       "SpringApplication",


### PR DESCRIPTION
If a parent pom is specified in the customParentPomGAV in the format "groupId:artifactid:version", use that group / artifact / version for the parent pom in the generated pom

When using a custom parent pom, the spring-boot-dependencies is added to the ```<dependencyManagement>``` section with the specified version of spring boot, and as a convenience to those who may want to have things in the parent pom that are tied to a property (for instance, having the spring-boot-maven plugin in the parent with a version of ${spring-boot.version}) will also work. 