### PR TITLE
Remove redundant targetCompatibility from gradle buildscript

### DIFF
--- a/initializr-generator/src/main/resources/templates/starter-build.gradle
+++ b/initializr-generator/src/main/resources/templates/starter-build.gradle
@@ -26,8 +26,8 @@ apply plugin: 'war'
 	baseName = '${artifactId}'
 	version = '${version}'
 }
+
 sourceCompatibility = ${javaVersion}
-targetCompatibility = ${javaVersion}
 
 repositories {
 	mavenCentral()<% if (repositories) { repositories.each { key, repo -> %>

--- a/initializr-generator/src/test/groovy/io/spring/initializr/test/generator/GradleBuildAssert.groovy
+++ b/initializr-generator/src/test/groovy/io/spring/initializr/test/generator/GradleBuildAssert.groovy
@@ -57,7 +57,6 @@ class GradleBuildAssert {
 
 	GradleBuildAssert hasJavaVersion(String javaVersion) {
 		contains("sourceCompatibility = $javaVersion")
-		contains("targetCompatibility = $javaVersion")
 	}
 
 	GradleBuildAssert hasSnapshotRepository() {

--- a/initializr-generator/src/test/resources/project/gradle/bom-property-build.gradle.gen
+++ b/initializr-generator/src/test/resources/project/gradle/bom-property-build.gradle.gen
@@ -20,8 +20,8 @@ jar {
 	baseName = 'demo'
 	version = '0.0.1-SNAPSHOT'
 }
+
 sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 repositories {
 	mavenCentral()

--- a/initializr-generator/src/test/resources/project/gradle/compile-only-dependency-build.gradle.gen
+++ b/initializr-generator/src/test/resources/project/gradle/compile-only-dependency-build.gradle.gen
@@ -20,8 +20,8 @@ jar {
 	baseName = 'demo'
 	version = '0.0.1-SNAPSHOT'
 }
+
 sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 repositories {
 	mavenCentral()

--- a/initializr-generator/src/test/resources/project/gradle/version-override-build.gradle.gen
+++ b/initializr-generator/src/test/resources/project/gradle/version-override-build.gradle.gen
@@ -20,8 +20,8 @@ jar {
 	baseName = 'demo'
 	version = '0.0.1-SNAPSHOT'
 }
+
 sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 repositories {
 	mavenCentral()

--- a/initializr-generator/src/test/resources/project/groovy/standard/build.gradle.gen
+++ b/initializr-generator/src/test/resources/project/groovy/standard/build.gradle.gen
@@ -20,8 +20,8 @@ jar {
 	baseName = 'demo'
 	version = '0.0.1-SNAPSHOT'
 }
+
 sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 repositories {
 	mavenCentral()

--- a/initializr-generator/src/test/resources/project/groovy/war/build.gradle.gen
+++ b/initializr-generator/src/test/resources/project/groovy/war/build.gradle.gen
@@ -22,8 +22,8 @@ war {
 	baseName = 'demo'
 	version = '0.0.1-SNAPSHOT'
 }
+
 sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 repositories {
 	mavenCentral()

--- a/initializr-generator/src/test/resources/project/java/standard/build.gradle.gen
+++ b/initializr-generator/src/test/resources/project/java/standard/build.gradle.gen
@@ -20,8 +20,8 @@ jar {
 	baseName = 'demo'
 	version = '0.0.1-SNAPSHOT'
 }
+
 sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 repositories {
 	mavenCentral()

--- a/initializr-generator/src/test/resources/project/java/war/build.gradle.gen
+++ b/initializr-generator/src/test/resources/project/java/war/build.gradle.gen
@@ -22,8 +22,8 @@ war {
 	baseName = 'demo'
 	version = '0.0.1-SNAPSHOT'
 }
+
 sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 repositories {
 	mavenCentral()

--- a/initializr-generator/src/test/resources/project/kotlin/standard/build.gradle.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/standard/build.gradle.gen
@@ -22,8 +22,8 @@ jar {
 	baseName = 'demo'
 	version = '0.0.1-SNAPSHOT'
 }
+
 sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 repositories {
 	mavenCentral()

--- a/initializr-generator/src/test/resources/project/kotlin/war/build.gradle.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/war/build.gradle.gen
@@ -24,8 +24,8 @@ war {
 	baseName = 'demo'
 	version = '0.0.1-SNAPSHOT'
 }
+
 sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 repositories {
 	mavenCentral()


### PR DESCRIPTION
Project's targetCompatibility in gradle buildscipts defaults to sourceCompatibility ([Gradle documentation](https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_convention_properties)) and in real world projects it almost always targets the same Java version as sourceCompatibility.