### PR TITLE
Expose resolved version range if .x present

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/metadata/Dependency.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/metadata/Dependency.java
@@ -216,6 +216,7 @@ public class Dependency extends MetadataElement implements Describable {
 		if (this.versionRange != null) {
 			try {
 				this.range = versionParser.parseRange(this.versionRange);
+				this.versionRange = this.range.toRangeString();
 				this.versionRequirement = this.range.toString();
 			}
 			catch (InvalidVersionException ex) {

--- a/initializr-generator/src/main/java/io/spring/initializr/util/VersionRange.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/util/VersionRange.java
@@ -105,6 +105,22 @@ public class VersionRange {
 		return this.higherInclusive;
 	}
 
+	public String toRangeString() {
+		StringBuilder sb = new StringBuilder();
+		if (this.lowerVersion == null && this.higherVersion == null) {
+			return "";
+		}
+		if (this.higherVersion != null) {
+			sb.append(this.lowerInclusive ? "[" : "(").append(this.lowerVersion)
+					.append(",").append(this.higherVersion)
+					.append(this.higherInclusive ? "]" : ")");
+		}
+		else {
+			sb.append(this.lowerVersion);
+		}
+		return sb.toString();
+	}
+
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();

--- a/initializr-generator/src/test/java/io/spring/initializr/metadata/DependencyTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/metadata/DependencyTests.java
@@ -272,6 +272,25 @@ public class DependencyTests {
 				"foo", "com.acme", "bar", "0.3.0.RELEASE");
 	}
 
+	@Test
+	public void resolveVersionWithX() {
+		Dependency dependency1 = Dependency.withId("foo1", "com.acme", "foo1",
+				"0.3.0.RELEASE");
+		dependency1.setVersionRange("1.2.x.RELEASE");
+		dependency1.resolve();
+		assertThat(dependency1.getVersionRange()).isEqualTo("1.2.999.RELEASE");
+	}
+
+	@Test
+	public void resolveVersionRangeWithX() {
+		Dependency dependency = Dependency.withId("foo1", "com.acme", "foo1",
+				"0.3.0.RELEASE");
+		dependency.setVersionRange("[1.1.0.RELEASE, 1.2.x.RELEASE)");
+		dependency.resolve();
+		assertThat(dependency.getVersionRange())
+				.isEqualTo("[1.1.0.RELEASE,1.2.999.RELEASE)");
+	}
+
 	private static void validateResolvedWebDependency(Dependency dependency,
 			String expectedGroupId, String expectedArtifactId, String expectedVersion) {
 		validateResolvedDependency(dependency, "web", expectedGroupId, expectedArtifactId,

--- a/initializr-generator/src/test/java/io/spring/initializr/util/VersionRangeTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/util/VersionRangeTests.java
@@ -123,6 +123,46 @@ public class VersionRangeTests {
 						Version.parse("1.3.6.BUILD-SNAPSHOT")))));
 	}
 
+	@Test
+	public void toVersionRangeWithSimpleVersion() {
+		VersionRange range = new VersionParser(
+				Collections.singletonList(Version.parse("1.5.6.RELEASE")))
+						.parseRange("1.3.5.RELEASE");
+		assertThat(range.toRangeString()).isEqualTo("1.3.5.RELEASE");
+	}
+
+	@Test
+	public void toVersionRangeWithVersionsIncluded() {
+		VersionRange range = new VersionParser(
+				Collections.singletonList(Version.parse("1.5.6.RELEASE")))
+						.parseRange("[1.3.5.RELEASE,1.5.5.RELEASE]");
+		assertThat(range.toRangeString()).isEqualTo("[1.3.5.RELEASE,1.5.5.RELEASE]");
+	}
+
+	@Test
+	public void toVersionRangeWithLowerVersionExcluded() {
+		VersionRange range = new VersionParser(
+				Collections.singletonList(Version.parse("1.5.6.RELEASE")))
+						.parseRange("(1.3.5.RELEASE,1.5.5.RELEASE]");
+		assertThat(range.toRangeString()).isEqualTo("(1.3.5.RELEASE,1.5.5.RELEASE]");
+	}
+
+	@Test
+	public void toVersionRangeWithHigherVersionExcluded() {
+		VersionRange range = new VersionParser(
+				Collections.singletonList(Version.parse("1.5.6.RELEASE")))
+						.parseRange("[1.3.5.RELEASE,1.5.5.RELEASE)");
+		assertThat(range.toRangeString()).isEqualTo("[1.3.5.RELEASE,1.5.5.RELEASE)");
+	}
+
+	@Test
+	public void toVersionRangeWithVersionsExcluded() {
+		VersionRange range = new VersionParser(
+				Collections.singletonList(Version.parse("1.5.6.RELEASE")))
+						.parseRange("(1.3.5.RELEASE,1.5.5.RELEASE)");
+		assertThat(range.toRangeString()).isEqualTo("(1.3.5.RELEASE,1.5.5.RELEASE)");
+	}
+
 	private static Condition<String> match(String range) {
 		return match(range, new VersionParser(Collections.emptyList()));
 	}


### PR DESCRIPTION
Fixes gh-586