### PR TITLE
Upgrade to Apache Camel 2.21.0

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -1173,7 +1173,7 @@ initializr:
             - versionRange: "[1.4.0.RELEASE,1.5.0.RELEASE)"
               version: 2.18.5
             - versionRange: "[1.5.0.RELEASE,2.0.0.M1)"
-              version: 2.20.2
+              version: 2.21.0
           description: Integration using Apache Camel
           groupId: org.apache.camel
           artifactId: camel-spring-boot-starter


### PR DESCRIPTION
Note this release do not support Spring Boot 2.
The next release Camel 2.22.0 will support Spring Boot 2.

Signed-off-by: Claus Ibsen <claus.ibsen@gmail.com>