### PR TITLE
Add configuration metadata for MetricsProperties

### DIFF
--- a/initializr-actuator/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/initializr-actuator/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -10,6 +10,11 @@
       "type": "io.spring.initializr.actuate.stat.StatsProperties$Elastic",
       "sourceType": "io.spring.initializr.actuate.stat.StatsProperties",
       "sourceMethod": "getElastic()"
+    },
+    {
+      "name": "initializr.metrics",
+      "type": "io.spring.initializr.actuate.autoconfigure.MetricsProperties",
+      "sourceType": "io.spring.initializr.actuate.autoconfigure.MetricsProperties"
     }
   ],
   "properties": [
@@ -49,6 +54,33 @@
       "description": "Number of attempts before giving up.",
       "defaultValue": 3,
       "sourceType": "io.spring.initializr.actuate.stat.StatsProperties$Elastic"
+    },
+    {
+      "name": "initializr.metrics.prefix",
+      "type": "java.lang.String",
+      "description": "Prefix for redis keys holding metrics in data store.",
+      "defaultValue": "spring.metrics.collector.",
+      "sourceType": "io.spring.initializr.actuate.autoconfigure.MetricsProperties"
+    },
+    {
+      "name": "initializr.metrics.key",
+      "type": "java.lang.String",
+      "description": "Redis key holding index to metrics keys in data store.",
+      "defaultValue": "keys.spring.metrics.collector",
+      "sourceType": "io.spring.initializr.actuate.autoconfigure.MetricsProperties"
+    },
+    {
+      "name": "initializr.metrics.id",
+      "type": "java.lang.String",
+      "description": "Identifier for application in metrics keys. Keys will be exported in the form '[id].[hex].[name]' (where '[id]' is this value, '[hex]' is unique per application context, and '[name]' is the \"natural\" name for the metric.",
+      "sourceType": "io.spring.initializr.actuate.autoconfigure.MetricsProperties"
+    },
+    {
+      "name": "initializr.metrics.rateMillis",
+      "type": "java.lang.Long",
+      "description": "The rate (in milliseconds) at which metrics are exported to Redis. If the value is <=0 then the export is disabled.",
+      "defaultValue": 5000,
+      "sourceType": "io.spring.initializr.actuate.autoconfigure.MetricsProperties"
     }
   ],
   "hints": []


### PR DESCRIPTION
The configuration processor does not work on Groovy classes, so the metadata for `MetricsProperties` was missing, which causes there to be no auto-completion in the IDE when using these properties from the initializr-actuator module. This commit adds the corresponding metadata for `MetricsProperties`.