### PR TITLE
Add Flapdoodle embedded Mongo as an option.

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -529,6 +529,12 @@ initializr:
           links:
             - rel: reference
               href: http://docs.spring.io/spring-boot/docs/{bootVersion}/reference/htmlsingle/#boot-features-mongodb
+        - name: Embedded MongoDB
+          id: mongo-embedded
+          description: Flapdoodle embedded Mongo for testing
+          groupId: de.flapdoodle.embed
+          artifactId: de.flapdoodle.embed.mongo
+          starter: false
         - name: Cassandra
           id: data-cassandra
           description: Cassandra NoSQL Database, including spring-data-cassandra


### PR DESCRIPTION
I use Flapdoodle a lot in demos, but struggle to remember the group ID and artifact ID. Although Spring Boot has dependency management for Flapdoodle, but Initializr has no checkbox. This PR adds Flapdoodle to Initializr.