### PR TITLE
Upgrade Spring Cloud Services to 1.4.1.RELEASE

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -65,7 +65,7 @@ initializr:
           - versionRange: "[1.4.0.RELEASE,1.4.x.BUILD-SNAPSHOT)"
             version: 1.4.1.RELEASE
           - versionRange: "[1.4.x.BUILD-SNAPSHOT, 1.5.0.RC1)"
-            version: 1.3.2.BUILD-SNAPSHOT
+            version: 1.4.2.BUILD-SNAPSHOT
             repositories: spring-snapshots,spring-milestones
       cloud-task-bom:
         groupId: org.springframework.cloud

--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -63,7 +63,7 @@ initializr:
           - versionRange: "[1.3.0.RELEASE,1.4.0.RELEASE)"
             version: 1.2.1.RELEASE
           - versionRange: "[1.4.0.RELEASE,1.4.x.BUILD-SNAPSHOT)"
-            version: 1.3.1.RELEASE
+            version: 1.4.1.RELEASE
           - versionRange: "[1.4.x.BUILD-SNAPSHOT, 1.5.0.RC1)"
             version: 1.3.2.BUILD-SNAPSHOT
             repositories: spring-snapshots,spring-milestones


### PR DESCRIPTION
Upgrades the GA version of Spring Cloud Services to 1.4.1.RELEASE.

Note that at this time, we have not yet tested SCS with Spring Boot 1.5.1 and therefore we are not ready to lift the restriction that keeps Initializr users from choosing Spring Boot 1.5.1 and SCS modules. We will be performing that testing soon and will followup with another PR that lifts the restriction. 