### PR TITLE
 Replace junit4 for junit5 when version >= 2.1.0.M4 

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectGenerator.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectGenerator.java
@@ -82,6 +82,8 @@ public class ProjectGenerator {
 
 	private static final Version VERSION_2_0_0_M6 = Version.parse("2.0.0.M6");
 
+	private static final Version Version_2_1_0_M4 = Version.parse("2.1.0.M4");
+
 	@Autowired
 	private ApplicationEventPublisher eventPublisher;
 
@@ -458,6 +460,9 @@ public class ProjectGenerator {
 		// New testing stuff
 		model.put("newTestInfrastructure", isNewTestInfrastructureAvailable(request));
 
+		// JUnit Jupiter
+		model.put("jupiterAvailable", isJupiterAvailable(request));
+
 		// Servlet Initializer
 		model.put("servletInitializrImport", new Imports(request.getLanguage())
 				.add(getServletInitializrClass(request)).toString());
@@ -548,9 +553,16 @@ public class ProjectGenerator {
 		Imports imports = new Imports(request.getLanguage());
 		Annotations testAnnotations = new Annotations();
 		boolean newTestInfrastructure = isNewTestInfrastructureAvailable(request);
+		boolean jupiterAvailable = isJupiterAvailable(request);
 		if (newTestInfrastructure) {
-			imports.add("org.springframework.boot.test.context.SpringBootTest")
-					.add("org.springframework.test.context.junit4.SpringRunner");
+			if (!jupiterAvailable) {
+				imports.add("org.springframework.boot.test.context.SpringBootTest")
+						.add("org.springframework.test.context.junit4.SpringRunner");
+			}
+			else {
+				imports.add("org.springframework.boot.test.context.SpringBootTest")
+						.add("org.junit.jupiter.api.Test");
+			}
 		}
 		else {
 			imports.add("org.springframework.boot.test.SpringApplicationConfiguration")
@@ -604,6 +616,11 @@ public class ProjectGenerator {
 
 	private static boolean isWar(ProjectRequest request) {
 		return "war".equals(request.getPackaging());
+	}
+
+	private static boolean isJupiterAvailable(ProjectRequest request) {
+		return Version_2_1_0_M4
+				.compareTo(Version.safeParse(request.getBootVersion())) <= 0;
 	}
 
 	private static boolean isNewTestInfrastructureAvailable(ProjectRequest request) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectGenerator.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/ProjectGenerator.java
@@ -555,18 +555,22 @@ public class ProjectGenerator {
 		boolean newTestInfrastructure = isNewTestInfrastructureAvailable(request);
 		boolean jupiterAvailable = isJupiterAvailable(request);
 		if (newTestInfrastructure) {
-			if (!jupiterAvailable) {
+			if (jupiterAvailable) {
 				imports.add("org.springframework.boot.test.context.SpringBootTest")
-						.add("org.springframework.test.context.junit4.SpringRunner");
+						.add("org.junit.jupiter.api.Test");
 			}
 			else {
 				imports.add("org.springframework.boot.test.context.SpringBootTest")
-						.add("org.junit.jupiter.api.Test");
+						.add("org.springframework.test.context.junit4.SpringRunner")
+						.add("org.junit.Test")
+						.add("org.junit.runner.RunWith");
 			}
 		}
 		else {
 			imports.add("org.springframework.boot.test.SpringApplicationConfiguration")
-					.add("org.springframework.test.context.junit4.SpringJUnit4ClassRunner");
+					.add("org.springframework.test.context.junit4.SpringJUnit4ClassRunner")
+					.add("org.junit.Test")
+					.add("org.junit.runner.RunWith");
 		}
 		if (request.hasWebFacet() && !newTestInfrastructure) {
 			imports.add("org.springframework.test.context.web.WebAppConfiguration");

--- a/initializr-generator/src/main/resources/templates/ApplicationTests.groovy
+++ b/initializr-generator/src/main/resources/templates/ApplicationTests.groovy
@@ -1,10 +1,14 @@
 package {{packageName}}
 
+{{^jupiterAvailable}}
 import org.junit.Test
 import org.junit.runner.RunWith
+{{/jupiterAvailable}}
 {{testImports}}
 {{#newTestInfrastructure}}
+{{^jupiterAvailable}}
 @RunWith(SpringRunner)
+{{/jupiterAvailable}}
 @SpringBootTest
 {{/newTestInfrastructure}}
 {{^newTestInfrastructure}}

--- a/initializr-generator/src/main/resources/templates/ApplicationTests.groovy
+++ b/initializr-generator/src/main/resources/templates/ApplicationTests.groovy
@@ -1,9 +1,5 @@
 package {{packageName}}
 
-{{^jupiterAvailable}}
-import org.junit.Test
-import org.junit.runner.RunWith
-{{/jupiterAvailable}}
 {{testImports}}
 {{#newTestInfrastructure}}
 {{^jupiterAvailable}}

--- a/initializr-generator/src/main/resources/templates/ApplicationTests.java
+++ b/initializr-generator/src/main/resources/templates/ApplicationTests.java
@@ -1,10 +1,14 @@
 package {{packageName}};
 
+{{^jupiterAvailable}}
 import org.junit.Test;
 import org.junit.runner.RunWith;
+{{/jupiterAvailable}}
 {{testImports}}
 {{#newTestInfrastructure}}
+{{^jupiterAvailable}}
 @RunWith(SpringRunner.class)
+{{/jupiterAvailable}}
 @SpringBootTest
 {{/newTestInfrastructure}}
 {{^newTestInfrastructure}}

--- a/initializr-generator/src/main/resources/templates/ApplicationTests.java
+++ b/initializr-generator/src/main/resources/templates/ApplicationTests.java
@@ -1,9 +1,5 @@
 package {{packageName}};
 
-{{^jupiterAvailable}}
-import org.junit.Test;
-import org.junit.runner.RunWith;
-{{/jupiterAvailable}}
 {{testImports}}
 {{#newTestInfrastructure}}
 {{^jupiterAvailable}}

--- a/initializr-generator/src/main/resources/templates/ApplicationTests.kt
+++ b/initializr-generator/src/main/resources/templates/ApplicationTests.kt
@@ -1,10 +1,14 @@
 package {{packageName}}
 
+{{^jupiterAvailable}}
 import org.junit.Test
 import org.junit.runner.RunWith
+{{/jupiterAvailable}}
 {{testImports}}
 {{#newTestInfrastructure}}
+{{^jupiterAvailable}}
 @RunWith(SpringRunner::class)
+{{/jupiterAvailable}}
 @SpringBootTest
 {{/newTestInfrastructure}}
 {{^newTestInfrastructure}}

--- a/initializr-generator/src/main/resources/templates/ApplicationTests.kt
+++ b/initializr-generator/src/main/resources/templates/ApplicationTests.kt
@@ -1,9 +1,5 @@
 package {{packageName}}
 
-{{^jupiterAvailable}}
-import org.junit.Test
-import org.junit.runner.RunWith
-{{/jupiterAvailable}}
 {{testImports}}
 {{#newTestInfrastructure}}
 {{^jupiterAvailable}}

--- a/initializr-generator/src/main/resources/templates/starter-build.gradle
+++ b/initializr-generator/src/main/resources/templates/starter-build.gradle
@@ -110,7 +110,7 @@ dependencies {
 	{{#providedDependencies}}
 	providedRuntime('{{groupId}}:{{artifactId}}{{#version}}:{{version}}{{/version}}{{#type}}@{{type}}{{/type}}')
 	{{/providedDependencies}}
-	{{gradleTestCompileConfig}}('org.springframework.boot:spring-boot-starter-test')
+	{{gradleTestCompileConfig}}('org.springframework.boot:spring-boot-starter-test'{{#jupiterAvailable}},'org.junit.jupiter:junit-jupiter-api','org.junit.jupiter:junit-jupiter-engine'{{/jupiterAvailable}})
 	{{#testDependencies}}
 	{{gradleTestCompileConfig}}('{{groupId}}:{{artifactId}}{{#version}}:{{version}}{{/version}}{{#type}}@{{type}}{{/type}}')
 	{{/testDependencies}}

--- a/initializr-generator/src/main/resources/templates/starter-pom.xml
+++ b/initializr-generator/src/main/resources/templates/starter-pom.xml
@@ -119,7 +119,18 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>{{#jupiterAvailable}}
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		{{/jupiterAvailable}}
 		{{#testDependencies}}
 		<dependency>
 			<groupId>{{groupId}}</groupId>
@@ -133,6 +144,7 @@
 			{{/type}}
 		</dependency>
 		{{/testDependencies}}
+
 	</dependencies>
 {{#hasBoms}}
 


### PR DESCRIPTION
Sam Brannen showed in his [presentation](https://youtu.be/K7g2HUhWbNE) that for springboot 2.1.0 `@ExtendWith` is not needed anymore. I discovered that spring initializer creates a junit 4 test as a default to demonstrate that the context loads.

Since the advent of junit 5 jupiter, I think we should opt to use junit 5 for the default test.

That inspired me to change the spring initializer. I've changed the following:
- maven pom, to include junit jupiter
- gradle build, to include junit jupiter
- java test, update test imports and remove `@RunWith`
- kotlin test, update test imports and remove `@RunWith`
- groovy test, update test imports and remove `@RunWith`

In the first commit I tried to change the template files as little as possible, but I think it would be better to let the imports be generated from the ProjectGenerator class. In the past it did make sense to have a part of the imports in the template files and the others in the java code, but with the advent of Spring boot 2.1.0 it is not so obvious anymore.   

I didn't saw an test to test the context loads test, so I preformed it manually. 

Please let me know if I need to change something or need to add a test to test the generated testclass.

I thought that this change is trivial one and a ticket is not needed, however if I'm mistaken, please let me know