### PR TITLE
Add Artifact type to the Dependency Model

### DIFF
--- a/initializr-generator/src/main/groovy/io/spring/initializr/metadata/Dependency.groovy
+++ b/initializr-generator/src/main/groovy/io/spring/initializr/metadata/Dependency.groovy
@@ -77,6 +77,8 @@ class Dependency extends MetadataElement {
 
 	String repository
 
+	String type
+
 	int weight
 
 	/**

--- a/initializr-generator/src/main/resources/templates/starter-build.gradle
+++ b/initializr-generator/src/main/resources/templates/starter-build.gradle
@@ -40,13 +40,13 @@ repositories {
 }
 <% } %>
 dependencies {<% compileDependencies.each { %>
-	compile('${it.groupId}:${it.artifactId}${it.version ? ":$it.version" : ""}')<% } %><% if (language=='groovy') { %>
+	compile('${it.groupId}:${it.artifactId}${it.version ? ":$it.version" : ""}${it.type ? "@$it.type" : ""}')<% } %><% if (language=='groovy') { %>
 	compile('org.codehaus.groovy:groovy')<% } %><% if (language=='kotlin') { %>
 	compile("org.jetbrains.kotlin:kotlin-stdlib:\${kotlinVersion}")<% } %><% runtimeDependencies.each { %>
-	runtime('${it.groupId}:${it.artifactId}${it.version ? ":$it.version" : ""}')<% } %><% providedDependencies.each { %>
-	providedRuntime('${it.groupId}:${it.artifactId}${it.version ? ":$it.version" : ""}')<% } %>
+	runtime('${it.groupId}:${it.artifactId}${it.version ? ":$it.version" : ""}${it.type ? "@$it.type" : ""}')<% } %><% providedDependencies.each { %>
+	providedRuntime('${it.groupId}:${it.artifactId}${it.version ? ":$it.version" : ""}${it.type ? "@$it.type" : ""}')<% } %>
 	testCompile('org.springframework.boot:spring-boot-starter-test') <% testDependencies.each { %>
-	testCompile('${it.groupId}:${it.artifactId}${it.version ? ":$it.version" : ""}')<% } %>
+	testCompile('${it.groupId}:${it.artifactId}${it.version ? ":$it.version" : ""}${it.type ? "@$it.type" : ""}')<% } %>
 }
 <% if (boms) { %>
 dependencyManagement {

--- a/initializr-generator/src/main/resources/templates/starter-pom.xml
+++ b/initializr-generator/src/main/resources/templates/starter-pom.xml
@@ -28,7 +28,8 @@
 		<dependency>
 			<groupId>${it.groupId}</groupId>
 			<artifactId>${it.artifactId}</artifactId><% if (it.version != null) { %>
-			<version>${it.version}</version><% } %>
+			<version>${it.version}</version><% } %><% if (it.type != null) { %>
+			<type>${it.type}</type><% } %>
 		</dependency><% } %><% if (language=='groovy') { %>
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
@@ -44,13 +45,15 @@
 			<groupId>${it.groupId}</groupId>
 			<artifactId>${it.artifactId}</artifactId><% if (it.version != null) { %>
 			<version>${it.version}</version><% } %>
-			<scope>runtime</scope>
+			<scope>runtime</scope><% if (it.type != null) { %>
+			<type>${it.type}</type><% } %>
 		</dependency><% } %><% providedDependencies.each { %>
 		<dependency>
 			<groupId>${it.groupId}</groupId>
 			<artifactId>${it.artifactId}</artifactId><% if (it.version != null) { %>
 			<version>${it.version}</version><% } %>
-			<scope>provided</scope>
+			<scope>provided</scope><% if (it.type != null) { %>
+			<type>${it.type}</type><% } %>
 		</dependency><% } %>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -61,7 +64,8 @@
 			<groupId>${it.groupId}</groupId>
 			<artifactId>${it.artifactId}</artifactId><% if (it.version != null) { %>
 			<version>${it.version}</version><% } %>
-			<scope>test</scope>
+			<scope>test</scope><% if (it.type != null) { %>
+			<type>${it.type}</type><% } %>
 		</dependency><% } %>
 	</dependencies>
 	<% if (boms) { %>

--- a/initializr-generator/src/test/groovy/io/spring/initializr/generator/ProjectGeneratorTests.groovy
+++ b/initializr-generator/src/test/groovy/io/spring/initializr/generator/ProjectGeneratorTests.groovy
@@ -76,6 +76,30 @@ class ProjectGeneratorTests extends AbstractProjectGeneratorTests {
 	}
 
 	@Test
+	void mavenPomWithTarDependency() {
+		def dependency = new Dependency(id: 'custom-artifact', groupId: 'org.foo', artifactId: 'custom-artifact', type: "tar.gz")
+		def metadata = InitializrMetadataTestBuilder.withDefaults()
+				.addDependencyGroup('test', dependency).build()
+		applyMetadata(metadata)
+
+		def request = createProjectRequest('custom-artifact')
+		generateMavenPom(request).hasDependency(dependency)
+				.hasDependenciesCount(2)
+	}
+
+	@Test
+	void gradleBuildWithTarDependency() {
+		def dependency = new Dependency(id: 'custom-artifact', groupId: 'org.foo', artifactId: 'custom-artifact', type: "tar.gz")
+		def metadata = InitializrMetadataTestBuilder.withDefaults()
+				.addDependencyGroup('test', dependency).build()
+		applyMetadata(metadata)
+
+		def request = createProjectRequest('custom-artifact')
+		generateGradleBuild(request)
+				.contains("compile('org.foo:custom-artifact@tar.gz')")
+	}
+
+	@Test
 	void mavenPomWithWebFacet() {
 		def dependency = new Dependency(id: 'thymeleaf', groupId: 'org.foo', artifactId: 'thymeleaf')
 		dependency.facets << 'web'

--- a/initializr-generator/src/test/groovy/io/spring/initializr/test/generator/PomAssert.groovy
+++ b/initializr-generator/src/test/groovy/io/spring/initializr/test/generator/PomAssert.groovy
@@ -146,6 +146,9 @@ class PomAssert {
 		if (expected.scope) {
 			assertEquals "Wrong scope for $dependency", expected.scope, dependency.scope
 		}
+		if (expected.type) {
+			assertEquals "Wrong type for $dependency", expected.type, dependency.type
+		}
 		this
 	}
 
@@ -237,6 +240,10 @@ class PomAssert {
 				def scope = element.getElementsByTagName('scope')
 				if (scope.length > 0) {
 					dependency.scope = scope.item(0).textContent
+				}
+				def type = element.getElementsByTagName('type')
+				if (type.length > 0) {
+					dependency.type = type.item(0).textContent
 				}
 				def id = dependency.generateId()
 				assertFalse("Duplicate dependency with id $id", dependencies.containsKey(id))


### PR DESCRIPTION
In order to include a dependency that is not distributed as a Jar, at least for maven, we needed to be able to set a type. This adds template handling for both maven and gradle for the field and a couple of tests to verify correctness when the field is set.

We are using this internally for a dependency that is a `tar.gz`

EDIT: I signed the CSR as brian.devins@dealer.com