### PR TITLE
support Spring Shell in the Spring Initializr

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -104,6 +104,16 @@ initializr:
   dependencies:
     - name: Core
       content:
+        - name: Spring Shell
+          groupId: org.springframework.shell
+          artifactId: spring-shell-starter
+          id: spring-shell
+          description: Build shell-based clients
+          version: 2.0.0.M2
+          repository: spring-milestones
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-shell/docs/2.0.0.M2/reference/htmlsingle/#extending-spring-shell
         - name: Security
           id: security
           description: Secure your application via spring-security


### PR DESCRIPTION
the Spring Shell version isn't managed by Spring Boot, but the version of Boot that it supports is Spring Boot 1.3.+. So, you could use this with older versions or newer ones, no problem. This PR adds the latest Spring Shell 2.0 milestone, which is very different than the old Spring Shell, principally because it has a comprehensive auto-configuration story. I can't quite figure out how to get the Initializr to add the MILESTONE/SNAPSHOT repositories for resolution of Spring Shell itself, not the Boot version, so I pinned this at 2.0.0.M5+. (Will Boot 2 go GA before Spring Shell goes GA? could Boot 2 manage the Spring Shell version?)

cc @ericbottard 