### PR TITLE
Add support for Spring Statemachine

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -138,7 +138,7 @@ initializr:
         versionProperty: spring-statemachine.version
         mappings:
           - versionRange: "2.0.0.RC1"
-            version: 2.0.0.M3
+            version: 2.0.0.M4
       vaadin:
         groupId: com.vaadin
         artifactId: vaadin-bom
@@ -1263,17 +1263,16 @@ initializr:
           links:
            - rel: reference
              href: https://docs.spring.io/spring-shell/docs/2.0.0.M2/reference/htmlsingle/
-        - name: Spring Statemachine
+        - name: Statemachine
           id: spring-statemachine
           groupId: org.springframework.statemachine
           artifactId: spring-statemachine-starter
-          description: Statemachine integration
-          version: 2.0.0.M3
+          description: Build applications using statemachine concepts
           versionRange: 2.0.0.RC1
           bom: spring-statemachine
           links:
             - rel: reference
-              href: http://docs.spring.io/spring-statemachine/docs/2.0.0.M3/reference/htmlsingle/
+              href: https://docs.spring.io/spring-statemachine/docs/current-SNAPSHOT/reference/htmlsingle/
     - name: Ops
       content:
         - name: Actuator

--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -132,6 +132,13 @@ initializr:
           - versionRange: "2.0.0.BUILD-SNAPSHOT"
             version: 2.0.0.BUILD-SNAPSHOT
             repositories: spring-snapshots,spring-milestones
+      spring-statemachine:
+        groupId: org.springframework.statemachine
+        artifactId: spring-statemachine-bom
+        versionProperty: spring-statemachine.version
+        mappings:
+          - versionRange: "2.0.0.RC1"
+            version: 2.0.0.M3
       vaadin:
         groupId: com.vaadin
         artifactId: vaadin-bom
@@ -1256,6 +1263,17 @@ initializr:
           links:
            - rel: reference
              href: https://docs.spring.io/spring-shell/docs/2.0.0.M2/reference/htmlsingle/
+        - name: Spring Statemachine
+          id: spring-statemachine
+          groupId: org.springframework.statemachine
+          artifactId: spring-statemachine-starter
+          description: Statemachine integration
+          version: 2.0.0.M3
+          versionRange: 2.0.0.RC1
+          bom: spring-statemachine
+          links:
+            - rel: reference
+              href: http://docs.spring.io/spring-statemachine/docs/2.0.0.M3/reference/htmlsingle/
     - name: Ops
       content:
         - name: Actuator


### PR DESCRIPTION
- Statemachine 2.0.0.M3 is out which uses boot 2.0.0.RC1,
  so add versions according to these.
- Fixes #597