### PR TITLE
Upgrade to spring statemachine 2.0.0

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -119,8 +119,10 @@ initializr:
         mappings:
           - versionRange: "[2.0.0.RC1,2.0.0.RC1]"
             version: 2.0.0.M4
-          - versionRange: "2.0.0.RC2"
+          - versionRange: "[2.0.0.RC2,2.0.0.RC2]"
             version: 2.0.0.M5
+          - versionRange: "2.0.0.RELEASE"
+            version: 2.0.0.RELEASE
       vaadin:
         groupId: com.vaadin
         artifactId: vaadin-bom
@@ -1211,7 +1213,7 @@ initializr:
           groupId: org.springframework.statemachine
           artifactId: spring-statemachine-starter
           description: Build applications using state machine concepts
-          versionRange: 2.0.0.RC1
+          versionRange: 2.0.0.RELEASE
           bom: spring-statemachine
           links:
             - rel: reference


### PR DESCRIPTION
- ssm 2.0.0 is now out so update to us boot 2.0.0
- Similarly done in previous ssm 2.0.0.M5 update,
  add versionHistory.