### PR TITLE
Remove spring-cloud-contract-wiremock dependency

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -1030,7 +1030,7 @@ initializr:
           starter: false
         - name: Cloud Contract Stub Runner
           id: cloud-contract-stub-runner
-          description: Stub Runner for HTTP/Messaging based communication
+          description: Stub Runner for HTTP/Messaging based communication, allows creating WireMock stubs from RestDocs tests
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-contract-stub-runner
           scope: test

--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -1035,13 +1035,6 @@ initializr:
           artifactId: spring-cloud-starter-contract-stub-runner
           scope: test
           starter: false
-        - name: Cloud Contract WireMock
-          id: cloud-contract-wiremock
-          description: Test dependencies required for the WireMock HTTP server
-          groupId: org.springframework.cloud
-          artifactId: spring-cloud-contract-wiremock
-          scope: test
-          starter: false
     - name: Pivotal Cloud Foundry
       bom: spring-cloud-services
       versionRange: "[1.3.0.RELEASE,2.0.0.M1)"


### PR DESCRIPTION
The preferred way of adding `spring-cloud-contract-wiremock` is via `spring-cloud-starter-stub-runner`. It has always included that dependency, and we want to limit the number of starters.