### PR TITLE
Upgrading Activiti to version 5.21.0

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -659,7 +659,7 @@ initializr:
           description: Activiti BPMN workflow engine
           groupId: org.activiti
           artifactId: activiti-spring-boot-starter-basic
-          version: 5.19.0
+          version: 5.21.0
         - name: Apache Camel
           id: camel
           description: Integration using Apache Camel


### PR DESCRIPTION
This PR changes the version of Activiti to 5.21.0 (see http://mvnrepository.com/artifact/org.activiti/activiti-spring-boot-starter-basic/5.21.0). 

I hope this is the only change needed. If not, let me know, and I'll amend the PR.