### PR TITLE
Upgrade to Azure Spring 2.0.3

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -34,7 +34,7 @@ initializr:
           - versionRange: "[1.5.4.RELEASE,2.0.0.RELEASE)"
             version: 0.2.3
           - versionRange: "2.0.0.RELEASE"
-            version: 2.0.1
+            version: 2.0.3
       codecentric-spring-boot-admin:
         groupId: de.codecentric
         artifactId: spring-boot-admin-dependencies


### PR DESCRIPTION
Main changes:

- Integrate Spring Security 5 with Azure Active Directory Spring Boot Starter
- Support for Azure Storage using user provided services
- Upgrade service bus java library to 1.2.5
- Upgrade spring-data-cosmosdb to latest released version 2.0.3