### PR TITLE
Upate Spring Boot Admin 2.0.1

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -43,9 +43,9 @@ initializr:
           - versionRange: "[1.5.9.RELEASE,2.0.0.M1)"
             version: 1.5.7
           - versionRange: "[2.0.0.M1,2.0.x.BUILD-SNAPSHOT)"
-            version: 2.0.0
+            version: 2.0.1
           - versionRange: "2.0.x.BUILD-SNAPSHOT"
-            version: 2.0.1-SNAPSHOT
+            version: 2.0.2-SNAPSHOT
             repositories: sonatype-snapshots
       keycloak:
         groupId: org.keycloak.bom


### PR DESCRIPTION
Updates Spring Boot Admin to 2.0.1 (and 2.0.2-SNAPHSOT)