### PR TITLE
Derive package name from groupId and artifactId

### DIFF
--- a/initializr-actuator/src/test/java/io/spring/initializr/actuate/stat/ProjectRequestDocumentFactoryTests.java
+++ b/initializr-actuator/src/test/java/io/spring/initializr/actuate/stat/ProjectRequestDocumentFactoryTests.java
@@ -46,7 +46,7 @@ public class ProjectRequestDocumentFactoryTests extends AbstractInitializrStatTe
 		assertEquals(null, document.getRequestIp());
 		assertEquals("com.example", document.getGroupId());
 		assertEquals("demo", document.getArtifactId());
-		assertEquals("com.example", document.getPackageName());
+		assertEquals("com.example.demo", document.getPackageName());
 		assertEquals("1.2.3.RELEASE", document.getBootVersion());
 		assertEquals("1.8", document.getJavaVersion());
 		assertEquals("java", document.getLanguage());

--- a/initializr-generator/src/main/java/io/spring/initializr/metadata/InitializrMetadata.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/metadata/InitializrMetadata.java
@@ -65,7 +65,7 @@ public class InitializrMetadata {
 	private final TextCapability version = new TextCapability("version", "Version",
 			"project version");
 
-	private final TextCapability packageName = new PackageCapability(groupId);
+	private final TextCapability packageName = new PackageCapability(groupId, artifactId);
 
 	public InitializrMetadata() {
 		this(new InitializrConfiguration());
@@ -282,19 +282,29 @@ public class InitializrMetadata {
 	}
 
 	private static class PackageCapability extends TextCapability {
-		private final TextCapability nameCapability;
+		private final TextCapability groupId;
+		private final TextCapability artifactId;
 
-		PackageCapability(TextCapability nameCapability) {
+		PackageCapability(TextCapability groupId, TextCapability artifactId) {
 			super("packageName", "Package Name", "root package");
-			this.nameCapability = nameCapability;
+			this.groupId = groupId;
+			this.artifactId = artifactId;
 		}
 
 		@Override
 		public String getContent() {
 			String value = super.getContent();
-			return value != null ? value
-					: (nameCapability.getContent() != null
-							? nameCapability.getContent().replace("-", ".") : null);
+			if (value != null) {
+				return value;
+			}
+			else if(this.groupId.getContent() != null && this.artifactId.getContent() != null) {
+				return this.groupId.getContent()
+						.concat(".")
+						.concat(this.artifactId.getContent())
+						.replaceAll("-", "")
+						.replaceAll("\\.[0-9]+", ".");
+			}
+			return null;
 		}
 	}
 

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/ProjectGeneratorLanguageTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/ProjectGeneratorLanguageTests.java
@@ -76,7 +76,7 @@ public class ProjectGeneratorLanguageTests extends AbstractProjectGeneratorTests
 
 		ProjectAssert project = generateProject(request);
 		project.sourceCodeAssert(
-				"src/main/" + language + "/com/example/DemoApplication." + extension)
+				"src/main/" + language + "/com/example/demo/DemoApplication." + extension)
 				.equalsTo(new ClassPathResource("project/" + language
 						+ "/standard/DemoApplication." + expectedExtension));
 	}
@@ -88,7 +88,7 @@ public class ProjectGeneratorLanguageTests extends AbstractProjectGeneratorTests
 
 		ProjectAssert project = generateProject(request);
 		project.sourceCodeAssert(
-				"src/test/" + language + "/com/example/DemoApplicationTests." + extension)
+				"src/test/" + language + "/com/example/demo/DemoApplicationTests." + extension)
 				.equalsTo(new ClassPathResource("project/" + language
 						+ "/standard/DemoApplicationTests." + expectedExtension));
 	}
@@ -100,7 +100,7 @@ public class ProjectGeneratorLanguageTests extends AbstractProjectGeneratorTests
 
 		ProjectAssert project = generateProject(request);
 		project.sourceCodeAssert(
-				"src/test/" + language + "/com/example/DemoApplicationTests." + extension)
+				"src/test/" + language + "/com/example/demo/DemoApplicationTests." + extension)
 				.equalsTo(new ClassPathResource("project/" + language
 						+ "/standard/DemoApplicationTestsWeb." + expectedExtension));
 	}
@@ -129,7 +129,7 @@ public class ProjectGeneratorLanguageTests extends AbstractProjectGeneratorTests
 		}
 		ProjectAssert project = generateProject(request);
 		project.sourceCodeAssert(
-				"src/main/" + language + "/com/example/ServletInitializer." + extension)
+				"src/main/" + language + "/com/example/demo/ServletInitializer." + extension)
 				.equalsTo(new ClassPathResource("project/" + language
 						+ "/" + expectedOutput + "/ServletInitializer." + expectedExtension));
 	}
@@ -142,7 +142,7 @@ public class ProjectGeneratorLanguageTests extends AbstractProjectGeneratorTests
 
 		ProjectAssert project = generateProject(request);
 		project.sourceCodeAssert(
-				"src/test/" + language + "/com/example/DemoApplicationTests." + extension)
+				"src/test/" + language + "/com/example/demo/DemoApplicationTests." + extension)
 				.equalsTo(new ClassPathResource("project/" + language
 						+ "/standard/DemoApplicationTests." + expectedExtension));
 	}
@@ -155,7 +155,7 @@ public class ProjectGeneratorLanguageTests extends AbstractProjectGeneratorTests
 
 		ProjectAssert project = generateProject(request);
 		project.sourceCodeAssert(
-				"src/test/" + language + "/com/example/DemoApplicationTests." + extension)
+				"src/test/" + language + "/com/example/demo/DemoApplicationTests." + extension)
 				.equalsTo(new ClassPathResource("project/" + language
 						+ "/spring-boot-1.4/DemoApplicationTests." + expectedExtension));
 	}
@@ -168,7 +168,7 @@ public class ProjectGeneratorLanguageTests extends AbstractProjectGeneratorTests
 
 		ProjectAssert project = generateProject(request);
 		project.sourceCodeAssert(
-				"src/test/" + language + "/com/example/DemoApplicationTests." + extension)
+				"src/test/" + language + "/com/example/demo/DemoApplicationTests." + extension)
 				.equalsTo(new ClassPathResource("project/" + language
 						+ "/spring-boot-1.4/DemoApplicationTests." + expectedExtension));
 	}

--- a/initializr-generator/src/test/java/io/spring/initializr/metadata/InitializrMetadataTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/metadata/InitializrMetadataTests.java
@@ -199,4 +199,17 @@ public class InitializrMetadataTests {
 		builder.build();
 	}
 
+	@Test
+	public void stripInvalidCharsFromPackage() {
+		InitializrMetadata metadata = InitializrMetadataTestBuilder.withDefaults().build();
+		metadata.getGroupId().setContent("org.acme");
+		metadata.getArtifactId().setContent("2foo.bar");
+		assertThat(metadata.getPackageName().getContent()).isEqualTo("org.acme.foo.bar");
+
+		metadata = InitializrMetadataTestBuilder.withDefaults().build();
+		metadata.getGroupId().setContent("org.ac-me");
+		metadata.getArtifactId().setContent("foo-bar");
+		assertThat(metadata.getPackageName().getContent()).isEqualTo("org.acme.foobar");
+	}
+
 }

--- a/initializr-generator/src/test/java/io/spring/initializr/test/generator/ProjectAssert.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/test/generator/ProjectAssert.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class ProjectAssert {
 
-	public static final String DEFAULT_PACKAGE_NAME = "com.example";
+	public static final String DEFAULT_PACKAGE_NAME = "com.example.demo";
 
 	public static final String DEFAULT_APPLICATION_NAME = "DemoApplication";
 

--- a/initializr-generator/src/test/resources/project/groovy/spring-boot-1.4/DemoApplicationTests.groovy.gen
+++ b/initializr-generator/src/test/resources/project/groovy/spring-boot-1.4/DemoApplicationTests.groovy.gen
@@ -1,4 +1,4 @@
-package com.example
+package com.example.demo
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/initializr-generator/src/test/resources/project/groovy/spring-boot-1.4/ServletInitializer.groovy.gen
+++ b/initializr-generator/src/test/resources/project/groovy/spring-boot-1.4/ServletInitializer.groovy.gen
@@ -1,4 +1,4 @@
-package com.example
+package com.example.demo
 
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.web.support.SpringBootServletInitializer

--- a/initializr-generator/src/test/resources/project/groovy/standard/DemoApplication.groovy.gen
+++ b/initializr-generator/src/test/resources/project/groovy/standard/DemoApplication.groovy.gen
@@ -1,4 +1,4 @@
-package com.example
+package com.example.demo
 
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication

--- a/initializr-generator/src/test/resources/project/groovy/standard/DemoApplicationTests.groovy.gen
+++ b/initializr-generator/src/test/resources/project/groovy/standard/DemoApplicationTests.groovy.gen
@@ -1,4 +1,4 @@
-package com.example
+package com.example.demo
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/initializr-generator/src/test/resources/project/groovy/standard/DemoApplicationTestsWeb.groovy.gen
+++ b/initializr-generator/src/test/resources/project/groovy/standard/DemoApplicationTestsWeb.groovy.gen
@@ -1,4 +1,4 @@
-package com.example
+package com.example.demo
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/initializr-generator/src/test/resources/project/groovy/standard/ServletInitializer.groovy.gen
+++ b/initializr-generator/src/test/resources/project/groovy/standard/ServletInitializer.groovy.gen
@@ -1,4 +1,4 @@
-package com.example
+package com.example.demo
 
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.context.web.SpringBootServletInitializer

--- a/initializr-generator/src/test/resources/project/java/spring-boot-1.4/DemoApplicationTests.java.gen
+++ b/initializr-generator/src/test/resources/project/java/spring-boot-1.4/DemoApplicationTests.java.gen
@@ -1,4 +1,4 @@
-package com.example;
+package com.example.demo;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/initializr-generator/src/test/resources/project/java/spring-boot-1.4/ServletInitializer.java.gen
+++ b/initializr-generator/src/test/resources/project/java/spring-boot-1.4/ServletInitializer.java.gen
@@ -1,4 +1,4 @@
-package com.example;
+package com.example.demo;
 
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.support.SpringBootServletInitializer;

--- a/initializr-generator/src/test/resources/project/java/standard/DemoApplication.java.gen
+++ b/initializr-generator/src/test/resources/project/java/standard/DemoApplication.java.gen
@@ -1,4 +1,4 @@
-package com.example;
+package com.example.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/initializr-generator/src/test/resources/project/java/standard/DemoApplicationTests.java.gen
+++ b/initializr-generator/src/test/resources/project/java/standard/DemoApplicationTests.java.gen
@@ -1,4 +1,4 @@
-package com.example;
+package com.example.demo;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/initializr-generator/src/test/resources/project/java/standard/DemoApplicationTestsWeb.java.gen
+++ b/initializr-generator/src/test/resources/project/java/standard/DemoApplicationTestsWeb.java.gen
@@ -1,4 +1,4 @@
-package com.example;
+package com.example.demo;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/initializr-generator/src/test/resources/project/java/standard/ServletInitializer.java.gen
+++ b/initializr-generator/src/test/resources/project/java/standard/ServletInitializer.java.gen
@@ -1,4 +1,4 @@
-package com.example;
+package com.example.demo;
 
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.web.SpringBootServletInitializer;

--- a/initializr-generator/src/test/resources/project/kotlin/spring-boot-1.4/DemoApplicationTests.kt.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/spring-boot-1.4/DemoApplicationTests.kt.gen
@@ -1,4 +1,4 @@
-package com.example
+package com.example.demo
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/initializr-generator/src/test/resources/project/kotlin/spring-boot-1.4/ServletInitializer.kt.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/spring-boot-1.4/ServletInitializer.kt.gen
@@ -1,4 +1,4 @@
-package com.example
+package com.example.demo
 
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.web.support.SpringBootServletInitializer

--- a/initializr-generator/src/test/resources/project/kotlin/standard/DemoApplication.kt.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/standard/DemoApplication.kt.gen
@@ -1,4 +1,4 @@
-package com.example
+package com.example.demo
 
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication

--- a/initializr-generator/src/test/resources/project/kotlin/standard/DemoApplicationTests.kt.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/standard/DemoApplicationTests.kt.gen
@@ -1,4 +1,4 @@
-package com.example
+package com.example.demo
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/initializr-generator/src/test/resources/project/kotlin/standard/DemoApplicationTestsWeb.kt.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/standard/DemoApplicationTestsWeb.kt.gen
@@ -1,4 +1,4 @@
-package com.example
+package com.example.demo
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/initializr-generator/src/test/resources/project/kotlin/standard/ServletInitializer.kt.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/standard/ServletInitializer.kt.gen
@@ -1,4 +1,4 @@
-package com.example
+package com.example.demo
 
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.context.web.SpringBootServletInitializer

--- a/initializr-web/src/main/resources/static/js/start.js
+++ b/initializr-web/src/main/resources/static/js/start.js
@@ -156,12 +156,24 @@ $(function () {
             engine.add(data.dependencies);
         });
     };
+    var generatePackageName = function() {
+        var groupId = $("#groupId").val();
+        var artifactId = $("#artifactId").val();
+        var package = groupId.concat(".").concat(artifactId)
+            .replace(/-/g, '');
+        $("#packageName").val(package);
+    };
     refreshDependencies($("#bootVersion").val());
     $("#type").on('change', function () {
         $("#form").attr('action', $(this.options[this.selectedIndex]).attr('data-action'))
     });
+    $("#groupId").on("change", function() {
+        generatePackageName();
+    });
     $("#artifactId").on('change', function () {
+        $("#name").val($(this).val());
         $("#baseDir").attr('value', this.value)
+        generatePackageName();
     });
     $("#bootVersion").on("change", function (e) {
         refreshDependencies(this.value);
@@ -235,12 +247,6 @@ $(function () {
         $("#dependencies input[value='" + id + "']").prop('checked', false);
         removeTag(id);
     });
-    $("#groupId").on("change", function() {
-        $("#packageName").val($(this).val());
-    });
-    $("#artifactId").on("change", function() {
-        $("#name").val($(this).val());
-    });
     $("#dependencies input").bind("change", function () {
         var value = $(this).val()
         if ($(this).prop('checked')) {
@@ -266,7 +272,6 @@ $(function () {
             e.returnValue = false;
         }
     });
-
     applyParams();
     if ("onhashchange" in window) {
         window.onhashchange = function() {
@@ -276,5 +281,4 @@ $(function () {
             applyParams();
         }
     }
-
 });

--- a/initializr-web/src/test/resources/metadata/config/test-default.json
+++ b/initializr-web/src/test/resources/metadata/config/test-default.json
@@ -308,7 +308,7 @@
     "type": "TEXT"
   },
   "packageName": {
-    "content": "com.example",
+    "content": "com.example.demo",
     "description": "root package",
     "id": "packageName",
     "title": "Package Name",

--- a/initializr-web/src/test/resources/metadata/test-default-2.0.0.json
+++ b/initializr-web/src/test/resources/metadata/test-default-2.0.0.json
@@ -189,6 +189,6 @@
   },
   "packageName": {
     "type": "text",
-    "default": "com.example"
+    "default": "com.example.demo"
   }
 }

--- a/initializr-web/src/test/resources/metadata/test-default-2.1.0.json
+++ b/initializr-web/src/test/resources/metadata/test-default-2.1.0.json
@@ -227,6 +227,6 @@
   },
   "packageName": {
     "type": "text",
-    "default": "com.example"
+    "default": "com.example.demo"
   }
 }


### PR DESCRIPTION
This commit derives the package name of the application from the
artifact's `groupId` and `artifactId`. Previously sources were put in a
package that mirrors the groupId value.

This goes against the "unique package per application" policy that we
try to enforce. Even if the package name value can be customized
manually, deriving it automatically from the values provided in those
fields will help structure codebases.

With this change, the package name is derived like this:
* groupId `com.example`, artifactId `bookmarks` -> package
`com.example.bookmarks`
* groupId `com.example`, artifactId `user-management` -> package
`com.example.usermanagement`

This commit fixes the package name generation on the server, but also
in the web interfaces when the user updates the form fields.

Fixes gh-421