### PR TITLE
Add links of MyBatis

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -479,6 +479,12 @@ initializr:
         - name: MyBatis
           id: mybatis
           description: Persistence support using MyBatis
+          links:
+            - rel: guide
+              href: https://github.com/mybatis/spring-boot-starter/wiki/Quick-Start
+              description: Quick Start
+            - rel: reference
+              href: http://www.mybatis.org/spring-boot-starter/mybatis-spring-boot-autoconfigure/
           groupId: org.mybatis.spring.boot
           artifactId: mybatis-spring-boot-starter
           mappings:


### PR DESCRIPTION
I've added two links as follows:

* The Reference document for MyBatis Spring Boot Starter
* The guide for quick start on MyBatis Spring Boot Starter GitHub wiki page
