### PR TITLE
Upgrade to Kotlin 1.1.3-2

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -89,7 +89,7 @@ initializr:
     gradle:
       dependency-management-plugin-version: 0.6.0.RELEASE
     kotlin:
-      version: 1.1.3
+      version: 1.1.3-2
   dependencies:
     - name: Core
       content:


### PR DESCRIPTION
This patch release fixes a kotlin-noarg regression,
see https://github.com/JetBrains/kotlin/releases/tag/v1.1.3-2
for more details.