### PR TITLE
Create a settings.gradle file for Gradle projects

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectGenerator.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectGenerator.java
@@ -59,6 +59,7 @@ import org.springframework.util.StreamUtils;
  * @author Stephane Nicoll
  * @author Sebastien Deleuze
  * @author Andy Wilkinson
+ * @author Chris Vogel
  */
 public class ProjectGenerator {
 
@@ -219,6 +220,8 @@ public class ProjectGenerator {
 		if (isGradleBuild(request)) {
 			String gradle = new String(doGenerateGradleBuild(model));
 			writeText(new File(dir, "build.gradle"), gradle);
+			String settings = new String(doGenerateGradleSettings(model));
+			writeText(new File(dir, "settings.gradle"), settings);
 			writeGradleWrapper(dir, Version.safeParse(request.getBootVersion()));
 		}
 		else {
@@ -598,6 +601,10 @@ public class ProjectGenerator {
 
 	private byte[] doGenerateGradleBuild(Map<String, Object> model) {
 		return templateRenderer.process("starter-build.gradle", model).getBytes();
+	}
+
+	private byte[] doGenerateGradleSettings(Map<String, Object> model) {
+		return templateRenderer.process("starter-settings.gradle", model).getBytes();
 	}
 
 	private void writeGradleWrapper(File dir, Version bootVersion) {

--- a/initializr-generator/src/main/resources/templates/starter-settings.gradle
+++ b/initializr-generator/src/main/resources/templates/starter-settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = '{{artifactId}}'


### PR DESCRIPTION
It would be beneficial to create a settings.gradle file for Gradle projects and add the "rootProject.name = '<artifact name>'" to it. This is the default behavior when doing a gradle init. It also provides a specified project.name when doing builds and can be used by different Gradle plugins. Fixes gh-641.