### PR TITLE
Ignore .sts4-cache folder

### DIFF
--- a/initializr-generator/src/main/resources/templates/gitignore.tmpl
+++ b/initializr-generator/src/main/resources/templates/gitignore.tmpl
@@ -15,6 +15,7 @@ target/
 .project
 .settings
 .springBeans
+.sts4-cache
 
 ### IntelliJ IDEA ###
 .idea

--- a/initializr-generator/src/test/resources/project/gradle/gitignore.gen
+++ b/initializr-generator/src/test/resources/project/gradle/gitignore.gen
@@ -9,6 +9,7 @@
 .project
 .settings
 .springBeans
+.sts4-cache
 
 ### IntelliJ IDEA ###
 .idea

--- a/initializr-generator/src/test/resources/project/maven/gitignore.gen
+++ b/initializr-generator/src/test/resources/project/maven/gitignore.gen
@@ -8,6 +8,7 @@ target/
 .project
 .settings
 .springBeans
+.sts4-cache
 
 ### IntelliJ IDEA ###
 .idea


### PR DESCRIPTION
Ignore the new .sts4-cache folder added as part of spring tools 4.