### PR TITLE
Keycloak: bump up BOM version to 3.4.0.Final

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -96,7 +96,7 @@ initializr:
         groupId: org.keycloak.bom
         artifactId: keycloak-adapter-bom
         versionProperty: keycloak.version
-        version: 3.2.1.Final
+        version: 3.4.0.Final
     gradle:
       dependency-management-plugin-version: 0.6.0.RELEASE
     kotlin:


### PR DESCRIPTION
Keycloak spring boot and spring security adapters received some
interesting fixes in releases 3.3.x and 3.4.0