### PR TITLE
Support Dozer starter

### DIFF
--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -1332,6 +1332,18 @@ initializr:
           versionRange: "[1.3.0.RELEASE,2.0.0.M1)"
           groupId: org.springframework.boot
           artifactId: spring-boot-actuator-docs
+    - name: Utilities
+      content:
+        - name: Dozer
+          id: dozer
+          description: Java Bean to Java Bean mapper that recursively copies data from one object to another
+          links:
+            - rel: reference
+              href: https://dozermapper.github.io/gitbook/documentation/springBootIntegration.html
+          groupId: com.github.dozermapper
+          artifactId: dozer-spring-boot-starter
+          version: 6.3.0
+          versionRange: "1.4.0.RELEASE"
   types:
     - name: Maven Project
       id: maven-project


### PR DESCRIPTION
I propose support the [Dozer spring boot starter](https://dozermapper.github.io/gitbook/documentation/springBootIntegration.html).

We can use dozer more easy as follow:

```java
package com.example.dozerdemo;

import com.github.dozermapper.core.Mapper;
import org.springframework.boot.CommandLineRunner;
import org.springframework.boot.SpringApplication;
import org.springframework.boot.autoconfigure.SpringBootApplication;
import org.springframework.context.annotation.Bean;

@SpringBootApplication
public class DozerDemoApplication {

  public static void main(String[] args) {
    SpringApplication.run(DozerDemoApplication.class, args);
  }

  @Bean
  CommandLineRunner run(Mapper dozerMapper) {
    return args -> {
      Src src = new Src();
      src.a = "dozer demo";

      Dest dest = dozerMapper.map(src, Dest.class);

      System.out.println(dest.a);

    };
  }

  static class Src {
    private String a;

    public String getA() {
      return a;
    }

    public void setA(String a) {
      this.a = a;
    }
  }

  static class Dest {
    private String a;

    public String getA() {
      return a;
    }

    public void setA(String a) {
      this.a = a;
    }
  }

}
```