### PR TITLE
Enable Maven incremental compilation

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectRequest.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectRequest.java
@@ -232,6 +232,7 @@ public class ProjectRequest extends BasicProjectRequest {
 			if ("kotlin".equals(getLanguage())) {
 				buildProperties.getVersions().put(new VersionProperty("kotlin.version"),
 						() -> metadata.getConfiguration().getEnv().getKotlin().getVersion());
+				buildProperties.getMaven().put("kotlin.compiler.incremental", () -> "true");
 			}
 		}
 	}

--- a/initializr-generator/src/test/resources/project/kotlin/standard/pom.xml.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/standard/pom.xml.gen
@@ -19,6 +19,7 @@
 	</parent>
 
 	<properties>
+		<kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>

--- a/initializr-generator/src/test/resources/project/kotlin/war/pom.xml.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/war/pom.xml.gen
@@ -19,6 +19,7 @@
 	</parent>
 
 	<properties>
+		<kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>

--- a/initializr-generator/src/test/resources/project/maven/kotlin-java6-pom.xml.gen
+++ b/initializr-generator/src/test/resources/project/maven/kotlin-java6-pom.xml.gen
@@ -19,6 +19,7 @@
 	</parent>
 
 	<properties>
+		<kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.6</java.version>

--- a/initializr-generator/src/test/resources/project/maven/kotlin-java7-pom.xml.gen
+++ b/initializr-generator/src/test/resources/project/maven/kotlin-java7-pom.xml.gen
@@ -19,6 +19,7 @@
 	</parent>
 
 	<properties>
+		<kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.7</java.version>

--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -98,7 +98,7 @@ initializr:
     gradle:
       dependency-management-plugin-version: 0.6.0.RELEASE
     kotlin:
-      version: 1.1.1
+      version: 1.1.2
   dependencies:
     - name: Core
       content:


### PR DESCRIPTION
As explained in [Kotlin 1.1.2](https://blog.jetbrains.com/kotlin/2017/04/kotlin-1-1-2-is-out/) release notes, incremental compilation which was previously available for IntelliJ IDEA and Gradle builds is now supported for Maven. To enable, it is needed to set the kotlin.compiler.incremental property to true.

This is the first version supporting it and flagged as experimental but given the time you gain on big projects and the fact that it brings feature parity between Maven and Gradle, I propose to enable it. My basic tests seems to show it works as expected.