### PR TITLE
Upgrade to Kotlin 1.1.1

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectGenerator.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectGenerator.java
@@ -429,6 +429,11 @@ public class ProjectGenerator {
 		// New Servlet Initializer location
 		model.put("newServletInitializer", isNewServletInitializerAvailable(request));
 
+		// Java versions
+		model.put("isJava6", isJava6(request));
+		model.put("isJava7", isJava7(request));
+		model.put("isJava8", isJava8(request));
+
 		// Append the project request to the model
 		BeanWrapperImpl bean = new BeanWrapperImpl(request);
 		for (PropertyDescriptor descriptor : bean.getPropertyDescriptors()) {
@@ -503,6 +508,18 @@ public class ProjectGenerator {
 
 	private static boolean isGradle3Available(Version bootVersion) {
 		return VERSION_1_5_0_M1.compareTo(bootVersion) <= 0;
+	}
+
+	private static boolean isJava6(ProjectRequest request) {
+		return "1.6".equals(request.getJavaVersion());
+	}
+
+	private static boolean isJava7(ProjectRequest request) {
+		return "1.7".equals(request.getJavaVersion());
+	}
+
+	private static boolean isJava8(ProjectRequest request) {
+		return "1.8".equals(request.getJavaVersion());
 	}
 
 	private byte[] doGenerateMavenPom(Map<String, Object> model) {

--- a/initializr-generator/src/main/resources/templates/starter-build.gradle
+++ b/initializr-generator/src/main/resources/templates/starter-build.gradle
@@ -42,7 +42,13 @@ apply plugin: 'war'
 {{/war}}
 
 version = '{{version}}'
-sourceCompatibility = {{javaVersion}}
+sourceCompatibility = {{javaVersion}}{{#kotlin}}{{#isJava8}}
+compileKotlin {
+	kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+	kotlinOptions.jvmTarget = "1.8"
+}{{/isJava8}}{{/kotlin}}
 
 repositories {
 	mavenCentral()
@@ -71,7 +77,15 @@ dependencies {
 	compile('org.codehaus.groovy:groovy')
 	{{/groovy}}
 	{{#kotlin}}
+	{{#isJava6}}
 	compile("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
+	{{/isJava6}}
+	{{#isJava7}}
+	compile("org.jetbrains.kotlin:kotlin-stdlib-jre7:${kotlinVersion}")
+	{{/isJava7}}
+	{{#isJava8}}
+	compile("org.jetbrains.kotlin:kotlin-stdlib-jre8:${kotlinVersion}")
+	{{/isJava8}}
 	compile("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
 	{{/kotlin}}
 	{{#runtimeDependencies}}

--- a/initializr-generator/src/main/resources/templates/starter-pom.xml
+++ b/initializr-generator/src/main/resources/templates/starter-pom.xml
@@ -49,7 +49,15 @@
 		{{#kotlin}}
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
+			{{#isJava6}}
 			<artifactId>kotlin-stdlib</artifactId>
+			{{/isJava6}}
+			{{#isJava7}}
+			<artifactId>kotlin-stdlib-jre7</artifactId>
+			{{/isJava7}}
+			{{#isJava8}}
+			<artifactId>kotlin-stdlib-jre8</artifactId>
+			{{/isJava8}}
 			<version>${kotlin.version}</version>
 		</dependency>
 		<dependency>
@@ -174,6 +182,9 @@
 					<compilerPlugins>
 						<plugin>spring</plugin>
 					</compilerPlugins>
+					{{#isJava8}}
+					<jvmTarget>${java.version}</jvmTarget>
+					{{/isJava8}}
 				</configuration>
 				<executions>
 					<execution>

--- a/initializr-generator/src/test/java/io/spring/initializr/test/metadata/InitializrMetadataTestBuilder.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/test/metadata/InitializrMetadataTestBuilder.java
@@ -77,7 +77,7 @@ public class InitializrMetadataTestBuilder {
 	public InitializrMetadataTestBuilder addDefaults() {
 		return addDefaultTypes().addDefaultPackagings().addDefaultJavaVersions()
 				.addDefaultLanguages().addDefaultBootVersions()
-				.setGradleEnv("0.5.1.RELEASE").setKotlinEnv("1.0.1");
+				.setGradleEnv("0.5.1.RELEASE").setKotlinEnv("1.1.1");
 	}
 
 	public InitializrMetadataTestBuilder addDefaultTypes() {

--- a/initializr-generator/src/test/resources/project/kotlin/standard/build.gradle.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/standard/build.gradle.gen
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		kotlinVersion = '1.0.1'
+		kotlinVersion = '1.1.1'
 		springBootVersion = '1.2.3.RELEASE'
 	}
 	repositories {
@@ -22,6 +22,12 @@ apply plugin: 'io.spring.dependency-management'
 
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = 1.8
+compileKotlin {
+	kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+	kotlinOptions.jvmTarget = "1.8"
+}
 
 repositories {
 	mavenCentral()
@@ -30,7 +36,7 @@ repositories {
 
 dependencies {
 	compile('org.springframework.boot:spring-boot-starter')
-	compile("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
+	compile("org.jetbrains.kotlin:kotlin-stdlib-jre8:${kotlinVersion}")
 	compile("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
 	testCompile('org.springframework.boot:spring-boot-starter-test')
 }

--- a/initializr-generator/src/test/resources/project/kotlin/standard/pom.xml.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/standard/pom.xml.gen
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<kotlin.version>1.0.1</kotlin.version>
+		<kotlin.version>1.1.1</kotlin.version>
 	</properties>
 
 	<dependencies>
@@ -32,7 +32,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
-			<artifactId>kotlin-stdlib</artifactId>
+			<artifactId>kotlin-stdlib-jre8</artifactId>
 			<version>${kotlin.version}</version>
 		</dependency>
 		<dependency>
@@ -64,6 +64,7 @@
 					<compilerPlugins>
 						<plugin>spring</plugin>
 					</compilerPlugins>
+					<jvmTarget>${java.version}</jvmTarget>
 				</configuration>
 				<executions>
 					<execution>

--- a/initializr-generator/src/test/resources/project/kotlin/war/build.gradle.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/war/build.gradle.gen
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		kotlinVersion = '1.0.1'
+		kotlinVersion = '1.1.1'
 		springBootVersion = '1.2.3.RELEASE'
 	}
 	repositories {
@@ -23,6 +23,12 @@ apply plugin: 'war'
 
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = 1.8
+compileKotlin {
+	kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+	kotlinOptions.jvmTarget = "1.8"
+}
 
 repositories {
 	mavenCentral()
@@ -34,7 +40,7 @@ configurations {
 
 dependencies {
 	compile('org.springframework.boot:spring-boot-starter-web')
-	compile("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
+	compile("org.jetbrains.kotlin:kotlin-stdlib-jre8:${kotlinVersion}")
 	compile("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
 	providedRuntime('org.springframework.boot:spring-boot-starter-tomcat')
 	testCompile('org.springframework.boot:spring-boot-starter-test')

--- a/initializr-generator/src/test/resources/project/kotlin/war/pom.xml.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/war/pom.xml.gen
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<kotlin.version>1.0.1</kotlin.version>
+		<kotlin.version>1.1.1</kotlin.version>
 	</properties>
 
 	<dependencies>
@@ -32,7 +32,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
-			<artifactId>kotlin-stdlib</artifactId>
+			<artifactId>kotlin-stdlib-jre8</artifactId>
 			<version>${kotlin.version}</version>
 		</dependency>
 		<dependency>
@@ -69,6 +69,7 @@
 					<compilerPlugins>
 						<plugin>spring</plugin>
 					</compilerPlugins>
+					<jvmTarget>${java.version}</jvmTarget>
 				</configuration>
 				<executions>
 					<execution>

--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -91,7 +91,7 @@ initializr:
     gradle:
       dependency-management-plugin-version: 0.6.0.RELEASE
     kotlin:
-      version: 1.0.6
+      version: 1.1.1
   dependencies:
     - name: Core
       content:


### PR DESCRIPTION
This commit also enables Java 8 bytecode and
uses kotlin-stdlib-jre7 or kotlin-stdlib-jre8
dependencies when possible.

Closes gh-377