### PR TITLE
Fix 591: Add jsr305-style support to Kotlin compiler options in gener…

### DIFF
--- a/initializr-generator/src/main/resources/templates/starter-build.gradle
+++ b/initializr-generator/src/main/resources/templates/starter-build.gradle
@@ -49,9 +49,11 @@ version = '{{version}}'
 sourceCompatibility = {{javaVersion}}{{#kotlin}}{{#java8OrLater}}
 compileKotlin {
 	kotlinOptions.jvmTarget = "1.8"
+	kotlinOptions.freeCompilerArgs = ["-Xjsr305=strict"]
 }
 compileTestKotlin {
 	kotlinOptions.jvmTarget = "1.8"
+	kotlinOptions.freeCompilerArgs = ["-Xjsr305=strict"]
 }{{/java8OrLater}}{{/kotlin}}
 
 repositories {

--- a/initializr-generator/src/main/resources/templates/starter-pom.xml
+++ b/initializr-generator/src/main/resources/templates/starter-pom.xml
@@ -183,6 +183,9 @@
 					{{^kotlinSupport}}
 					{{#java8OrLater}}
 					<jvmTarget>1.8</jvmTarget>
+					<args>
+						<arg>-Xjsr305=strict</arg>
+					</args>
 					{{/java8OrLater}}
 					{{/kotlinSupport}}
 				</configuration>


### PR DESCRIPTION
…ated build files

Adds JetBrains-specified compiler options to build.gradle & pom.xml starters to
leverage prior & continuing efforts to incorporate jsr305-style annotations
throughout Spring Framework 5, Spring Boot 2, et al to indicate nullability &
non-nullability of APIs for full Kotlin interoperability and support.