### PR TITLE
Using localstorage to populate project type, language and bootVersion…

### DIFF
--- a/initializr-web/src/main/resources/static/js/start.js
+++ b/initializr-web/src/main/resources/static/js/start.js
@@ -141,7 +141,6 @@
         }
         initLocalStorageField('type');
         initLocalStorageField('language');
-        initLocalStorageField('bootVersion');
     }
 
 }());

--- a/initializr-web/src/main/resources/static/js/start.js
+++ b/initializr-web/src/main/resources/static/js/start.js
@@ -113,32 +113,25 @@
     }
 
     LOCAL_STORAGE_AVAILABLE = (function () {
-        var mod = 'localstorage-test';
+        var test = 'localstorage-test';
         try {
-            localStorage.setItem(mod, mod);
-            localStorage.removeItem(mod);
+            localStorage.setItem(test, test);
+            localStorage.removeItem(test);
             return true;
         } catch(e) {
             return false;
         }
     })()
 
-    function setLocalStorage(key, value) {
-        localStorage.setItem(key, value);
-    }
-
-    function getLocalStorage(key) {
-        return localStorage.getItem(key);
-    }
-
-    function initLocalStorageField(selector, lsKey) {
-        var $field = $(selector);
-        var value = getLocalStorage(lsKey);
+    function initLocalStorageField(field) {
+        var $field = $('#' + field);
+        var lsKey = 'initializer-' + field;
+        var value = localStorage.getItem(lsKey);
         if (value && $field.find("option[value='" + value + "']").length > 0) {
             $field.val(value);
         }
         $field.bind('change', function (e) {
-            setLocalStorage(lsKey, e.target.value);
+            localStorage.setItem(lsKey, e.target.value);
         });
     }
 
@@ -146,9 +139,9 @@
         if (!LOCAL_STORAGE_AVAILABLE) {
             return;
         }
-        initLocalStorageField('#type', 'initializer-type');
-        initLocalStorageField('#language', 'initializer-language');
-        initLocalStorageField('#bootVersion', 'initializer-bootVersion');
+        initLocalStorageField('type');
+        initLocalStorageField('language');
+        initLocalStorageField('bootVersion');
     }
 
 }());

--- a/initializr-web/src/main/resources/static/js/start.js
+++ b/initializr-web/src/main/resources/static/js/start.js
@@ -112,7 +112,7 @@
         });
     }
 
-    LOCAL_STORAGE_AVAILABLE = (function () {
+    var LOCAL_STORAGE_AVAILABLE = (function () {
         var test = 'localstorage-test';
         try {
             localStorage.setItem(test, test);

--- a/initializr-web/src/main/resources/static/js/start.js
+++ b/initializr-web/src/main/resources/static/js/start.js
@@ -112,6 +112,45 @@
         });
     }
 
+    LOCAL_STORAGE_AVAILABLE = (function () {
+        var mod = 'localstorage-test';
+        try {
+            localStorage.setItem(mod, mod);
+            localStorage.removeItem(mod);
+            return true;
+        } catch(e) {
+            return false;
+        }
+    })()
+
+    function setLocalStorage(key, value) {
+        localStorage.setItem(key, value);
+    }
+
+    function getLocalStorage(key) {
+        return localStorage.getItem(key);
+    }
+
+    function initLocalStorageField(selector, lsKey) {
+        var $field = $(selector);
+        var value = getLocalStorage(lsKey);
+        if (value && $field.find("option[value='" + value + "']").length > 0) {
+            $field.val(value);
+        }
+        $field.bind('change', function (e) {
+            setLocalStorage(lsKey, e.target.value);
+        });
+    }
+
+    applyLocalStorage = function () {
+        if (!LOCAL_STORAGE_AVAILABLE) {
+            return;
+        }
+        initLocalStorageField('#type', 'initializer-type');
+        initLocalStorageField('#language', 'initializer-language');
+        initLocalStorageField('#bootVersion', 'initializer-bootVersion');
+    }
+
 }());
 
 $(function () {
@@ -273,6 +312,7 @@ $(function () {
         }
     });
     applyParams();
+    applyLocalStorage();
     if ("onhashchange" in window) {
         window.onhashchange = function() {
             $(".full").addClass("hidden");


### PR DESCRIPTION
… fields with previously used values

I always use Gradle and Kotlin when creating projects with start.spring.io. Sometimes I rush through creating a project and have to regenerate a project because I created a Maven or Java project instead.

This change is for preserving the user's previously used type, language and bootVersion values using local storage. I feel that these values do not typically change for a user -- you most likely almost always use maven or almost always use gradle and similar with language and bootVersion.

Nothing is done if the user's browser does not support the local storage api.