### PR TITLE
Apply the dependency management plugin in Boot 2.0 Gradle projects

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectGenerator.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectGenerator.java
@@ -56,6 +56,7 @@ import org.springframework.util.StreamUtils;
  * @author Dave Syer
  * @author Stephane Nicoll
  * @author Sebastien Deleuze
+ * @author Andy Wilkinson
  */
 public class ProjectGenerator {
 
@@ -72,6 +73,8 @@ public class ProjectGenerator {
 	private static final Version VERSION_1_4_2_M1 = Version.parse("1.4.2.M1");
 
 	private static final Version VERSION_1_5_0_M1 = Version.parse("1.5.0.M1");
+
+	private static final Version VERSION_2_0_0_BUILD_SNAPSHOT = Version.parse("2.0.0.BUILD-SNAPSHOT");
 
 	@Autowired
 	private ApplicationEventPublisher eventPublisher;
@@ -415,6 +418,9 @@ public class ProjectGenerator {
 
 		// Gradle plugin has changed as from 1.3.0
 		model.put("bootOneThreeAvailable", VERSION_1_3_0_M1
+				.compareTo(Version.safeParse(request.getBootVersion())) <= 0);
+
+		model.put("bootTwoZeroAvailable", VERSION_2_0_0_BUILD_SNAPSHOT
 				.compareTo(Version.safeParse(request.getBootVersion())) <= 0);
 
 		// Gradle plugin has changed again as from 1.4.2

--- a/initializr-generator/src/main/resources/templates/starter-build.gradle
+++ b/initializr-generator/src/main/resources/templates/starter-build.gradle
@@ -37,6 +37,9 @@ apply plugin: '{{springBootPluginName}}'
 {{^bootOneThreeAvailable}}
 apply plugin: 'io.spring.dependency-management'
 {{/bootOneThreeAvailable}}
+{{#bootTwoZeroAvailable}}
+apply plugin: 'io.spring.dependency-management'
+{{/bootTwoZeroAvailable}}
 {{#war}}
 apply plugin: 'war'
 {{/war}}

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/ProjectGeneratorTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/ProjectGeneratorTests.java
@@ -41,6 +41,7 @@ import static org.junit.Assert.fail;
  * Tests for {@link ProjectGenerator}
  *
  * @author Stephane Nicoll
+ * @author Andy Wilkinson
  */
 public class ProjectGeneratorTests extends AbstractProjectGeneratorTests {
 
@@ -508,6 +509,17 @@ public class ProjectGeneratorTests extends AbstractProjectGeneratorTests {
 				.contains("springBootVersion = '1.4.2.BUILD-SNAPSHOT'")
 				.contains("apply plugin: 'org.springframework.boot'")
 				.doesNotContain("apply plugin: 'spring-boot'");
+	}
+
+	@Test
+	public void gradleBuildAsFromSpringBoot20() {
+		ProjectRequest request = createProjectRequest("web");
+		request.setBootVersion("2.0.0.BUILD-SNAPSHOT");
+		generateGradleBuild(request)
+				.contains("springBootVersion = '2.0.0.BUILD-SNAPSHOT'")
+				.contains("apply plugin: 'org.springframework.boot'")
+				.doesNotContain("apply plugin: 'spring-boot'")
+				.contains("apply plugin: 'io.spring.dependency-management'");
 	}
 
 	@Test


### PR DESCRIPTION
When the new Gradle plugin is merged, projects using Spring Boot 2.0 will need to explicitly apply the dependency management plugin if they want to use Boot's dependency management. This PR updates the project generator accordingly. Projects using the current Gradle plugin which automatically applies the dependency management plugin will be unaffected by this change as applying a plugin is idempotent.