### PR TITLE
Spring Cloud Finchley.M5 has been released

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -47,7 +47,7 @@ initializr:
             version: Edgware.BUILD-SNAPSHOT
             repositories: spring-snapshots,spring-milestones
           - versionRange: "[2.0.0.M2, 2.0.0.BUILD-SNAPSHOT)"
-            version: Finchley.M4
+            version: Finchley.M5
             repositories: spring-milestones
           - versionRange: "2.0.0.BUILD-SNAPSHOT"
             version: Finchley.BUILD-SNAPSHOT


### PR DESCRIPTION
Updated for spring-boot 2.0.0.M7. This would be helpful to get merged prior to s1p.