### PR TITLE
The module of initializr-service has been delete.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 		<module>initializr-docs</module>
 		<module>initializr-generator</module>
 		<module>initializr-web</module>
+		<module>initializr-service</module>
 	</modules>
 
 	<dependencyManagement>


### PR DESCRIPTION
The module of initializr-service has been delete by somebody. I think should add it again. And after I modified this root pom.xml, I can install the initializr jar with the service package to ".m2". So if this is right, please merge it.