### PR TITLE
Update Spring Cloud BOMs

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -24,12 +24,12 @@ initializr:
           - versionRange: "[1.2.3.RELEASE,1.3.0.M1)"
             version: Angel.SR6
           - versionRange: "[1.3.0.M1,1.3.9.BUILD-SNAPSHOT)"
-            version: Brixton.SR6
+            version: Brixton.SR7
           - versionRange: "[1.3.9.BUILD-SNAPSHOT,1.4.0.RELEASE)"
             version: Brixton.BUILD-SNAPSHOT
             repositories: spring-snapshots,spring-milestones
           - versionRange: "[1.4.0.RELEASE,1.4.3.BUILD-SNAPSHOT)"
-            version: Camden.SR2
+            version: Camden.SR3
           - versionRange: 1.4.3.BUILD-SNAPSHOT
             version: Camden.BUILD-SNAPSHOT
             repositories: spring-snapshots,spring-milestones


### PR DESCRIPTION
Spring Cloud's release trains Brixton and Camden had a service release today[1], so this bumps the versions for each.

[1] https://spring.io/blog/2016/11/29/spring-cloud-brixton-sr7-and-spring-cloud-camden-sr3-are-available