### PR TITLE
Upgrade to Kotlin 1.1.51

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -93,7 +93,7 @@ initializr:
     gradle:
       dependency-management-plugin-version: 0.6.0.RELEASE
     kotlin:
-      version: 1.1.4-3
+      version: 1.1.51
   dependencies:
     - name: Core
       content:


### PR DESCRIPTION
The main new feature available in this new
version is null-safety of Spring APIs (Framework,
Data, Reactor) with Boot 2 without requiring
jsr305.jar to be present in project classpath.

-Xjsr305=strict compiler flag is not enabled by default
because it is considered as experimental, see
https://docs.spring.io/spring/docs/current/spring-framework-reference/kotlin.html#null-safety
for more details.