### PR TITLE
upgrade to Azure Spring 0.2.4

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -32,7 +32,7 @@ initializr:
         versionProperty: azure.version
         mappings:
           - versionRange: "[1.5.4.RELEASE,2.0.0.RELEASE)"
-            version: 0.2.3
+            version: 0.2.4
           - versionRange: "2.0.0.RELEASE"
             version: 2.0.3
       codecentric-spring-boot-admin:


### PR DESCRIPTION
[0.2.4](http://search.maven.org/#artifactdetails%7Ccom.microsoft.azure%7Cazure-active-directory-spring-boot-starter%7C0.2.4%7Cjar) has been released.

The changes of 0.2.4 (for Spring Boot 1.5.x) is mainly cherry picked from 2.0.x branch(for Spring Boot 2.x).