### PR TITLE
Upgrade to MyBatis 1.2.2 and 1.3.1

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -443,9 +443,9 @@ initializr:
             - versionRange: "[1.3.0.RELEASE,1.4.0.RELEASE)"
               version: 1.1.1
             - versionRange: "[1.4.0.RELEASE,1.5.0.RELEASE)"
-              version: 1.2.1
+              version: 1.2.2
             - versionRange: 1.5.0.RELEASE
-              version: 1.3.0
+              version: 1.3.1
         - name: JDBC
           id: jdbc
           description: JDBC databases


### PR DESCRIPTION
Update MyBatis version as follow:

* 1.2.1 -> 1.2.2
* 1.3.0 -> 1.3.1

Note:
mybatis-spring-boot-starter 1.2.2 and 1.3.1 has been released at today. (For details refer to [here](http://blog.mybatis.org/2017/08/mybatis-spring-boot-starter-122-131.html))