### PR TITLE
Fix typo link → links

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -313,7 +313,7 @@ initializr:
           id: hateoas
           description: HATEOAS-based RESTful services
           versionRange: 1.2.2.RELEASE
-          link:
+          links:
             - rel: guide
               href: https://spring.io/guides/gs/rest-hateoas/
               description: Building a Hypermedia-Driven RESTful Web Service
@@ -470,7 +470,7 @@ initializr:
           artifactId: mysql-connector-java
           scope: runtime
           starter: false
-          link:
+          links:
             - rel: guide
               href: https://spring.io/guides/gs/accessing-data-mysql/
               description: Accessing data with MySQL
@@ -975,7 +975,7 @@ initializr:
           id: activemq
           description: Java Message Service API via Apache ActiveMQ
           versionRange: 1.4.0.RC1
-          link:
+          links:
             - rel: guide
               href: https://spring.io/guides/gs/messaging-jms/
               description: Messaging with JMS
@@ -985,7 +985,7 @@ initializr:
           id: artemis
           description: Java Message Service API via Apache Artemis
           versionRange: 1.3.0.M2
-          link:
+          links:
             - rel: guide
               href: https://spring.io/guides/gs/messaging-jms/
               description: Messaging with JMS
@@ -995,7 +995,7 @@ initializr:
           id: hornetq
           description: Java Message Service API via HornetQ
           versionRange: "[1.1.0.RELEASE,1.4.0.RC1)"
-          link:
+          links:
             - rel: guide
               href: https://spring.io/guides/gs/messaging-jms/
               description: Messaging with JMS
@@ -1004,7 +1004,7 @@ initializr:
         - name: AMQP
           id: amqp
           description: Advanced Message Queuing Protocol via spring-rabbit
-          link:
+          links:
             - rel: guide
               href: https://spring.io/guides/gs/messaging-rabbitmq/
               description: Messaging with RabbitMQ
@@ -1018,21 +1018,21 @@ initializr:
           groupId: org.springframework.kafka
           artifactId: spring-kafka
           starter: false
-          link:
+          links:
             - rel: reference
               href: http://docs.spring.io/spring-boot/docs/{bootVersion}/reference/htmlsingle/#boot-features-kafka
         - name: Mail
           id: mail
           description: javax.mail
           versionRange: 1.2.0.RC1
-          link:
+          links:
             - rel: reference
               href: http://docs.spring.io/spring-boot/docs/{bootVersion}/reference/htmlsingle/#boot-features-email
         - name: LDAP
           id: data-ldap
           description: LDAP support, including spring-data-ldap
           versionRange: 1.5.0.RC1
-          link:
+          links:
             - rel: reference
               href: http://docs.spring.io/spring-boot/docs/{bootVersion}/reference/htmlsingle/#boot-features-ldap
     - name: Ops
@@ -1040,12 +1040,12 @@ initializr:
         - name: Actuator
           id: actuator
           description: Production ready features to help you monitor and manage your application
-          link:
+          links:
             - rel: guide
               href: https://spring.io/guides/gs/actuator-service/
               description: Building a RESTful Web Service with Spring Boot Actuator
             - rel: reference
-              href: http://docs.spring.io/spring-boot/docs/{bootVersion}/reference/htmlsingle/#boot-features-ldap
+              href: http://docs.spring.io/spring-boot/docs/{bootVersion}/reference/htmlsingle/#production-ready
         - name: Actuator Docs
           id: actuator-docs
           description: API documentation for the Actuator endpoints

--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -317,7 +317,7 @@ initializr:
             - rel: guide
               href: https://spring.io/guides/gs/rest-hateoas/
               description: Building a Hypermedia-Driven RESTful Web Service
-            - ref: reference
+            - rel: reference
               href: http://docs.spring.io/spring-boot/docs/{bootVersion}/reference/htmlsingle/#boot-features-spring-hateoas
         - name: Rest Repositories HAL Browser
           id: data-rest-hal


### PR DESCRIPTION
Links seems to be the correct key name according to the code and semantically for a list, so all instances of `link:` have been replaced by `links:`. Additionally, the Actuator reference link was pointing to the wrong section in the documentation and has been fixed.