### PR TITLE
Add `out` directory to .gitignore for Gradle-based projects

### DIFF
--- a/initializr-generator/src/main/resources/templates/gitignore.tmpl
+++ b/initializr-generator/src/main/resources/templates/gitignore.tmpl
@@ -8,6 +8,9 @@ target/
 !gradle/wrapper/gradle-wrapper.jar
 {{/mavenBuild}}
 
+### Kotlin ###
+/out/
+
 ### STS ###
 .apt_generated
 .classpath


### PR DESCRIPTION
Hello,

I generated a gradle/kotlin + Web, JPA project on http://start.spring.io/ , added some kotlin classes (I'm following [this tutorial](https://spring.io/guides/tutorials/bookmarks/) but in kotlin) and build it.

The `out/` directory created for `.class` files is not in the .gitignore by default.

Suggestion: add it :) This is the stupid way to fix the .gitignore , please provide feedback if this is incorrect/insufficient: I am willing to rework this PR :)

Cheers,

Bernard