### PR TITLE
Ignore `/out/` directory with Gradle

### DIFF
--- a/initializr-generator/src/main/resources/templates/gitignore.tmpl
+++ b/initializr-generator/src/main/resources/templates/gitignore.tmpl
@@ -22,6 +22,9 @@
 *.iws
 *.iml
 *.ipr
+{{^mavenBuild}}
+/out/
+{{/mavenBuild}}
 
 ### NetBeans ###
 /nbproject/private/

--- a/initializr-generator/src/test/resources/project/gradle/gitignore.gen
+++ b/initializr-generator/src/test/resources/project/gradle/gitignore.gen
@@ -16,6 +16,7 @@
 *.iws
 *.iml
 *.ipr
+/out/
 
 ### NetBeans ###
 /nbproject/private/


### PR DESCRIPTION
Following the discussion in #469 and the commit + revert of `out/` in `.gitignore`, I think the good trade-of would be to ignore `/out/` (with a leading slash like in the original PR) since current default is quite painful, IDEA team won't change the directory name + I think the root `/out/` is much safer than the risk of false positive raised by @wilkinsona with `out/` (without a leading slash). It is also consistent with what we do with `/build/`.