### PR TITLE
Spring Cloud Stream Kafka Streams, redux

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -727,6 +727,14 @@ initializr:
           links:
             - rel: reference
               href: http://docs.spring.io/spring-boot/docs/{bootVersion}/reference/htmlsingle/#boot-features-kafka
+        - name: Kafka Streams
+          id: kafka-streams
+          description: Stream processing with Spring Cloud Stream Kafka Streams
+          versionRange: 2.0.0.RC2
+          weight: 100
+          starter: false
+          groupId: org.springframework.cloud
+          artifactId: spring-cloud-stream-binder-kafka-streams
         - name: JMS (ActiveMQ)
           id: activemq
           description: Java Message Service API via Apache ActiveMQ
@@ -998,13 +1006,6 @@ initializr:
           weight: 90
           groupId: org.springframework.cloud
           artifactId: spring-cloud-stream-reactive
-        - name: Cloud Stream Kafka Streams
-          id: cloud-stream-kafka-streams
-          description: Stream processing with Spring Cloud Stream Kafka Streams
-          versionRange: 2.0.0.RC2
-          weight: 90
-          groupId: org.springframework.cloud
-          artifactId: spring-cloud-stream-binder-kafka-streams
     - name: Cloud AWS
       bom: spring-cloud
       versionRange: 1.2.3.RELEASE

--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -998,6 +998,13 @@ initializr:
           weight: 90
           groupId: org.springframework.cloud
           artifactId: spring-cloud-stream-reactive
+        - name: Cloud Stream Kafka Streams
+          id: cloud-stream-kafka-streams
+          description: Stream processing with Spring Cloud Stream Kafka Streams
+          versionRange: 2.0.0.RC2
+          weight: 90
+          groupId: org.springframework.cloud
+          artifactId: spring-cloud-stream-binder-kafka-streams
     - name: Cloud AWS
       bom: spring-cloud
       versionRange: 1.2.3.RELEASE


### PR DESCRIPTION
I revised the PR. It's now in a different column. 

- it works if you choose `Cloud Stream` + `Kafka Streams` 
- it also works if you choose just `Kafka Streams` since there is no fundamental library, as there is w/ Spring Kafka vs. Spring Cloud Stream Kafka. 
- it also works if you choose 'Cloud Stream' with 'Kafka Streams'. it works but it's redundant. I didn't change the `SpringCloudMessagingRequestPostProcessor` to remove the redundant `cloud-stream` because.. well you might need it when using one of the other binders. 
- it also works if you choose 'Reactive Cloud Stream' + 'Kafka Streams' since it's possible you could use that with Spring Cloud Streamm Kafka Streams. 
