### PR TITLE
Upgrade to Spring Cloud Services 1.2.0.RELEASE

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -52,7 +52,7 @@ initializr:
       scs-bom:
         groupId: io.pivotal.spring.cloud
         artifactId: spring-cloud-services-dependencies
-        version: 1.1.2.RELEASE
+        version: 1.2.0.RELEASE
         additionalBoms: [cloud-bom]
     gradle:
       dependency-management-plugin-version: 0.6.0.RELEASE
@@ -605,7 +605,7 @@ initializr:
           starter: false
     - name: Pivotal Cloud Foundry
       bom: scs-bom
-      versionRange: 1.3.0.RELEASE
+      versionRange: "[1.3.0.RELEASE,1.4.0.M1)"
       content:
         - name: Config Client (PCF)
           id: scs-config-client


### PR DESCRIPTION
Also restrict choice of Spring Boot to 1.3.x to ensure that Spring Cloud Brixton.SR6 is the chosen version of Spring Cloud. The reason for this restriction is that although Spring Cloud Services supports Spring Boot 1.4.x, we've not had opportunity to test it with Camden. 