### PR TITLE
Remove Stream Redis 

### DIFF
--- a/initializr-service/application.yml
+++ b/initializr-service/application.yml
@@ -480,12 +480,6 @@ initializr:
           versionRange: 1.3.0.M4
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-stream-rabbit
-        - name: Stream Redis
-          id: cloud-stream-binder-redis
-          description: Messaging microservices with Redis
-          versionRange: 1.3.0.M4
-          groupId: org.springframework.cloud
-          artifactId: spring-cloud-starter-stream-redis
         - name: Stream Kafka
           id: cloud-stream-binder-kafka
           description: Messaging microservices with Kafka


### PR DESCRIPTION
We do not recommend using Redis and the starter is not necessary 
for creating custom Spring Cloud Data Flow modules anymore 
(Rabbit MQ and Kafka would be used instead). 