### PR TITLE
Updated Vaadin versions

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -163,8 +163,10 @@ initializr:
         mappings:
           - versionRange: "[1.3.0.RELEASE, 1.5.0.M1)"
             version: 7.7.7
-          - versionRange: "1.5.0.M1"
-            version: 8.4.1
+          - versionRange: "[1.5.0.M1, 2.0.0.M1)"
+            version: 8.4.4
+          - versionRange: "2.0.3.RELEASE"
+            version: 10.0.1
     gradle:
       dependency-management-plugin-version: 0.6.0.RELEASE
     kotlin:

--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -165,7 +165,7 @@ initializr:
             version: 7.7.7
           - versionRange: "[1.5.0.M1, 2.0.0.M1)"
             version: 8.4.4
-          - versionRange: "2.0.3.RELEASE"
+          - versionRange: "2.0.0.M1"
             version: 10.0.1
     gradle:
       dependency-management-plugin-version: 0.6.0.RELEASE


### PR DESCRIPTION
 * Vaadin 10 now served for latest stable versions
 * Vaadin 8 for 1.5 series (Vaadin 10 don't support Spring Boot 1.5)