### PR TITLE
Upgrade to Spring Statemachine 2.0.0.M5

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -137,8 +137,8 @@ initializr:
         artifactId: spring-statemachine-bom
         versionProperty: spring-statemachine.version
         mappings:
-          - versionRange: "2.0.0.RC1"
-            version: 2.0.0.M4
+          - versionRange: "2.0.0.RC2"
+            version: 2.0.0.M5
       vaadin:
         groupId: com.vaadin
         artifactId: vaadin-bom
@@ -1267,7 +1267,7 @@ initializr:
           groupId: org.springframework.statemachine
           artifactId: spring-statemachine-starter
           description: Build applications using state machine concepts
-          versionRange: 2.0.0.RC1
+          versionRange: 2.0.0.RC2
           bom: spring-statemachine
           links:
             - rel: reference


### PR DESCRIPTION
Spring statemachine now builds with Spring Boot 2.0.0.RC2.