### PR TITLE
Allow generation of custom files

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectGenerator.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectGenerator.java
@@ -186,7 +186,9 @@ public class ProjectGenerator {
 	 */
 	public File generateProjectStructure(ProjectRequest request) {
 		try {
-			return doGenerateProjectStructure(request);
+			File rootDir = doGenerateProjectStructure(request);
+			publishProjectGeneratedEvent(request);
+			return rootDir;
 		}
 		catch (InitializrException ex) {
 			publishProjectFailedEvent(request, ex);
@@ -254,9 +256,7 @@ public class ProjectGenerator {
 			new File(dir, "src/main/resources/templates").mkdirs();
 			new File(dir, "src/main/resources/static").mkdirs();
 		}
-		publishProjectGeneratedEvent(request);
 		return rootDir;
-
 	}
 
 	/**
@@ -566,11 +566,11 @@ public class ProjectGenerator {
 				&& !request.getJavaVersion().equals("1.7");
 	}
 
-	private static boolean isGradleBuild(ProjectRequest request) {
+	protected static boolean isGradleBuild(ProjectRequest request) {
 		return "gradle".equals(request.getBuild());
 	}
 
-	private static boolean isMavenBuild(ProjectRequest request) {
+	protected static boolean isMavenBuild(ProjectRequest request) {
 		return "maven".equals(request.getBuild());
 	}
 

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/AbstractProjectGeneratorTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/AbstractProjectGeneratorTests.java
@@ -48,10 +48,18 @@ public abstract class AbstractProjectGeneratorTests {
 	@Rule
 	public final TemporaryFolder folder = new TemporaryFolder();
 
-	protected final ProjectGenerator projectGenerator = new ProjectGenerator();
+	protected final ProjectGenerator projectGenerator;
 
-	private final ApplicationEventPublisher eventPublisher = mock(
+	protected final ApplicationEventPublisher eventPublisher = mock(
 			ApplicationEventPublisher.class);
+
+	public AbstractProjectGeneratorTests() {
+		this(new ProjectGenerator());
+	}
+
+	public AbstractProjectGeneratorTests(ProjectGenerator projectGenerator) {
+		this.projectGenerator = projectGenerator;
+	}
 
 	@Before
 	public void setup() throws IOException {
@@ -104,7 +112,7 @@ public abstract class AbstractProjectGeneratorTests {
 		verify(eventPublisher, times(1)).publishEvent(argThat(new ProjectFailedEventMatcher(request, ex)));
 	}
 
-	private static class ProjectGeneratedEventMatcher
+	protected static class ProjectGeneratedEventMatcher
 			extends ArgumentMatcher<ProjectGeneratedEvent> {
 
 		private final ProjectRequest request;

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/CustomProjectGeneratorTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/CustomProjectGeneratorTests.java
@@ -1,0 +1,63 @@
+package io.spring.initializr.generator;
+
+import io.spring.initializr.test.generator.ProjectAssert;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.File;
+
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.times;
+
+public class CustomProjectGeneratorTests extends AbstractProjectGeneratorTests {
+
+    public CustomProjectGeneratorTests() {
+        super(new MyProjectGenerator());
+    }
+
+    @Test
+    public void jenkinsfileMaven() {
+        ProjectRequest request = createProjectRequest();
+        request.setType("maven-project");
+        ProjectAssert project = generateProject(request);
+        project.sourceCodeAssert("Jenkinsfile")
+                .equalsTo(new ClassPathResource("project/maven/Jenkinsfile"));
+    }
+
+    @Test
+    public void jenkinsfileGradle() {
+        ProjectRequest request = createProjectRequest();
+        request.setType("gradle-build");
+        ProjectAssert project = generateProject(request);
+        project.hasNoFile("Jenkinsfile");
+    }
+
+    @Test
+    public void projectGenerationEventAfterGeneratingAllFiles() throws Exception {
+        ProjectRequest request = createProjectRequest("web");
+        generateProject(request);
+        verifyProjectSuccessfulEventFor(request);
+
+        Runnable jenkinsfileGenerated = ((MyProjectGenerator) projectGenerator).jenkinsfileGenerated;
+        InOrder inOrder = Mockito.inOrder(eventPublisher, jenkinsfileGenerated);
+
+        inOrder.verify(jenkinsfileGenerated, times(1)).run();
+        inOrder.verify(eventPublisher, times(1)).publishEvent(argThat(new ProjectGeneratedEventMatcher(request)));
+    }
+
+    private static class MyProjectGenerator extends ProjectGenerator {
+        protected final Runnable jenkinsfileGenerated = Mockito.mock(Runnable.class);
+
+        @Override
+        protected File doGenerateProjectStructure(ProjectRequest request) {
+            File dir = super.doGenerateProjectStructure(request);
+            if (isMavenBuild(request)) {
+                write(new File(dir, "Jenkinsfile"), "Jenkinsfile.tmpl", resolveModel(request));
+                jenkinsfileGenerated.run();
+            }
+            return dir;
+        }
+    }
+}

--- a/initializr-generator/src/test/resources/project/maven/Jenkinsfile
+++ b/initializr-generator/src/test/resources/project/maven/Jenkinsfile
@@ -1,0 +1,16 @@
+pipeline {
+    agent any
+    stages {
+        stage ('Build') {
+            steps {
+                echo "building com.example:demo:0.0.1-SNAPSHOT"
+                sh 'mvn -Dmaven.test.failure.ignore=true -B clean install'
+            }
+            post {
+                success {
+                    junit 'target/surefire-reports/**/*.xml'
+                }
+            }
+        }
+    }
+}

--- a/initializr-generator/src/test/resources/templates/Jenkinsfile.tmpl
+++ b/initializr-generator/src/test/resources/templates/Jenkinsfile.tmpl
@@ -1,0 +1,16 @@
+pipeline {
+    agent any
+    stages {
+        stage ('Build') {
+            steps {
+                echo "building {{groupId}}:{{artifactId}}:{{version}}"
+                sh 'mvn -Dmaven.test.failure.ignore=true -B clean install'
+            }
+            post {
+                success {
+                    junit 'target/surefire-reports/**/*.xml'
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Spring initializr allows to be customization so that it can be used in corporate environments or other pages than https://start.spring.io/.

To make it even more convenient to use generated projects right away is to generate additional files which are needed for CI tools e.g. Jenkins. In our case we would like to generate Jenkinsfiles which can be used as is.

One way to generate additional files is to override the method doGenerateProjectStructure:

```
    public class MyProjectGenerator extends ProjectGenerator {
        protected final Runnable jenkinsfileGenerated = Mockito.mock(Runnable.class);

        @Override
        protected File doGenerateProjectStructure(ProjectRequest request) {
            File dir = super.doGenerateProjectStructure(request);
            if (isMavenBuild(request)) {
                write(new File(dir, "Jenkinsfile"), "Jenkinsfile.tmpl", resolveModel(request));
                jenkinsfileGenerated.run();
            }
            return dir;
        }
    }
```

The problem here is that `doGenerateProjectStructure` publishes a ProjectGeneratedEvent. The issue is that with this setup ProjectGeneratedEvent would be published before the generation of files is actually done. Therefor this PR proses moving publishing of events to "generateProjectStructure".

To make it possible to reuse `isMavenBuild` and `isGradleBuild` their visibility has been changed to protected.