### PR TITLE
Add `jackson-module-kotlin` dependency when relevant

### DIFF
--- a/initializr-service/src/main/java/io/spring/initializr/service/extension/JacksonKotlinRequestPostProcessor.java
+++ b/initializr-service/src/main/java/io/spring/initializr/service/extension/JacksonKotlinRequestPostProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.service.extension;
+
+import io.spring.initializr.generator.ProjectRequest;
+import io.spring.initializr.generator.ProjectRequestPostProcessor;
+import io.spring.initializr.metadata.Dependency;
+import io.spring.initializr.metadata.InitializrMetadata;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * A {@link ProjectRequestPostProcessor} that automatically adds "jackson-module-kotlin"
+ * when Kotlin is used and a dependency has the "json" facet (meaning that it has
+ * "spring-boot-starter-json" transitive dependency).
+ *
+ * @author Sebastien Deleuze
+ */
+@Component
+class JacksonKotlinRequestPostProcessor implements ProjectRequestPostProcessor {
+
+	private final Dependency jacksonModuleKotlin;
+
+	public JacksonKotlinRequestPostProcessor() {
+		this.jacksonModuleKotlin = Dependency.withId(
+				"jackson-module-kotlin", "com.fasterxml.jackson.module", "jackson-module-kotlin");
+	}
+
+	@Override
+	public void postProcessAfterResolution(ProjectRequest request, InitializrMetadata metadata) {
+		if (request.getFacets().contains("json") && "kotlin".equals(request.getLanguage())) {
+			request.getResolvedDependencies().add(this.jacksonModuleKotlin);
+		}
+	}
+
+}

--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -277,6 +277,7 @@ initializr:
           weight: 100
           facets:
             - web
+            - json
           links:
             - rel: guide
               href: https://spring.io/guides/gs/rest-service/
@@ -294,9 +295,13 @@ initializr:
           versionRange: 2.0.0.M1
           description: Reactive web development with Netty and Spring WebFlux
           weight: 90
+          facets:
+            - json
         - name: Rest Repositories
           id: data-rest
           weight: 10
+          facets:
+            - json
           description: Exposing Spring Data repositories over REST via spring-data-rest-webmvc
           links:
             - rel: guide
@@ -346,6 +351,8 @@ initializr:
         - name: Jersey (JAX-RS)
           id: jersey
           description: RESTful Web Services framework with support of JAX-RS
+          facets:
+            - json
           versionRange: 1.2.0.RELEASE
           links:
             - rel: reference

--- a/initializr-service/src/test/java/io/spring/initializr/service/extension/JacksonKotlinRequestPostProcessorTests.java
+++ b/initializr-service/src/test/java/io/spring/initializr/service/extension/JacksonKotlinRequestPostProcessorTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.service.extension;
+
+import io.spring.initializr.generator.ProjectRequest;
+import io.spring.initializr.metadata.Dependency;
+import org.junit.Test;
+
+/**
+ * Tests for {@link JacksonKotlinRequestPostProcessor}.
+ *
+ * @author Sebastien Deleuze
+ */
+public class JacksonKotlinRequestPostProcessorTests
+		extends AbstractRequestPostProcessorTests {
+
+	@Test
+	public void jacksonModuleKotlinIsAdded() {
+		ProjectRequest request = createProjectRequest("webflux");
+		request.setBootVersion("2.0.0.M2");
+		request.setLanguage("kotlin");
+		Dependency jacksonKotlinModuleTest = Dependency.withId(
+				"jackson-module-kotlin", "com.fasterxml.jackson.module", "jackson-module-kotlin");
+		generateMavenPom(request)
+				.hasDependency(jacksonKotlinModuleTest)
+				.hasDependenciesCount(6);
+	}
+
+	@Test
+	public void jacksonModuleKotlinIsNotAddedWithoutKotlin() {
+		ProjectRequest request = createProjectRequest("webflux");
+		request.setBootVersion("2.0.0.M2");
+		generateMavenPom(request)
+				.hasDependenciesCount(3);
+	}
+
+	@Test
+	public void jacksonModuleKotlinIsNotAddedWithoutJsonFacet() {
+		ProjectRequest request = createProjectRequest("batch");
+		request.setBootVersion("2.0.0.M2");
+		request.setLanguage("kotlin");
+		generateMavenPom(request)
+				.hasDependenciesCount(5);
+	}
+
+}


### PR DESCRIPTION
This commit introduces a "json" facet designed to identify `spring-boot-starter-json` transitive dependency, and adds `jackson-module-kotlin` dependency if any dependency with that facet is included when Kotlin language is used.