### PR TITLE
Use Tag Manager instead of Analytics

### DIFF
--- a/initializr-web/src/main/resources/templates/home.html
+++ b/initializr-web/src/main/resources/templates/home.html
@@ -8,6 +8,13 @@
     <link rel="stylesheet" href="{{#linkTo}}/css/spring.css{{/linkTo}}"/>
     <link rel="shortcut icon" type="image/x-icon" href="/img/favicon.png"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    {{#trackingCode}}
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KZM7GF6');</script>
+    {{/trackingCode}}
 </head>
 <body>
 <form id="form" action="/starter.zip" method="get" role="form">
@@ -173,15 +180,5 @@
 <script src="{{#linkTo}}/js/typeahead.bundle.min.js{{/linkTo}}"></script>
 <script src="{{#linkTo}}/js/mousetrap.min.js{{/linkTo}}"></script>
 <script src="{{#linkTo}}/js/start.js{{/linkTo}}"></script>
-{{#trackingCode}}
-<script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', '{{.}}', 'auto');
-    ga('send', 'pageview');
-</script>
-{{/trackingCode}}
 </body>
 </html>


### PR DESCRIPTION
This commit replaces Google Analytics with Tag Manager in the official
start.spring.io service instance.
The code section has been moved from the end of the body to the end
of the head section.