### PR TITLE
Add version mapping for mybatis-spring-boot-starter 1.2.0

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -278,8 +278,11 @@ initializr:
           description: Persistence support using MyBatis
           groupId: org.mybatis.spring.boot
           artifactId: mybatis-spring-boot-starter
-          version: 1.1.1
-          versionRange: 1.3.0.RELEASE
+          mappings:
+            - versionRange: 1.4.0.M2
+              version: 1.2.0
+            - versionRange: "[1.3.0.RELEASE,1.4.0.M2)"
+              version: 1.1.1
         - name: JDBC
           id: jdbc
           description: JDBC databases


### PR DESCRIPTION
I've added a version mapping for mybatis-spring-boot-starter 1.2.0 because we released the mybatis-spring-boot-starter 1.2.0 to the maven central repository.
