### PR TITLE
Add description to DependencyGroup - Fixes gh-285

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/metadata/DependencyGroup.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/metadata/DependencyGroup.java
@@ -26,9 +26,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  *
  * @author Stephane Nicoll
  */
-public class DependencyGroup {
+public class DependencyGroup implements Describable {
 
 	private String name;
+
+	private String description;
 
 	@JsonIgnore
 	private String versionRange;
@@ -50,6 +52,19 @@ public class DependencyGroup {
 
 	public void setName(String name) {
 		this.name = name;
+	}
+
+	/**
+	 * Return the description of this group
+	 * @return
+	 */
+	@Override
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
 	}
 
 	/**

--- a/initializr-generator/src/test/resources/application-test-default.yml
+++ b/initializr-generator/src/test/resources/application-test-default.yml
@@ -41,6 +41,7 @@ initializr:
         url: http://example.com/repo3
   dependencies:
     - name: Core
+      description: Core Dependencies
       content:
         - name: Web
           id: web
@@ -60,6 +61,7 @@ initializr:
           aliases:
             - jpa
     - name: Other
+      description: Other Dependencies
       content:
         - name: Foo
           groupId: org.acme

--- a/initializr-web/src/main/resources/static/css/spring.css
+++ b/initializr-web/src/main/resources/static/css/spring.css
@@ -85,6 +85,11 @@ input[type=text] {
     display: block;
 }
 
+.group-heading {
+    padding-left: 20px ;
+    text-indent: -20px ;
+}
+
 /* autocomplete */
 
 #autocomplete, .twitter-typeahead, .tt-hint {

--- a/initializr-web/src/main/resources/templates/home.mustache
+++ b/initializr-web/src/main/resources/templates/home.mustache
@@ -143,7 +143,9 @@ new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
                 <div id="dependencies" class="full hidden">
                     {{#dependencies.content}}
                     <div class="form-group col-sm-6">
-                        <h3>{{name}}</h3>
+                        <div class="group-heading">
+                            <h3>{{name}}<small>{{#description}} - {{.}}{{/description}}</small></h3>
+                        </div>
                         {{#content}}
                         <div class="checkbox" data-range="{{#versionRange}}{{versionRange}}{{/versionRange}}">
                             <label>

--- a/initializr-web/src/test/resources/metadata/config/test-default.json
+++ b/initializr-web/src/test/resources/metadata/config/test-default.json
@@ -173,7 +173,8 @@
             "scope": "compile"
           }
         ],
-        "name": "Core"
+        "name": "Core",
+        "description": "Core Dependencies"
       },
       {
         "content": [
@@ -243,7 +244,8 @@
             "bom": "my-api-bom"
           }
         ],
-        "name": "Other"
+        "name": "Other",
+        "description": "Other Dependencies"
       }
     ],
     "description": "dependency identifiers (comma-separated)",

--- a/initializr-web/src/test/resources/metadata/test-default-2.0.0.json
+++ b/initializr-web/src/test/resources/metadata/test-default-2.0.0.json
@@ -22,6 +22,7 @@
     "values": [
       {
         "name": "Core",
+        "description": "Core Dependencies",
         "values": [
           {
             "id": "web",
@@ -40,6 +41,7 @@
       },
       {
         "name": "Other",
+        "description": "Other Dependencies",
         "values": [
           {
             "id": "org.acme:foo",

--- a/initializr-web/src/test/resources/metadata/test-default-2.1.0.json
+++ b/initializr-web/src/test/resources/metadata/test-default-2.1.0.json
@@ -26,6 +26,7 @@
     "values": [
       {
         "name": "Core",
+        "description": "Core Dependencies",
         "values": [
           {
             "id": "web",
@@ -53,6 +54,7 @@
       },
       {
         "name": "Other",
+        "description": "Other Dependencies",
         "values": [
           {
             "id": "org.acme:foo",


### PR DESCRIPTION
Adding the enhancement in Issue #285.

In the web interface this produces:

<img width="1036" alt="screen shot 2018-02-17 at 10 05 06 am" src="https://user-images.githubusercontent.com/4583878/36342294-2ce70718-13ca-11e8-8e17-808af13350b4.png">

With an extra long description it will look like this:

<img width="1076" alt="screen shot 2018-02-17 at 10 07 41 am" src="https://user-images.githubusercontent.com/4583878/36342316-798bd4fe-13ca-11e8-99ad-e76e39d2a905.png">

Thanks!

- Lee