### PR TITLE
Bumped the Stormpath bom version

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -95,7 +95,7 @@ initializr:
       stormpath-bom:
         groupId: com.stormpath.sdk
         artifactId: stormpath-bom
-        version: 1.5.0
+        version: 1.5.2
     gradle:
       dependency-management-plugin-version: 0.6.0.RELEASE
     kotlin:


### PR DESCRIPTION
This new version includes a default static home page with a logout button. This is needed as you *must* POST to the `/logout` endpoint.

It is now possible to launch a demo project generated by start.spring.io that includes Stormpath and have all of the identity functionality we offer, including logout.