### PR TITLE
Upgrade to Azure Spring 2.0.4

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -34,7 +34,7 @@ initializr:
           - versionRange: "[1.5.4.RELEASE,2.0.0.RELEASE)"
             version: 0.2.4
           - versionRange: "2.0.0.RELEASE"
-            version: 2.0.3
+            version: 2.0.4
       codecentric-spring-boot-admin:
         groupId: de.codecentric
         artifactId: spring-boot-admin-dependencies


### PR DESCRIPTION
A new version [2.0.4](http://repo1.maven.org/maven2/com/microsoft/azure/azure-spring-boot/2.0.4/) has been released.