### PR TITLE
Merge Dependencies within an existing group.

### DIFF
--- a/initializr-generator/src/main/groovy/io/spring/initializr/metadata/DependenciesCapability.groovy
+++ b/initializr-generator/src/main/groovy/io/spring/initializr/metadata/DependenciesCapability.groovy
@@ -56,7 +56,18 @@ class DependenciesCapability extends ServiceCapability<List<DependencyGroup>> {
 	@Override
 	void merge(List<DependencyGroup> otherContent) {
 		otherContent.each { group ->
-			if (!content.find { group.name.equals(it.name)}) {
+			def contentGroup = content.find { group.name.equals(it.name)}
+			if (contentGroup != null) {
+				contentGroup.bom = group.bom
+				contentGroup.repository = group.repository
+				contentGroup.versionRange = group.versionRange
+				group.content.each { dependency ->
+					if (!contentGroup.content.contains(dependency)) {
+						contentGroup.content.add(dependency)
+					}
+				}
+			}
+			else {
 				content << group
 			}
 		}

--- a/initializr-generator/src/test/groovy/io/spring/initializr/metadata/InitializrMetadataBuilderTests.groovy
+++ b/initializr-generator/src/test/groovy/io/spring/initializr/metadata/InitializrMetadataBuilderTests.groovy
@@ -158,6 +158,37 @@ class InitializrMetadataBuilderTests {
 	}
 
 	@Test
+	void mergeConfigurationNewDependencyGroup() {
+		def config = load(new ClassPathResource("application-test-default.yml"))
+		def metadata = InitializrMetadataBuilder
+				.fromInitializrProperties(config).build()
+		assertEquals 2, metadata.dependencies.content.size()
+
+		metadata = InitializrMetadataBuilder
+				.fromInitializrProperties(config)
+				.withInitializrMetadata(new ClassPathResource("application-test-overrides.json")).build()
+		assertEquals 3, metadata.dependencies.content.size()
+	}
+
+	@Test
+	void mergeConfigurationExistingDependencyGroup() {
+		def config = load(new ClassPathResource("application-test-default.yml"))
+		def metadata = InitializrMetadataBuilder
+				.fromInitializrProperties(config).build()
+		assertEquals 2, metadata.dependencies.content.size()
+		assertEquals 3, metadata.dependencies.content[0].content.size()
+		assertEquals 5, metadata.dependencies.content[1].content.size()
+
+		metadata = InitializrMetadataBuilder
+				.fromInitializrProperties(config)
+				.withInitializrMetadata(new ClassPathResource("application-test-overrides.json")).build()
+		assertEquals 3, metadata.dependencies.content.size()
+		assertEquals 4, metadata.dependencies.content[0].content.size()
+		assertEquals 5, metadata.dependencies.content[1].content.size()
+		assertEquals 1, metadata.dependencies.content[2].content.size()
+	}
+
+	@Test
 	void addDependencyInCustomizer() {
 		def group = new DependencyGroup(name: 'Extra')
 		def dependency = new Dependency(id: 'com.foo:foo:1.0.0')

--- a/initializr-generator/src/test/resources/application-test-overrides.json
+++ b/initializr-generator/src/test/resources/application-test-overrides.json
@@ -1,0 +1,35 @@
+{
+  "dependencies": {
+    "id": "dependencies",
+    "type": "HIERARCHICAL_MULTI_SELECT",
+    "description": null,
+    "content": [
+      {
+        "name": "Extra",
+        "content": [
+          {
+            "name": "Apache Commons Lang",
+            "id": "apacheLang",
+            "groupId": "org.apache.commons",
+            "artifactId": "commons-lang3",
+            "version": "3.4",
+            "scope": "compile"
+          }
+        ]
+      },
+      {
+        "name": "Core",
+        "content": [
+          {
+            "name": "Apache Commons IO",
+            "id": "apacheio",
+            "groupId": "org.apache.commons",
+            "artifactId": "commons-io",
+            "version": "1.3.2",
+            "scope": "compile"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This allows users to add more dependencies to the existing DependencyGroups. Also allowing them to override the other properties of the DependencyGroup if they need to.