### PR TITLE
Expand Boot support for Spring Cloud Services to include Boot 1.5

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -59,9 +59,9 @@ initializr:
         mappings:
           - versionRange: "[1.3.0.RELEASE,1.4.0.RELEASE)"
             version: 1.2.1.RELEASE
-          - versionRange: "[1.4.0.RELEASE,1.4.x.BUILD-SNAPSHOT)"
+          - versionRange: "[1.4.0.RELEASE,2.0.0.M1)"
             version: 1.4.1.RELEASE
-          - versionRange: "[1.4.x.BUILD-SNAPSHOT, 1.5.0.RC1)"
+          - versionRange: "[1.5.x.BUILD-SNAPSHOT, 2.0.0.M1)"
             version: 1.4.2.BUILD-SNAPSHOT
             repositories: spring-snapshots,spring-milestones
       cloud-task-bom:
@@ -895,7 +895,7 @@ initializr:
           starter: false
     - name: Pivotal Cloud Foundry
       bom: cloud-services-bom
-      versionRange: "[1.3.0.RELEASE,1.5.0.RC1)"
+      versionRange: "[1.3.0.RELEASE,2.0.0.M1)"
       content:
         - name: Config Client (PCF)
           id: scs-config-client


### PR DESCRIPTION
I'm not entirely certain that I got the cloud BOM section right, but I was able to confirm that if Spring Boot 1.5.2 is selected you can now select SCS starters. If there's something that can be done better/differently with the cloud BOM section, let me know and I'll be happy to follow up with another commit to this PR.