### PR TITLE
Use kotlin jpa in both Maven and Gradle when kotlin with Data JPA facet is selected

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectGenerator.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectGenerator.java
@@ -467,6 +467,11 @@ public class ProjectGenerator {
 		// Java versions
 		model.put("java8OrLater", isJava8OrLater(request));
 
+		// Has JPA facet
+		if (request.hasJpaFacet()) {
+			model.put("jpaFacet", true);
+		}
+
 		// Append the project request to the model
 		BeanWrapperImpl bean = new BeanWrapperImpl(request);
 		for (PropertyDescriptor descriptor : bean.getPropertyDescriptors()) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectRequest.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectRequest.java
@@ -313,6 +313,14 @@ public class ProjectRequest extends BasicProjectRequest {
 	}
 
 	/**
+	 * Specify if this request has the jpa facet enabled.
+	 * @return {@code true} if the project has the jpa facet
+	 */
+	public boolean hasJpaFacet() {
+		return hasFacet("jpa");
+	}
+
+	/**
 	 * Specify if this request has the specified facet enabled.
 	 * @param facet the facet to check
 	 * @return {@code true} if the project has the facet

--- a/initializr-generator/src/main/resources/templates/starter-build.gradle
+++ b/initializr-generator/src/main/resources/templates/starter-build.gradle
@@ -19,6 +19,9 @@ buildscript {
 		{{#kotlin}}
 		classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")
 		classpath("org.jetbrains.kotlin:kotlin-allopen:${kotlinVersion}")
+		{{#jpaFacet}}
+		classpath("org.jetbrains.kotlin:kotlin-noarg:${kotlinVersion}")
+		{{/jpaFacet}}
 		{{/kotlin}}
 	}
 }
@@ -26,6 +29,9 @@ buildscript {
 apply plugin: '{{language}}'
 {{#kotlin}}
 apply plugin: 'kotlin-spring'
+{{#jpaFacet}}
+apply plugin: 'kotlin-jpa'
+{{/jpaFacet}}
 {{/kotlin}}
 {{#war}}
 apply plugin: 'eclipse-wtp'

--- a/initializr-generator/src/main/resources/templates/starter-pom.xml
+++ b/initializr-generator/src/main/resources/templates/starter-pom.xml
@@ -195,6 +195,9 @@
 					</args>
 					<compilerPlugins>
 						<plugin>spring</plugin>
+						{{#jpaFacet}}
+						<plugin>jpa</plugin>
+						{{/jpaFacet}}
 					</compilerPlugins>
 					{{^kotlinSupport}}
 					{{#java8OrLater}}

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/ProjectGeneratorTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/ProjectGeneratorTests.java
@@ -960,4 +960,92 @@ public class ProjectGeneratorTests extends AbstractProjectGeneratorTests {
 		}
 	}
 
+	@Test
+	public void kotlinWithMavenUseJpaFacetHasJpaKotlinPlugin() {
+		Dependency jpa = Dependency.withId("data-jpa");
+		jpa.setFacets(Collections.singletonList("jpa"));
+		InitializrMetadata metadata = InitializrMetadataTestBuilder.withDefaults()
+				.addDependencyGroup("data-jpa", jpa).build();
+		applyMetadata(metadata);
+
+		ProjectRequest request = createProjectRequest("data-jpa");
+		request.setType("maven-project");
+		request.setLanguage("kotlin");
+		assertThat(generateMavenPom(request).getMavenPom())
+				.contains("<plugin>jpa</plugin>");
+	}
+
+	@Test
+	public void kotlinWithMavenWithoutJpaFacetDoesNotHaveJpaKotlinPlugin() {
+		Dependency jpa = Dependency.withId("data-jpa");
+		InitializrMetadata metadata = InitializrMetadataTestBuilder.withDefaults()
+				.addDependencyGroup("data-jpa", jpa).build();
+		applyMetadata(metadata);
+
+		ProjectRequest request = createProjectRequest("data-jpa");
+		request.setType("maven-project");
+		request.setLanguage("kotlin");
+		assertThat(generateMavenPom(request).getMavenPom())
+				.doesNotContain("<plugin>jpa</plugin>");
+	}
+
+	@Test
+	public void javaWithMavenUseJpaFacetDoesNotHaveJpaKotlinPlugin() {
+		Dependency jpa = Dependency.withId("data-jpa");
+		jpa.setFacets(Collections.singletonList("jpa"));
+		InitializrMetadata metadata = InitializrMetadataTestBuilder.withDefaults()
+				.addDependencyGroup("data-jpa", jpa).build();
+		applyMetadata(metadata);
+
+		ProjectRequest request = createProjectRequest("data-jpa");
+		request.setType("maven-project");
+		request.setLanguage("java");
+		assertThat(generateMavenPom(request).getMavenPom())
+				.doesNotContain("<plugin>jpa</plugin>");
+	}
+
+	@Test
+	public void kotlinWithGradleUseJpaFacetHasJpaKotlinPlugin() {
+		Dependency jpa = Dependency.withId("data-jpa");
+		jpa.setFacets(Collections.singletonList("jpa"));
+		InitializrMetadata metadata = InitializrMetadataTestBuilder.withDefaults()
+				.addDependencyGroup("data-jpa", jpa).build();
+		applyMetadata(metadata);
+
+		ProjectRequest request = createProjectRequest("data-jpa");
+		request.setType("gradle-project");
+		request.setLanguage("kotlin");
+		assertThat(generateGradleBuild(request).getGradleBuild())
+				.contains("apply plugin: 'kotlin-jpa'");
+	}
+
+	@Test
+	public void kotlinWithGradleWithoutJpaFacetDoesNotHaveJpaKotlinPlugin() {
+		Dependency jpa = Dependency.withId("data-jpa");
+		InitializrMetadata metadata = InitializrMetadataTestBuilder.withDefaults()
+				.addDependencyGroup("data-jpa", jpa).build();
+		applyMetadata(metadata);
+
+		ProjectRequest request = createProjectRequest("data-jpa");
+		request.setType("gradle-project");
+		request.setLanguage("kotlin");
+		assertThat(generateGradleBuild(request).getGradleBuild())
+				.doesNotContain("apply plugin: 'kotlin-jpa'");
+	}
+
+	@Test
+	public void javaWithGradleUseJpaFacetDoesNotHaveJpaKotlinPlugin() {
+		Dependency jpa = Dependency.withId("data-jpa");
+		jpa.setFacets(Collections.singletonList("jpa"));
+		InitializrMetadata metadata = InitializrMetadataTestBuilder.withDefaults()
+				.addDependencyGroup("data-jpa", jpa).build();
+		applyMetadata(metadata);
+
+		ProjectRequest request = createProjectRequest("data-jpa");
+		request.setType("gradle-project");
+		request.setLanguage("java");
+		assertThat(generateGradleBuild(request).getGradleBuild())
+				.doesNotContain("apply plugin: 'kotlin-jpa'");
+	}
+
 }

--- a/initializr-generator/src/test/java/io/spring/initializr/test/generator/PomAssert.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/test/generator/PomAssert.java
@@ -46,6 +46,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class PomAssert {
 
+	private final String content;
+
 	private final XpathEngine eng;
 
 	private final Document doc;
@@ -61,6 +63,7 @@ public class PomAssert {
 	private final Map<String, Repository> repositories = new LinkedHashMap<>();
 
 	public PomAssert(String content) {
+		this.content = content;
 		this.eng = XMLUnit.newXpathEngine();
 		Map<String, String> context = new LinkedHashMap<>();
 		context.put("pom", "http://maven.apache.org/POM/4.0.0");
@@ -296,6 +299,10 @@ public class PomAssert {
 	public PomAssert hasRepositoriesCount(int count) {
 		assertThat(this.repositories).hasSize(count);
 		return this;
+	}
+
+	public String getMavenPom() {
+		return this.content;
 	}
 
 	private PomAssert hasPluginRepository(String name) {

--- a/initializr-service/src/main/resources/application.yml
+++ b/initializr-service/src/main/resources/application.yml
@@ -483,6 +483,8 @@ initializr:
           id: data-jpa
           description: Java Persistence API including spring-data-jpa, spring-orm and Hibernate
           weight: 100
+          facets:
+            - jpa
           aliases:
             - jpa
           links:


### PR DESCRIPTION
When using JPA + kotlin, it's nice to have the kotlin jpa plugin enabled so that `@Entity` classes get a default constructor.

This PR adds this plugin to the generated project when **JPA** dependency is added for a kotlin project, both for Maven and Gradle.

Check https://kotlinlang.org/docs/reference/compiler-plugins.html#jpa-support for more information about the kotlin jpa plugin.