### PR TITLE
Replace junit4 for junit5 when version >= 2.1.0.M4

### DIFF
--- a/initializr-generator/src/main/resources/templates/ApplicationTests.groovy
+++ b/initializr-generator/src/main/resources/templates/ApplicationTests.groovy
@@ -1,10 +1,10 @@
 package {{packageName}}
 
-import org.junit.Test
-import org.junit.runner.RunWith
 {{testImports}}
 {{#newTestInfrastructure}}
+{{^jupiterAvailable}}
 @RunWith(SpringRunner)
+{{/jupiterAvailable}}
 @SpringBootTest
 {{/newTestInfrastructure}}
 {{^newTestInfrastructure}}

--- a/initializr-generator/src/main/resources/templates/ApplicationTests.java
+++ b/initializr-generator/src/main/resources/templates/ApplicationTests.java
@@ -1,10 +1,10 @@
 package {{packageName}};
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
 {{testImports}}
 {{#newTestInfrastructure}}
+{{^jupiterAvailable}}
 @RunWith(SpringRunner.class)
+{{/jupiterAvailable}}
 @SpringBootTest
 {{/newTestInfrastructure}}
 {{^newTestInfrastructure}}

--- a/initializr-generator/src/main/resources/templates/ApplicationTests.kt
+++ b/initializr-generator/src/main/resources/templates/ApplicationTests.kt
@@ -1,10 +1,10 @@
 package {{packageName}}
 
-import org.junit.Test
-import org.junit.runner.RunWith
 {{testImports}}
 {{#newTestInfrastructure}}
+{{^jupiterAvailable}}
 @RunWith(SpringRunner::class)
+{{/jupiterAvailable}}
 @SpringBootTest
 {{/newTestInfrastructure}}
 {{^newTestInfrastructure}}

--- a/initializr-generator/src/main/resources/templates/starter-build.gradle
+++ b/initializr-generator/src/main/resources/templates/starter-build.gradle
@@ -110,7 +110,7 @@ dependencies {
 	{{#providedDependencies}}
 	providedRuntime('{{groupId}}:{{artifactId}}{{#version}}:{{version}}{{/version}}{{#type}}@{{type}}{{/type}}')
 	{{/providedDependencies}}
-	{{gradleTestCompileConfig}}('org.springframework.boot:spring-boot-starter-test')
+	{{gradleTestCompileConfig}}('org.springframework.boot:spring-boot-starter-test'{{#jupiterAvailable}},'org.junit.jupiter:junit-jupiter-api','org.junit.jupiter:junit-jupiter-engine'{{/jupiterAvailable}})
 	{{#testDependencies}}
 	{{gradleTestCompileConfig}}('{{groupId}}:{{artifactId}}{{#version}}:{{version}}{{/version}}{{#type}}@{{type}}{{/type}}')
 	{{/testDependencies}}

--- a/initializr-generator/src/main/resources/templates/starter-pom.xml
+++ b/initializr-generator/src/main/resources/templates/starter-pom.xml
@@ -119,7 +119,18 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>{{#jupiterAvailable}}
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		{{/jupiterAvailable}}
 		{{#testDependencies}}
 		<dependency>
 			<groupId>{{groupId}}</groupId>
@@ -133,6 +144,7 @@
 			{{/type}}
 		</dependency>
 		{{/testDependencies}}
+
 	</dependencies>
 {{#hasBoms}}
 

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/ProjectGeneratorLanguageTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/ProjectGeneratorLanguageTests.java
@@ -180,4 +180,18 @@ public class ProjectGeneratorLanguageTests extends AbstractProjectGeneratorTests
 						+ this.expectedExtension));
 	}
 
+	@Test
+	public void springBoot21M4TestClass() {
+		ProjectRequest request = createProjectRequest();
+		request.setLanguage(this.language);
+		request.setBootVersion("2.1.0.M4");
+
+		ProjectAssert project = generateProject(request);
+		project.sourceCodeAssert("src/test/" + this.language
+				+ "/com/example/demo/DemoApplicationTests." + this.extension)
+				.equalsTo(new ClassPathResource("project/" + this.language
+						+ "/spring-boot-2.1/DemoApplicationTests."
+						+ this.expectedExtension));
+	}
+
 }

--- a/initializr-generator/src/test/resources/project/groovy/spring-boot-2.1/DemoApplicationTests.groovy.gen
+++ b/initializr-generator/src/test/resources/project/groovy/spring-boot-2.1/DemoApplicationTests.groovy.gen
@@ -1,0 +1,13 @@
+package com.example.demo
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class DemoApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/initializr-generator/src/test/resources/project/java/spring-boot-2.1/DemoApplicationTests.java.gen
+++ b/initializr-generator/src/test/resources/project/java/spring-boot-2.1/DemoApplicationTests.java.gen
@@ -1,0 +1,13 @@
+package com.example.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class DemoApplicationTests {
+
+	@Test
+	public void contextLoads() {
+	}
+
+}

--- a/initializr-generator/src/test/resources/project/kotlin/spring-boot-2.1/DemoApplicationTests.kt.gen
+++ b/initializr-generator/src/test/resources/project/kotlin/spring-boot-2.1/DemoApplicationTests.kt.gen
@@ -1,0 +1,13 @@
+package com.example.demo
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class DemoApplicationTests {
+
+	@Test
+	fun contextLoads() {
+	}
+
+}


### PR DESCRIPTION
Sam Brannen showed in his [presentation](https://youtu.be/K7g2HUhWbNE) that for springboot 2.1.0 `@ExtendWith` is not needed anymore. I discovered that spring initializer creates a junit 4 test as a default to demonstrate that the context loads.

Since the advent of junit 5 jupiter, I think we should opt to use junit 5 for the default test.

That inspired me to change the spring initializer. I've changed the following:
- maven pom, to include junit jupiter
- gradle build, to include junit jupiter
- java test, update test imports and remove `@RunWith`
- kotlin test, update test imports and remove `@RunWith`
- groovy test, update test imports and remove `@RunWith`

In the first commit I tried to change the template files as little as possible, but I think it would be better to let the imports be generated from the ProjectGenerator class. In the past it did make sense to have a part of the imports in the template files and the others in the java code, but with the advent of Spring boot 2.1.0 it is not so obvious anymore. 

I've also added a test to make sure that the test is generated correctly.

I thought that this change is trivial one and a ticket is not needed, however if I'm mistaken, please let me know