### PR TITLE
Force UTF-8 encoding on /ui/dependencies endpoint

### DIFF
--- a/initializr-web/src/main/groovy/io/spring/initializr/web/ui/UiController.groovy
+++ b/initializr-web/src/main/groovy/io/spring/initializr/web/ui/UiController.groovy
@@ -44,7 +44,7 @@ class UiController {
 	@Autowired
 	protected InitializrMetadataProvider metadataProvider
 
-	@RequestMapping(value = "/ui/dependencies", produces = ["application/json"])
+	@RequestMapping(value = "/ui/dependencies", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
 	ResponseEntity<String> dependencies(@RequestParam(required = false) String version) {
 		def dependencyGroups = metadataProvider.get().dependencies.content
 		def content = []
@@ -61,8 +61,7 @@ class UiController {
 			}
 		}
 		def json = writeDependencies(content)
-		ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).
-				eTag(createUniqueId(json)).body(json)
+		ResponseEntity.ok().eTag(createUniqueId(json)).body(json)
 	}
 
 	private static String writeDependencies(List<DependencyItem> items) {


### PR DESCRIPTION
This commit declares the `application/json;charset=UTF-8` encoding
on the `@RequestMapping` annotation directly and removes the response
header manually set in the Controller.

Content negotiation operated by Spring MVC will take place and the HTTP
client should receive the expected encoding.