### PR TITLE
Add Gradle Kotlin DSL support

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/BuildProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/BuildProjectGenerationConfiguration.java
@@ -19,6 +19,7 @@ package io.spring.initializr.generator.spring.build;
 import io.spring.initializr.generator.buildsystem.Build;
 import io.spring.initializr.generator.buildsystem.DependencyScope;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
+import io.spring.initializr.generator.buildsystem.gradle.GradleKtsBuildSystem;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
 import io.spring.initializr.generator.condition.ConditionalOnBuildSystem;
 import io.spring.initializr.generator.condition.ConditionalOnLanguage;
@@ -39,6 +40,7 @@ import org.springframework.context.annotation.Bean;
  * Project generation configuration for projects using any build system.
  *
  * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
  */
 @ProjectGenerationConfiguration
 public class BuildProjectGenerationConfiguration {
@@ -70,7 +72,7 @@ public class BuildProjectGenerationConfiguration {
 
 	@Bean
 	@ConditionalOnLanguage(KotlinLanguage.ID)
-	@ConditionalOnBuildSystem(GradleBuildSystem.ID)
+	@ConditionalOnBuildSystem({ GradleBuildSystem.ID, GradleKtsBuildSystem.ID })
 	public KotlinJpaGradleBuildCustomizer kotlinJpaGradleBuildCustomizer(
 			InitializrMetadata metadata, KotlinProjectSettings settings) {
 		return new KotlinJpaGradleBuildCustomizer(metadata, settings);

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleBuildProjectContributor.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleBuildProjectContributor.java
@@ -29,11 +29,14 @@ import io.spring.initializr.generator.project.contributor.ProjectContributor;
 import io.spring.initializr.generator.spring.build.BuildWriter;
 
 /**
- * {@link ProjectContributor} for the project's {@code build.gradle} file.
+ * {@link ProjectContributor} template for the project's {@code build.gradle} or
+ * {@code build.gradle.kts} file. A subclass exists for each DSL.
  *
  * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
  */
-public class GradleBuildProjectContributor implements BuildWriter, ProjectContributor {
+public abstract class GradleBuildProjectContributor
+		implements BuildWriter, ProjectContributor {
 
 	private final GradleBuildWriter buildWriter;
 
@@ -41,21 +44,25 @@ public class GradleBuildProjectContributor implements BuildWriter, ProjectContri
 
 	private final IndentingWriterFactory indentingWriterFactory;
 
-	GradleBuildProjectContributor(GradleBuildWriter buildWriter, GradleBuild build,
-			IndentingWriterFactory indentingWriterFactory) {
+	private final String buildFileName;
+
+	protected GradleBuildProjectContributor(GradleBuildWriter buildWriter,
+			GradleBuild build, IndentingWriterFactory indentingWriterFactory,
+			String buildFileName) {
 		this.buildWriter = buildWriter;
 		this.build = build;
 		this.indentingWriterFactory = indentingWriterFactory;
+		this.buildFileName = buildFileName;
 	}
 
 	@Override
-	public void contribute(Path projectRoot) throws IOException {
-		Path buildGradle = Files.createFile(projectRoot.resolve("build.gradle"));
+	public final void contribute(Path projectRoot) throws IOException {
+		Path buildGradle = Files.createFile(projectRoot.resolve(this.buildFileName));
 		writeBuild(Files.newBufferedWriter(buildGradle));
 	}
 
 	@Override
-	public void writeBuild(Writer out) throws IOException {
+	public final void writeBuild(Writer out) throws IOException {
 		try (IndentingWriter writer = this.indentingWriterFactory
 				.createIndentingWriter("gradle", out)) {
 			this.buildWriter.writeTo(writer, this.build);

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfiguration.java
@@ -23,7 +23,9 @@ import io.spring.initializr.generator.buildsystem.BuildItemResolver;
 import io.spring.initializr.generator.buildsystem.gradle.Gradle3BuildWriter;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
-import io.spring.initializr.generator.buildsystem.gradle.GradleBuildWriter;
+import io.spring.initializr.generator.buildsystem.gradle.GradleKtsBuildSystem;
+import io.spring.initializr.generator.buildsystem.gradle.GroovyDslGradleBuildWriter;
+import io.spring.initializr.generator.buildsystem.gradle.KotlinDslGradleBuildWriter;
 import io.spring.initializr.generator.condition.ConditionalOnBuildSystem;
 import io.spring.initializr.generator.condition.ConditionalOnLanguage;
 import io.spring.initializr.generator.condition.ConditionalOnPackaging;
@@ -35,6 +37,7 @@ import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
 import io.spring.initializr.generator.project.ResolvedProjectDescription;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 import io.spring.initializr.generator.spring.util.LambdaSafe;
+import io.spring.initializr.metadata.InitializrMetadata;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
@@ -45,9 +48,10 @@ import org.springframework.context.annotation.Configuration;
  * Gradle as its build system.
  *
  * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
  */
 @ProjectGenerationConfiguration
-@ConditionalOnBuildSystem(GradleBuildSystem.ID)
+@ConditionalOnBuildSystem({ GradleBuildSystem.ID, GradleKtsBuildSystem.ID })
 public class GradleProjectGenerationConfiguration {
 
 	private final IndentingWriterFactory indentingWriterFactory;
@@ -100,14 +104,24 @@ public class GradleProjectGenerationConfiguration {
 
 	@Bean
 	@ConditionalOnPlatformVersion("2.0.0.M1")
+	@ConditionalOnBuildSystem(GradleBuildSystem.ID)
 	public BuildCustomizer<GradleBuild> applyDependencyManagementPluginContributor() {
 		return (build) -> build.applyPlugin("io.spring.dependency-management");
 	}
 
 	@Bean
+	@ConditionalOnBuildSystem(GradleBuildSystem.ID)
 	public GradleBuildProjectContributor gradleBuildProjectContributor(
-			GradleBuildWriter buildWriter, GradleBuild build) {
-		return new GradleBuildProjectContributor(buildWriter, build,
+			GroovyDslGradleBuildWriter buildWriter, GradleBuild build) {
+		return new GroovyDslGradleBuildProjectContributor(buildWriter, build,
+				this.indentingWriterFactory);
+	}
+
+	@Bean
+	@ConditionalOnBuildSystem(GradleKtsBuildSystem.ID)
+	public KotlinDslGradleBuildProjectContributor gradleKtsBuildProjectContributor(
+			KotlinDslGradleBuildWriter buildWriter, GradleBuild build) {
+		return new KotlinDslGradleBuildProjectContributor(buildWriter, build,
 				this.indentingWriterFactory);
 	}
 
@@ -116,6 +130,7 @@ public class GradleProjectGenerationConfiguration {
 	 */
 	@Configuration
 	@ConditionalOnGradleVersion("3")
+	@ConditionalOnBuildSystem(GradleBuildSystem.ID)
 	static class Gradle3ProjectGenerationConfiguration {
 
 		@Bean
@@ -152,6 +167,7 @@ public class GradleProjectGenerationConfiguration {
 	 */
 	@Configuration
 	@ConditionalOnGradleVersion("4")
+	@ConditionalOnBuildSystem(GradleBuildSystem.ID)
 	static class Gradle4ProjectGenerationConfiguration {
 
 		@Bean
@@ -176,21 +192,23 @@ public class GradleProjectGenerationConfiguration {
 	}
 
 	/**
-	 * Configuration specific to projects using Gradle 4 or 5.
+	 * Configuration specific to projects using Gradle (Groovy DSL) 4 or 5.
 	 */
 	@Configuration
+	@ConditionalOnBuildSystem(GradleBuildSystem.ID)
 	@ConditionalOnGradleVersion({ "4", "5" })
 	static class Gradle4Or5ProjectGenerationConfiguration {
 
 		@Bean
-		public GradleBuildWriter gradleBuildWriter() {
-			return new GradleBuildWriter();
+		public GroovyDslGradleBuildWriter gradleBuildWriter() {
+			return new GroovyDslGradleBuildWriter();
 		}
 
 		@Bean
 		public SettingsGradleProjectContributor settingsGradleProjectContributor(
 				GradleBuild build, IndentingWriterFactory indentingWriterFactory) {
-			return new SettingsGradleProjectContributor(build, indentingWriterFactory);
+			return new GroovyDslSettingsGradleProjectContributor(build,
+					indentingWriterFactory);
 		}
 
 		@Bean
@@ -198,6 +216,40 @@ public class GradleProjectGenerationConfiguration {
 				ResolvedProjectDescription projectDescription) {
 			return (build) -> build.addPlugin("org.springframework.boot",
 					projectDescription.getPlatformVersion().toString());
+		}
+
+	}
+
+	/**
+	 * Configuration specific to projects using Gradle (Kotlin DSL).
+	 */
+	@Configuration
+	@ConditionalOnBuildSystem(GradleKtsBuildSystem.ID)
+	static class GradleKtsProjectGenerationConfiguration {
+
+		@Bean
+		public KotlinDslGradleBuildWriter gradleKtsBuildWriter() {
+			return new KotlinDslGradleBuildWriter();
+		}
+
+		@Bean
+		public KotlinDslSettingsGradleProjectContributor settingsGradleKtsProjectContributor(
+				GradleBuild build, IndentingWriterFactory indentingWriterFactory) {
+			return new KotlinDslSettingsGradleProjectContributor(build,
+					indentingWriterFactory);
+		}
+
+		@Bean
+		public BuildCustomizer<GradleBuild> springBootPluginContributor(
+				ResolvedProjectDescription projectDescription,
+				InitializrMetadata metadata) {
+			return (build) -> {
+				build.addPlugin("org.springframework.boot",
+						projectDescription.getPlatformVersion().toString());
+				build.addPlugin("io.spring.dependency-management",
+						metadata.getConfiguration().getEnv().getGradle()
+								.getDependencyManagementPluginVersion());
+			};
 		}
 
 	}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GroovyDslGradleBuildProjectContributor.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GroovyDslGradleBuildProjectContributor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.build.gradle;
+
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.buildsystem.gradle.GroovyDslGradleBuildWriter;
+import io.spring.initializr.generator.io.IndentingWriterFactory;
+import io.spring.initializr.generator.project.contributor.ProjectContributor;
+
+/**
+ * {@link ProjectContributor} for the project's {@code build.gradle} file.
+ *
+ * @author Jean-Baptiste Nizet
+ */
+public class GroovyDslGradleBuildProjectContributor
+		extends GradleBuildProjectContributor {
+
+	GroovyDslGradleBuildProjectContributor(GroovyDslGradleBuildWriter buildWriter,
+			GradleBuild build, IndentingWriterFactory indentingWriterFactory) {
+		super(buildWriter, build, indentingWriterFactory, "build.gradle");
+	}
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GroovyDslSettingsGradleProjectContributor.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GroovyDslSettingsGradleProjectContributor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.build.gradle;
+
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.buildsystem.gradle.GroovyDslGradleSettingsWriter;
+import io.spring.initializr.generator.io.IndentingWriterFactory;
+import io.spring.initializr.generator.project.contributor.ProjectContributor;
+
+/**
+ * {@link ProjectContributor} for the project's {@code settings.gradle} file.
+ *
+ * @author Jean-Baptiste Nizet
+ */
+class GroovyDslSettingsGradleProjectContributor extends SettingsGradleProjectContributor {
+
+	GroovyDslSettingsGradleProjectContributor(GradleBuild build,
+			IndentingWriterFactory indentingWriterFactory) {
+		super(build, indentingWriterFactory, new GroovyDslGradleSettingsWriter(),
+				"settings.gradle");
+	}
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/KotlinDslGradleBuildProjectContributor.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/KotlinDslGradleBuildProjectContributor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.build.gradle;
+
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.buildsystem.gradle.KotlinDslGradleBuildWriter;
+import io.spring.initializr.generator.io.IndentingWriterFactory;
+import io.spring.initializr.generator.project.contributor.ProjectContributor;
+
+/**
+ * {@link ProjectContributor} for the project's {@code build.gradle.kts} file.
+ *
+ * @author Jean-Baptiste Nizet
+ */
+public class KotlinDslGradleBuildProjectContributor
+		extends GradleBuildProjectContributor {
+
+	KotlinDslGradleBuildProjectContributor(KotlinDslGradleBuildWriter buildWriter,
+			GradleBuild build, IndentingWriterFactory indentingWriterFactory) {
+		super(buildWriter, build, indentingWriterFactory, "build.gradle.kts");
+	}
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/KotlinDslSettingsGradleProjectContributor.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/KotlinDslSettingsGradleProjectContributor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.build.gradle;
+
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.buildsystem.gradle.KotlinDslGradleSettingsWriter;
+import io.spring.initializr.generator.io.IndentingWriterFactory;
+import io.spring.initializr.generator.project.contributor.ProjectContributor;
+
+/**
+ * {@link ProjectContributor} for the project's {@code settings.gradle.kts} file.
+ *
+ * @author Jean-Baptiste Nizet
+ */
+class KotlinDslSettingsGradleProjectContributor extends SettingsGradleProjectContributor {
+
+	KotlinDslSettingsGradleProjectContributor(GradleBuild build,
+			IndentingWriterFactory indentingWriterFactory) {
+		super(build, indentingWriterFactory, new KotlinDslGradleSettingsWriter(),
+				"settings.gradle.kts");
+	}
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/SettingsGradleProjectContributor.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/SettingsGradleProjectContributor.java
@@ -27,11 +27,13 @@ import io.spring.initializr.generator.io.IndentingWriterFactory;
 import io.spring.initializr.generator.project.contributor.ProjectContributor;
 
 /**
- * {@link ProjectContributor} for the project's {@code settings.gradle} file.
+ * {@link ProjectContributor} for the project's {@code settings.gradle}
+ * {@code settings.gradle.kts} or file. A subclass exists for each of the DSLs.
  *
  * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
  */
-class SettingsGradleProjectContributor implements ProjectContributor {
+abstract class SettingsGradleProjectContributor implements ProjectContributor {
 
 	private final GradleBuild build;
 
@@ -39,16 +41,21 @@ class SettingsGradleProjectContributor implements ProjectContributor {
 
 	private final GradleSettingsWriter settingsWriter;
 
-	SettingsGradleProjectContributor(GradleBuild build,
-			IndentingWriterFactory indentingWriterFactory) {
+	private final String settingsFileName;
+
+	protected SettingsGradleProjectContributor(GradleBuild build,
+			IndentingWriterFactory indentingWriterFactory,
+			GradleSettingsWriter settingsWriter, String settingsFileName) {
 		this.build = build;
 		this.indentingWriterFactory = indentingWriterFactory;
-		this.settingsWriter = new GradleSettingsWriter();
+		this.settingsWriter = settingsWriter;
+		this.settingsFileName = settingsFileName;
 	}
 
 	@Override
-	public void contribute(Path projectRoot) throws IOException {
-		Path settingsGradle = Files.createFile(projectRoot.resolve("settings.gradle"));
+	public final void contribute(Path projectRoot) throws IOException {
+		Path settingsGradle = Files
+				.createFile(projectRoot.resolve(this.settingsFileName));
 		try (IndentingWriter writer = this.indentingWriterFactory.createIndentingWriter(
 				"gradle", Files.newBufferedWriter(settingsGradle))) {
 			this.settingsWriter.writeTo(writer, this.build);

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/groovy/GroovyProjectGenerationDefaultContributorsConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/groovy/GroovyProjectGenerationDefaultContributorsConfiguration.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Modifier;
 
 import io.spring.initializr.generator.buildsystem.Build;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
+import io.spring.initializr.generator.buildsystem.gradle.GradleKtsBuildSystem;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
 import io.spring.initializr.generator.condition.ConditionalOnBuildSystem;
 import io.spring.initializr.generator.condition.ConditionalOnPackaging;
@@ -44,6 +45,7 @@ import org.springframework.context.annotation.Configuration;
  * Default Groovy language contributors.
  *
  * @author Stephane Nicoll
+ * @author Jean-Baptiste Nizet
  */
 @Configuration
 class GroovyProjectGenerationDefaultContributorsConfiguration {
@@ -121,7 +123,7 @@ class GroovyProjectGenerationDefaultContributorsConfiguration {
 	 * Configuration for Groovy projects built with Gradle.
 	 */
 	@Configuration
-	@ConditionalOnBuildSystem(GradleBuildSystem.ID)
+	@ConditionalOnBuildSystem({ GradleBuildSystem.ID, GradleKtsBuildSystem.ID })
 	static class GroovyGradleProjectConfiguration {
 
 		@Bean

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/GroovyDslKotlinGradleBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/GroovyDslKotlinGradleBuildCustomizer.java
@@ -16,33 +16,30 @@
 
 package io.spring.initializr.generator.spring.code.kotlin;
 
-import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import java.util.stream.Collectors;
+
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild.TaskCustomization;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 
 /**
- * {@link BuildCustomizer} template for Kotlin projects build with Gradle. A subclass
- * exists for each DSL.
+ * {@link BuildCustomizer} for Kotlin projects build with Gradle (Groovy DSL).
  *
- * @author Andy Wilkinson
  * @author Jean-Baptiste Nizet
  */
-abstract class KotlinGradleBuildCustomizer implements BuildCustomizer<GradleBuild> {
+class GroovyDslKotlinGradleBuildCustomizer extends KotlinGradleBuildCustomizer {
 
-	protected final KotlinProjectSettings settings;
-
-	KotlinGradleBuildCustomizer(KotlinProjectSettings kotlinProjectSettings) {
-		this.settings = kotlinProjectSettings;
+	GroovyDslKotlinGradleBuildCustomizer(KotlinProjectSettings kotlinProjectSettings) {
+		super(kotlinProjectSettings);
 	}
 
 	@Override
-	public final void customize(GradleBuild build) {
-		build.addPlugin("org.jetbrains.kotlin.jvm", this.settings.getVersion());
-		build.addPlugin("org.jetbrains.kotlin.plugin.spring", this.settings.getVersion());
-		build.addImportedType("org.jetbrains.kotlin.gradle.tasks.KotlinCompile");
-		build.customizeTasksWithType("KotlinCompile", this::customizeKotlinOptions);
+	protected void customizeKotlinOptions(TaskCustomization compile) {
+		compile.nested("kotlinOptions", (kotlinOptions) -> {
+			String compilerArgs = this.settings.getCompilerArgs().stream()
+					.map((arg) -> "'" + arg + "'").collect(Collectors.joining(", "));
+			kotlinOptions.set("freeCompilerArgs", "[" + compilerArgs + "]");
+			kotlinOptions.set("jvmTarget", "'" + this.settings.getJvmTarget() + "'");
+		});
 	}
-
-	protected abstract void customizeKotlinOptions(TaskCustomization compile);
 
 }

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinDslKotlinGradleBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinDslKotlinGradleBuildCustomizer.java
@@ -16,33 +16,30 @@
 
 package io.spring.initializr.generator.spring.code.kotlin;
 
-import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import java.util.stream.Collectors;
+
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild.TaskCustomization;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 
 /**
- * {@link BuildCustomizer} template for Kotlin projects build with Gradle. A subclass
- * exists for each DSL.
+ * {@link BuildCustomizer} for Kotlin projects build with Gradle (Kotlin DSL).
  *
- * @author Andy Wilkinson
  * @author Jean-Baptiste Nizet
  */
-abstract class KotlinGradleBuildCustomizer implements BuildCustomizer<GradleBuild> {
+class KotlinDslKotlinGradleBuildCustomizer extends KotlinGradleBuildCustomizer {
 
-	protected final KotlinProjectSettings settings;
-
-	KotlinGradleBuildCustomizer(KotlinProjectSettings kotlinProjectSettings) {
-		this.settings = kotlinProjectSettings;
+	KotlinDslKotlinGradleBuildCustomizer(KotlinProjectSettings kotlinProjectSettings) {
+		super(kotlinProjectSettings);
 	}
 
 	@Override
-	public final void customize(GradleBuild build) {
-		build.addPlugin("org.jetbrains.kotlin.jvm", this.settings.getVersion());
-		build.addPlugin("org.jetbrains.kotlin.plugin.spring", this.settings.getVersion());
-		build.addImportedType("org.jetbrains.kotlin.gradle.tasks.KotlinCompile");
-		build.customizeTasksWithType("KotlinCompile", this::customizeKotlinOptions);
+	protected void customizeKotlinOptions(TaskCustomization compile) {
+		compile.nested("kotlinOptions", (kotlinOptions) -> {
+			String compilerArgs = this.settings.getCompilerArgs().stream()
+					.map((arg) -> "\"" + arg + "\"").collect(Collectors.joining(", "));
+			kotlinOptions.set("freeCompilerArgs", "listOf(" + compilerArgs + ")");
+			kotlinOptions.set("jvmTarget", "\"" + this.settings.getJvmTarget() + "\"");
+		});
 	}
-
-	protected abstract void customizeKotlinOptions(TaskCustomization compile);
 
 }

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinGradleBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinGradleBuildCustomizer.java
@@ -26,6 +26,7 @@ import io.spring.initializr.generator.spring.build.BuildCustomizer;
  * {@link BuildCustomizer} for Kotlin projects build with Gradle.
  *
  * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
  */
 class KotlinGradleBuildCustomizer implements BuildCustomizer<GradleBuild> {
 
@@ -39,8 +40,8 @@ class KotlinGradleBuildCustomizer implements BuildCustomizer<GradleBuild> {
 	public void customize(GradleBuild build) {
 		build.addPlugin("org.jetbrains.kotlin.jvm", this.settings.getVersion());
 		build.addPlugin("org.jetbrains.kotlin.plugin.spring", this.settings.getVersion());
-		build.customizeTask("compileKotlin", this::customizeKotlinOptions);
-		build.customizeTask("compileTestKotlin", this::customizeKotlinOptions);
+		build.addImportedType("org.jetbrains.kotlin.gradle.tasks.KotlinCompile");
+		build.customizeTasksWithType("KotlinCompile", this::customizeKotlinOptions);
 	}
 
 	private void customizeKotlinOptions(TaskCustomization compile) {

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinProjectGenerationDefaultContributorsConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinProjectGenerationDefaultContributorsConfiguration.java
@@ -18,6 +18,7 @@ package io.spring.initializr.generator.spring.code.kotlin;
 
 import io.spring.initializr.generator.buildsystem.Build;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
+import io.spring.initializr.generator.buildsystem.gradle.GradleKtsBuildSystem;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
 import io.spring.initializr.generator.condition.ConditionalOnBuildSystem;
 import io.spring.initializr.generator.condition.ConditionalOnPackaging;
@@ -47,6 +48,7 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author Jean-Baptiste Nizet
  */
 @Configuration
 class KotlinProjectGenerationDefaultContributorsConfiguration {
@@ -155,7 +157,7 @@ class KotlinProjectGenerationDefaultContributorsConfiguration {
 	}
 
 	/**
-	 * Configuration for Kotlin projects built with Gradle.
+	 * Configuration for Kotlin projects built with Gradle (Groovy DSL).
 	 *
 	 * @author Andy Wilkinson
 	 */
@@ -166,7 +168,24 @@ class KotlinProjectGenerationDefaultContributorsConfiguration {
 		@Bean
 		public KotlinGradleBuildCustomizer kotlinBuildCustomizer(
 				KotlinProjectSettings kotlinProjectSettings) {
-			return new KotlinGradleBuildCustomizer(kotlinProjectSettings);
+			return new GroovyDslKotlinGradleBuildCustomizer(kotlinProjectSettings);
+		}
+
+	}
+
+	/**
+	 * Configuration for Kotlin projects built with Gradle (Kotlin DSL).
+	 *
+	 * @author Jean-Baptiste Nizet
+	 */
+	@Configuration
+	@ConditionalOnBuildSystem(GradleKtsBuildSystem.ID)
+	static class KotlinGradleKtsProjectConfiguration {
+
+		@Bean
+		public KotlinDslKotlinGradleBuildCustomizer kotlinBuildCustomizer(
+				KotlinProjectSettings kotlinProjectSettings) {
+			return new KotlinDslKotlinGradleBuildCustomizer(kotlinProjectSettings);
 		}
 
 	}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/scm/git/GitProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/scm/git/GitProjectGenerationConfiguration.java
@@ -17,6 +17,7 @@
 package io.spring.initializr.generator.spring.scm.git;
 
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
+import io.spring.initializr.generator.buildsystem.gradle.GradleKtsBuildSystem;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
 import io.spring.initializr.generator.condition.ConditionalOnBuildSystem;
 import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
@@ -56,7 +57,7 @@ public class GitProjectGenerationConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnBuildSystem(GradleBuildSystem.ID)
+	@ConditionalOnBuildSystem({ GradleBuildSystem.ID, GradleKtsBuildSystem.ID })
 	public GitIgnoreCustomizer gradleGitIgnoreCustomizer() {
 		return (gitIgnore) -> {
 			gitIgnore.getGeneral().add(".gradle", "/build/",

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/BuildComplianceTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/BuildComplianceTests.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import io.spring.initializr.generator.buildsystem.BuildSystem;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
+import io.spring.initializr.generator.buildsystem.gradle.GradleKtsBuildSystem;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
 import io.spring.initializr.generator.language.Language;
 import io.spring.initializr.generator.language.groovy.GroovyLanguage;
@@ -44,6 +45,7 @@ import org.springframework.core.io.ClassPathResource;
  * Build compliance tests.
  *
  * @author Stephane Nicoll
+ * @author Jean-Baptiste Nizet
  */
 class BuildComplianceTests extends AbstractComplianceTests {
 
@@ -53,11 +55,17 @@ class BuildComplianceTests extends AbstractComplianceTests {
 
 	private static final Language kotlin = new KotlinLanguage();
 
-	static Stream<Arguments> parameters() {
+	static Stream<Arguments> previousGenerationParameters() {
 		return Stream.of(
 				Arguments.arguments(BuildSystem.forId(MavenBuildSystem.ID), "pom.xml"),
 				Arguments.arguments(BuildSystem.forId(GradleBuildSystem.ID),
 						"build.gradle"));
+	}
+
+	static Stream<Arguments> parameters() {
+		return Stream.concat(previousGenerationParameters(),
+				Stream.of(Arguments.arguments(BuildSystem.forId(GradleKtsBuildSystem.ID),
+						"build.gradle.kts")));
 	}
 
 	@ParameterizedTest
@@ -116,19 +124,19 @@ class BuildComplianceTests extends AbstractComplianceTests {
 	}
 
 	@ParameterizedTest
-	@MethodSource("parameters")
+	@MethodSource("previousGenerationParameters")
 	void previousGenerationJarJava(BuildSystem build, String fileName) {
 		testPreviousGenerationJar(java, build, fileName);
 	}
 
 	@ParameterizedTest
-	@MethodSource("parameters")
+	@MethodSource("previousGenerationParameters")
 	void previousGenerationJarGroovy(BuildSystem build, String fileName) {
 		testPreviousGenerationJar(groovy, build, fileName);
 	}
 
 	@ParameterizedTest
-	@MethodSource("parameters")
+	@MethodSource("previousGenerationParameters")
 	void previousGenerationJarKotlin(BuildSystem build, String fileName) {
 		testPreviousGenerationJar(kotlin, build, fileName);
 	}

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleKtsProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleKtsProjectGenerationConfigurationTests.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 
 import io.spring.initializr.generator.buildsystem.Dependency;
 import io.spring.initializr.generator.buildsystem.DependencyScope;
-import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
+import io.spring.initializr.generator.buildsystem.gradle.GradleKtsBuildSystem;
 import io.spring.initializr.generator.language.java.JavaLanguage;
 import io.spring.initializr.generator.packaging.war.WarPackaging;
 import io.spring.initializr.generator.project.ProjectDescription;
@@ -50,12 +50,11 @@ import org.springframework.util.StreamUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link GradleProjectGenerationConfiguration} with Groovy DSL build system.
+ * Tests for {@link GradleProjectGenerationConfiguration} with Kotlin DSL build system.
  *
- * @author Stephane Nicoll
  * @author Jean-Baptiste Nizet
  */
-class GradleProjectGenerationConfigurationTests {
+class GradleKtsProjectGenerationConfigurationTests {
 
 	private ProjectAssetTester projectTester;
 
@@ -68,13 +67,12 @@ class GradleProjectGenerationConfigurationTests {
 				.withBean(InitializrMetadata.class,
 						() -> InitializrMetadataTestBuilder.withDefaults().build())
 				.withDescriptionCustomizer((description) -> description
-						.setBuildSystem(new GradleBuildSystem()));
+						.setBuildSystem(new GradleKtsBuildSystem()));
 	}
 
 	static Stream<Arguments> supportedPlatformVersions() {
-		return Stream.of(Arguments.arguments("1.5.17.RELEASE"),
-				Arguments.arguments("2.0.6.RELEASE"),
-				Arguments.arguments("2.1.3.RELEASE"));
+		// previous versions use gradle < 5, where Kotlin DSL is not supported
+		return Stream.of(Arguments.arguments("2.1.3.RELEASE"));
 	}
 
 	@ParameterizedTest(name = "Spring Boot {0}")
@@ -85,20 +83,17 @@ class GradleProjectGenerationConfigurationTests {
 		description.setLanguage(new JavaLanguage());
 		BuildWriter buildWriter = this.projectTester.generate(description,
 				(context) -> context.getBean(BuildWriter.class));
-		assertThat(buildWriter).isInstanceOf(GradleBuildProjectContributor.class);
 		assertThat(buildWriter)
-				.isNotInstanceOf(KotlinDslGradleBuildProjectContributor.class);
+				.isInstanceOf(KotlinDslGradleBuildProjectContributor.class);
 	}
 
 	static Stream<Arguments> gradleWrapperParameters() {
-		return Stream.of(Arguments.arguments("1.5.17.RELEASE", "3.5.1"),
-				Arguments.arguments("2.0.6.RELEASE", "4.10.2"),
-				Arguments.arguments("2.1.3.RELEASE", "5.2.1"));
+		return Stream.of(Arguments.arguments("2.1.3.RELEASE", "5.2.1"));
 	}
 
 	@ParameterizedTest(name = "Spring Boot {0}")
 	@MethodSource("gradleWrapperParameters")
-	void gradleWrapperIsContributedWhenGeneratingGradleProject(String platformVersion,
+	void gradleWrapperIsContributedWhenGeneratingGradleKtsProject(String platformVersion,
 			String expectedGradleVersion) throws IOException {
 		ProjectDescription description = new ProjectDescription();
 		description.setPlatformVersion(Version.parse(platformVersion));
@@ -117,7 +112,8 @@ class GradleProjectGenerationConfigurationTests {
 	}
 
 	@Test
-	void buildDotGradleIsContributedWhenGeneratingGradleProject() throws IOException {
+	void buildDotGradleDotKtsIsContributedWhenGeneratingGradleKtsProject()
+			throws IOException {
 		ProjectDescription description = new ProjectDescription();
 		description.setPlatformVersion(Version.parse("2.1.0.RELEASE"));
 		description.setLanguage(new JavaLanguage("11"));
@@ -125,19 +121,19 @@ class GradleProjectGenerationConfigurationTests {
 				new Dependency("com.example", "acme", DependencyScope.COMPILE));
 		ProjectStructure projectStructure = this.projectTester.generate(description);
 		List<String> relativePaths = projectStructure.getRelativePathsOfProjectFiles();
-		assertThat(relativePaths).contains("build.gradle");
-		Path path = projectStructure.resolve("build.gradle");
+		assertThat(relativePaths).contains("build.gradle.kts");
+		Path path = projectStructure.resolve("build.gradle.kts");
 		String[] lines = readAllLines(path);
 		assertThat(lines).containsExactly("plugins {",
-				"    id 'org.springframework.boot' version '2.1.0.RELEASE'",
-				"    id 'java'", "}", "",
-				"apply plugin: 'io.spring.dependency-management'", "",
-				"group = 'com.example'", "version = '0.0.1-SNAPSHOT'",
-				"sourceCompatibility = '11'", "", "repositories {", "    mavenCentral()",
-				"}", "", "dependencies {",
-				"    implementation 'org.springframework.boot:spring-boot-starter'",
-				"    implementation 'com.example:acme'",
-				"    testImplementation 'org.springframework.boot:spring-boot-starter-test'",
+				"    id(\"org.springframework.boot\") version \"2.1.0.RELEASE\"",
+				"    id(\"io.spring.dependency-management\") version \"1.0.6.RELEASE\"",
+				"    java", "}", "", "group = \"com.example\"",
+				"version = \"0.0.1-SNAPSHOT\"",
+				"java.sourceCompatibility = JavaVersion.VERSION_11", "", "repositories {",
+				"    mavenCentral()", "}", "", "dependencies {",
+				"    implementation(\"org.springframework.boot:spring-boot-starter\")",
+				"    implementation(\"com.example:acme\")",
+				"    testImplementation(\"org.springframework.boot:spring-boot-starter-test\")",
 				"}");
 	}
 
@@ -149,10 +145,10 @@ class GradleProjectGenerationConfigurationTests {
 		description.setPackaging(new WarPackaging());
 		ProjectStructure projectStructure = this.projectTester.generate(description);
 		List<String> relativePaths = projectStructure.getRelativePathsOfProjectFiles();
-		assertThat(relativePaths).contains("build.gradle");
+		assertThat(relativePaths).contains("build.gradle.kts");
 		try (Stream<String> lines = Files
-				.lines(projectStructure.resolve("build.gradle"))) {
-			assertThat(lines.filter((line) -> line.contains("    id 'war'"))).hasSize(1);
+				.lines(projectStructure.resolve("build.gradle.kts"))) {
+			assertThat(lines.filter((line) -> line.contains("    war"))).hasSize(1);
 		}
 	}
 

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GroovyDslGradleBuildProjectContributorTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GroovyDslGradleBuildProjectContributorTests.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
-import io.spring.initializr.generator.buildsystem.gradle.GradleBuildWriter;
+import io.spring.initializr.generator.buildsystem.gradle.GroovyDslGradleBuildWriter;
 import io.spring.initializr.generator.io.IndentingWriterFactory;
 import io.spring.initializr.generator.io.SimpleIndentStrategy;
 import org.junit.jupiter.api.Test;
@@ -32,19 +32,21 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link GradleBuildProjectContributor}.
+ * Tests for {@link GroovyDslGradleBuildProjectContributor}.
  *
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author Jean-Baptiste Nizet
  */
-class GradleBuildProjectContributorTests {
+class GroovyDslGradleBuildProjectContributorTests {
 
 	@Test
 	void gradleBuildIsContributedInProjectStructure(@TempDir Path projectDir)
 			throws IOException {
 		GradleBuild build = new GradleBuild();
-		new GradleBuildProjectContributor(new GradleBuildWriter(), build,
-				IndentingWriterFactory.withDefaultSettings()).contribute(projectDir);
+		new GroovyDslGradleBuildProjectContributor(new GroovyDslGradleBuildWriter(),
+				build, IndentingWriterFactory.withDefaultSettings())
+						.contribute(projectDir);
 		Path buildGradle = projectDir.resolve("build.gradle");
 		assertThat(buildGradle).isRegularFile();
 	}
@@ -81,8 +83,8 @@ class GradleBuildProjectContributorTests {
 	private List<String> generateBuild(GradleBuild build,
 			IndentingWriterFactory indentingWriterFactory) throws IOException {
 		StringWriter writer = new StringWriter();
-		new GradleBuildProjectContributor(new GradleBuildWriter(), build,
-				indentingWriterFactory).writeBuild(writer);
+		new GroovyDslGradleBuildProjectContributor(new GroovyDslGradleBuildWriter(),
+				build, indentingWriterFactory).writeBuild(writer);
 		return Arrays.asList(writer.toString().split("\\r?\\n"));
 	}
 

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GroovyDslSettingsGradleProjectContributorTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GroovyDslSettingsGradleProjectContributorTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.build.gradle;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.io.IndentingWriterFactory;
+import io.spring.initializr.generator.io.SimpleIndentStrategy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link GroovyDslSettingsGradleProjectContributor}.
+ *
+ * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
+ */
+class GroovyDslSettingsGradleProjectContributorTests {
+
+	@TempDir
+	Path directory;
+
+	@Test
+	void gradleSettingsIsContributedToProject() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.pluginRepositories().add("maven-central");
+		List<String> lines = generateSettings(build);
+		assertThat(lines).containsSequence("pluginManagement {", "    repositories {",
+				"        mavenCentral()", "        gradlePluginPortal()", "    }", "}");
+	}
+
+	@Test
+	void gradleSettingsIsContributedUsingGradleContentId() throws IOException {
+		IndentingWriterFactory indentingWriterFactory = IndentingWriterFactory
+				.create(new SimpleIndentStrategy("    "), (factory) -> factory
+						.indentingStrategy("gradle", new SimpleIndentStrategy("  ")));
+		GradleBuild build = new GradleBuild();
+		build.pluginRepositories().add("maven-central");
+		List<String> lines = generateSettings(build, indentingWriterFactory);
+		assertThat(lines).containsSequence("pluginManagement {", "  repositories {",
+				"    mavenCentral()", "    gradlePluginPortal()", "  }", "}");
+	}
+
+	@Test
+	void gradleSettingsDoesNotUseRepositories() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.repositories().add("maven-central");
+		List<String> lines = generateSettings(build);
+		assertThat(lines).containsSequence("pluginManagement {", "    repositories {",
+				"        gradlePluginPortal()", "    }", "}");
+	}
+
+	private List<String> generateSettings(GradleBuild build) throws IOException {
+		return generateSettings(build, IndentingWriterFactory.withDefaultSettings());
+	}
+
+	private List<String> generateSettings(GradleBuild build,
+			IndentingWriterFactory indentingWriterFactory) throws IOException {
+		Path projectDir = Files.createTempDirectory(this.directory, "project-");
+		new GroovyDslSettingsGradleProjectContributor(build, indentingWriterFactory)
+				.contribute(projectDir);
+		Path settingsGradle = projectDir.resolve("settings.gradle");
+		assertThat(settingsGradle).isRegularFile();
+		return Files.readAllLines(settingsGradle);
+	}
+
+}

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/KotlinDslGradleBuildProjectContributorTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/KotlinDslGradleBuildProjectContributorTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.build.gradle;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.buildsystem.gradle.KotlinDslGradleBuildWriter;
+import io.spring.initializr.generator.io.IndentingWriterFactory;
+import io.spring.initializr.generator.io.SimpleIndentStrategy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link KotlinDslGradleBuildProjectContributor}.
+ *
+ * @author Jean-Baptiste Nizet
+ */
+class KotlinDslGradleBuildProjectContributorTests {
+
+	@Test
+	void gradleBuildIsContributedInProjectStructure(@TempDir Path projectDir)
+			throws IOException {
+		GradleBuild build = new GradleBuild();
+		new KotlinDslGradleBuildProjectContributor(new KotlinDslGradleBuildWriter(),
+				build, IndentingWriterFactory.withDefaultSettings())
+						.contribute(projectDir);
+		Path buildGradleKts = projectDir.resolve("build.gradle.kts");
+		assertThat(buildGradleKts).isRegularFile();
+	}
+
+	@Test
+	void gradleBuildIsContributedToProject() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.setGroup("com.example");
+		build.setVersion("1.0.0-SNAPSHOT");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("group = \"com.example\"",
+				"version = \"1.0.0-SNAPSHOT\"");
+	}
+
+	@Test
+	void gradleBuildIsContributedUsingGradleContentId() throws IOException {
+		IndentingWriterFactory indentingWriterFactory = IndentingWriterFactory
+				.create(new SimpleIndentStrategy("    "), (factory) -> factory
+						.indentingStrategy("gradle", new SimpleIndentStrategy("  ")));
+		GradleBuild build = new GradleBuild();
+		build.addPlugin("java");
+		List<String> lines = generateBuild(build, indentingWriterFactory);
+		assertThat(lines).containsSequence("plugins {", "  java", "}");
+	}
+
+	private List<String> generateBuild(GradleBuild build) throws IOException {
+		return generateBuild(build, IndentingWriterFactory.withDefaultSettings());
+	}
+
+	private List<String> generateBuild(GradleBuild build,
+			IndentingWriterFactory indentingWriterFactory) throws IOException {
+		StringWriter writer = new StringWriter();
+		new KotlinDslGradleBuildProjectContributor(new KotlinDslGradleBuildWriter(),
+				build, indentingWriterFactory).writeBuild(writer);
+		return Arrays.asList(writer.toString().split("\\r?\\n"));
+	}
+
+}

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/KotlinDslSettingsGradleProjectContributorTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/KotlinDslSettingsGradleProjectContributorTests.java
@@ -30,11 +30,11 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link SettingsGradleProjectContributor}.
+ * Tests for {@link KotlinDslSettingsGradleProjectContributor}.
  *
- * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
  */
-class SettingsGradleProjectContributorTests {
+class KotlinDslSettingsGradleProjectContributorTests {
 
 	@TempDir
 	Path directory;
@@ -76,9 +76,9 @@ class SettingsGradleProjectContributorTests {
 	private List<String> generateSettings(GradleBuild build,
 			IndentingWriterFactory indentingWriterFactory) throws IOException {
 		Path projectDir = Files.createTempDirectory(this.directory, "project-");
-		new SettingsGradleProjectContributor(build, indentingWriterFactory)
+		new KotlinDslSettingsGradleProjectContributor(build, indentingWriterFactory)
 				.contribute(projectDir);
-		Path settingsGradle = projectDir.resolve("settings.gradle");
+		Path settingsGradle = projectDir.resolve("settings.gradle.kts");
 		assertThat(settingsGradle).isRegularFile();
 		return Files.readAllLines(settingsGradle);
 	}

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/GroovyDslKotlinGradleBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/GroovyDslKotlinGradleBuildCustomizerTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.code.kotlin;
+
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild.TaskCustomization;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link GroovyDslKotlinGradleBuildCustomizer}.
+ *
+ * @author Andy Wilkinson <<<<<<<
+ * HEAD:initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinGradleBuildCustomizerTests.java
+ * @author Jean-Baptiste Nizet ======= >>>>>>> 7ec6a29a... Configure spring project
+ * generation using Gradle Kotlin
+ * DSL:initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/GroovyDslKotlinGradleBuildCustomizerTests.java
+ */
+class GroovyDslKotlinGradleBuildCustomizerTests {
+
+	@Test
+	void kotlinPluginsAreConfigured() {
+		GradleBuild build = new GradleBuild();
+		new GroovyDslKotlinGradleBuildCustomizer(
+				new SimpleKotlinProjectSettings("1.2.70")).customize(build);
+		assertThat(build.getPlugins()).hasSize(2);
+		assertThat(build.getPlugins().get(0).getId())
+				.isEqualTo("org.jetbrains.kotlin.jvm");
+		assertThat(build.getPlugins().get(0).getVersion()).isEqualTo("1.2.70");
+		assertThat(build.getPlugins().get(1).getId())
+				.isEqualTo("org.jetbrains.kotlin.plugin.spring");
+		assertThat(build.getPlugins().get(1).getVersion()).isEqualTo("1.2.70");
+	}
+
+	@Test
+	void kotlinCompilationTasksAreCustomized() {
+		GradleBuild build = new GradleBuild();
+		new GroovyDslKotlinGradleBuildCustomizer(
+				new SimpleKotlinProjectSettings("1.2.70")).customize(build);
+		assertThat(build.getTasksWithTypeCustomizations()).hasSize(1);
+		assertThat(build.getTasksWithTypeCustomizations()).containsKeys("KotlinCompile");
+		assertKotlinOptions(build.getTasksWithTypeCustomizations().get("KotlinCompile"));
+	}
+
+	private void assertKotlinOptions(TaskCustomization compileTask) {
+		assertThat(compileTask.getAssignments()).isEmpty();
+		assertThat(compileTask.getInvocations()).isEmpty();
+		assertThat(compileTask.getNested()).hasSize(1);
+		TaskCustomization kotlinOptions = compileTask.getNested().get("kotlinOptions");
+		assertThat(kotlinOptions.getInvocations()).hasSize(0);
+		assertThat(kotlinOptions.getNested()).hasSize(0);
+		assertThat(kotlinOptions.getAssignments()).hasSize(2);
+		assertThat(kotlinOptions.getAssignments())
+				.containsEntry("freeCompilerArgs", "['-Xjsr305=strict']")
+				.containsEntry("jvmTarget", "'1.8'");
+	}
+
+}

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinDslKotlinGradleBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinDslKotlinGradleBuildCustomizerTests.java
@@ -23,18 +23,17 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link KotlinGradleBuildCustomizer}.
+ * Tests for {@link KotlinDslKotlinGradleBuildCustomizer}.
  *
- * @author Andy Wilkinson
  * @author Jean-Baptiste Nizet
  */
-class KotlinGradleBuildCustomizerTests {
+class KotlinDslKotlinGradleBuildCustomizerTests {
 
 	@Test
 	void kotlinPluginsAreConfigured() {
 		GradleBuild build = new GradleBuild();
-		new KotlinGradleBuildCustomizer(new SimpleKotlinProjectSettings("1.2.70"))
-				.customize(build);
+		new KotlinDslKotlinGradleBuildCustomizer(
+				new SimpleKotlinProjectSettings("1.2.70")).customize(build);
 		assertThat(build.getPlugins()).hasSize(2);
 		assertThat(build.getPlugins().get(0).getId())
 				.isEqualTo("org.jetbrains.kotlin.jvm");
@@ -47,10 +46,8 @@ class KotlinGradleBuildCustomizerTests {
 	@Test
 	void kotlinCompilationTasksAreCustomized() {
 		GradleBuild build = new GradleBuild();
-		new KotlinGradleBuildCustomizer(new SimpleKotlinProjectSettings("1.2.70"))
-				.customize(build);
-		assertThat(build.getImportedTypes())
-				.contains("org.jetbrains.kotlin.gradle.tasks.KotlinCompile");
+		new KotlinDslKotlinGradleBuildCustomizer(
+				new SimpleKotlinProjectSettings("1.2.70")).customize(build);
 		assertThat(build.getTasksWithTypeCustomizations()).hasSize(1);
 		assertThat(build.getTasksWithTypeCustomizations()).containsKeys("KotlinCompile");
 		assertKotlinOptions(build.getTasksWithTypeCustomizations().get("KotlinCompile"));
@@ -65,8 +62,8 @@ class KotlinGradleBuildCustomizerTests {
 		assertThat(kotlinOptions.getNested()).hasSize(0);
 		assertThat(kotlinOptions.getAssignments()).hasSize(2);
 		assertThat(kotlinOptions.getAssignments())
-				.containsEntry("freeCompilerArgs", "['-Xjsr305=strict']")
-				.containsEntry("jvmTarget", "'1.8'");
+				.containsEntry("freeCompilerArgs", "listOf(\"-Xjsr305=strict\")")
+				.containsEntry("jvmTarget", "\"1.8\"");
 	}
 
 }

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinGradleBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinGradleBuildCustomizerTests.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link KotlinGradleBuildCustomizer}.
  *
  * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
  */
 class KotlinGradleBuildCustomizerTests {
 
@@ -48,11 +49,11 @@ class KotlinGradleBuildCustomizerTests {
 		GradleBuild build = new GradleBuild();
 		new KotlinGradleBuildCustomizer(new SimpleKotlinProjectSettings("1.2.70"))
 				.customize(build);
-		assertThat(build.getTaskCustomizations()).hasSize(2);
-		assertThat(build.getTaskCustomizations()).containsKeys("compileKotlin",
-				"compileTestKotlin");
-		assertKotlinOptions(build.getTaskCustomizations().get("compileKotlin"));
-		assertKotlinOptions(build.getTaskCustomizations().get("compileTestKotlin"));
+		assertThat(build.getImportedTypes())
+				.contains("org.jetbrains.kotlin.gradle.tasks.KotlinCompile");
+		assertThat(build.getTasksWithTypeCustomizations()).hasSize(1);
+		assertThat(build.getTasksWithTypeCustomizations()).containsKeys("KotlinCompile");
+		assertKotlinOptions(build.getTasksWithTypeCustomizations().get("KotlinCompile"));
 	}
 
 	private void assertKotlinOptions(TaskCustomization compileTask) {

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/test/InitializrMetadataTestBuilder.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/test/InitializrMetadataTestBuilder.java
@@ -80,7 +80,7 @@ public class InitializrMetadataTestBuilder {
 	}
 
 	public InitializrMetadataTestBuilder addAllDefaults() {
-		return addBasicDefaults().setGradleEnv("0.5.1.RELEASE").setKotlinEnv("1.1.1");
+		return addBasicDefaults().setGradleEnv("1.0.6.RELEASE").setKotlinEnv("1.1.1");
 	}
 
 	public InitializrMetadataTestBuilder addBasicDefaults() {

--- a/initializr-generator-spring/src/test/resources/project/gradle-kts/annotation-processor-dependency-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle-kts/annotation-processor-dependency-build.gradle.kts.gen
@@ -1,0 +1,26 @@
+plugins {
+	id("org.springframework.boot") version "2.1.1.RELEASE"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+	java
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+configurations {
+	compileOnly {
+		extendsFrom(configurations.annotationProcessor.get())
+	}
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	implementation("org.springframework.boot:spring-boot-starter-web")
+	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/initializr-generator-spring/src/test/resources/project/gradle-kts/bom-ordering-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle-kts/bom-ordering-build.gradle.kts.gen
@@ -1,0 +1,26 @@
+plugins {
+	id("org.springframework.boot") version "2.1.1.RELEASE"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+	java
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation("org.acme:foo")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom("org.acme:bar-bom:1.0")
+		mavenBom("org.acme:biz-bom:1.0")
+		mavenBom("org.acme:foo-bom:1.0")
+	}
+}

--- a/initializr-generator-spring/src/test/resources/project/gradle-kts/bom-property-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle-kts/bom-property-build.gradle.kts.gen
@@ -1,0 +1,26 @@
+plugins {
+	id("org.springframework.boot") version "2.1.1.RELEASE"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+	java
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+	mavenCentral()
+}
+
+extra["fooVersion"] = "1.3.3"
+
+dependencies {
+	implementation("org.acme:foo")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom("org.acme:foo-bom:${fooVersion}")
+	}
+}

--- a/initializr-generator-spring/src/test/resources/project/gradle-kts/compile-only-dependency-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle-kts/compile-only-dependency-build.gradle.kts.gen
@@ -1,0 +1,20 @@
+plugins {
+	id("org.springframework.boot") version "2.1.1.RELEASE"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+	java
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	implementation("org.springframework.boot:spring-boot-starter-web")
+	compileOnly("org.acme:foo")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/initializr-generator-spring/src/test/resources/project/gradle-kts/gitignore.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle-kts/gitignore.gen
@@ -1,0 +1,26 @@
+.gradle
+/build/
+!gradle/wrapper/gradle-wrapper.jar
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/

--- a/initializr-generator-spring/src/test/resources/project/gradle-kts/kotlin-java11-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle-kts/kotlin-java11-build.gradle.kts.gen
@@ -1,0 +1,30 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+	id("org.springframework.boot") version "2.1.1.RELEASE"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+	kotlin("jvm") version "1.1.1"
+	kotlin("plugin.spring") version "1.1.1"
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_11
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation("org.springframework.boot:spring-boot-starter")
+	implementation("org.jetbrains.kotlin:kotlin-reflect")
+	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+tasks.withType<KotlinCompile> {
+	kotlinOptions {
+		freeCompilerArgs = listOf("-Xjsr305=strict")
+		jvmTarget = "1.8"
+	}
+}

--- a/initializr-generator-spring/src/test/resources/project/gradle-kts/repositories-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle-kts/repositories-build.gradle.kts.gen
@@ -1,0 +1,21 @@
+plugins {
+	id("org.springframework.boot") version "2.1.1.RELEASE"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+	java
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+	mavenCentral()
+	maven { url = uri("https://example.com/foo") }
+	maven { url = uri("https://example.com/bar") }
+}
+
+dependencies {
+	implementation("org.acme:bar")
+	implementation("org.acme:foo")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/initializr-generator-spring/src/test/resources/project/gradle-kts/repositories-milestone-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle-kts/repositories-milestone-build.gradle.kts.gen
@@ -1,0 +1,20 @@
+plugins {
+	id("org.springframework.boot") version "2.2.0.M1"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+	java
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+	mavenCentral()
+	maven { url = uri("https://repo.spring.io/snapshot") }
+	maven { url = uri("https://repo.spring.io/milestone") }
+}
+
+dependencies {
+	implementation("org.acme:foo")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/initializr-generator-spring/src/test/resources/project/gradle-kts/version-override-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle-kts/version-override-build.gradle.kts.gen
@@ -1,0 +1,21 @@
+plugins {
+	id("org.springframework.boot") version "2.1.1.RELEASE"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+	java
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+	mavenCentral()
+}
+
+extra["springBarVersion"] = "0.2.0.RELEASE"
+extra["spring-foo.version"] = "0.1.0.RELEASE"
+
+dependencies {
+	implementation("org.springframework.boot:spring-boot-starter-web")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/initializr-generator-spring/src/test/resources/project/gradle/kotlin-java11-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/kotlin-java11-build.gradle.gen
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
 	id 'org.springframework.boot' version '2.1.1.RELEASE'
 	id 'org.jetbrains.kotlin.jvm' version '1.1.1'
@@ -21,14 +23,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-compileKotlin {
-	kotlinOptions {
-		freeCompilerArgs = ['-Xjsr305=strict']
-		jvmTarget = '1.8'
-	}
-}
-
-compileTestKotlin {
+tasks.withType(KotlinCompile) {
 	kotlinOptions {
 		freeCompilerArgs = ['-Xjsr305=strict']
 		jvmTarget = '1.8'

--- a/initializr-generator-spring/src/test/resources/project/groovy/standard/build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/groovy/standard/build.gradle.kts.gen
@@ -1,0 +1,19 @@
+plugins {
+	id("org.springframework.boot") version "2.1.1.RELEASE"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+	groovy
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation("org.springframework.boot:spring-boot-starter")
+	implementation("org.codehaus.groovy:groovy")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/initializr-generator-spring/src/test/resources/project/groovy/standard/war-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/groovy/standard/war-build.gradle.kts.gen
@@ -1,0 +1,21 @@
+plugins {
+	id("org.springframework.boot") version "2.1.1.RELEASE"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+	war
+	groovy
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.codehaus.groovy:groovy")
+	providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/initializr-generator-spring/src/test/resources/project/java/standard/build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/java/standard/build.gradle.kts.gen
@@ -1,0 +1,18 @@
+plugins {
+	id("org.springframework.boot") version "2.1.1.RELEASE"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+	java
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation("org.springframework.boot:spring-boot-starter")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/initializr-generator-spring/src/test/resources/project/java/standard/war-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/java/standard/war-build.gradle.kts.gen
@@ -1,0 +1,20 @@
+plugins {
+	id("org.springframework.boot") version "2.1.1.RELEASE"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+	java
+	war
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation("org.springframework.boot:spring-boot-starter-web")
+	providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/initializr-generator-spring/src/test/resources/project/kotlin/previous/build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/previous/build.gradle.gen
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 buildscript {
 	repositories {
 		mavenCentral()
@@ -29,14 +31,7 @@ dependencies {
 	testCompile 'org.springframework.boot:spring-boot-starter-test'
 }
 
-compileKotlin {
-	kotlinOptions {
-		freeCompilerArgs = ['-Xjsr305=strict']
-		jvmTarget = '1.8'
-	}
-}
-
-compileTestKotlin {
+tasks.withType(KotlinCompile) {
 	kotlinOptions {
 		freeCompilerArgs = ['-Xjsr305=strict']
 		jvmTarget = '1.8'

--- a/initializr-generator-spring/src/test/resources/project/kotlin/standard/build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/standard/build.gradle.gen
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
 	id 'org.springframework.boot' version '2.1.1.RELEASE'
 	id 'org.jetbrains.kotlin.jvm' version '1.1.1'
@@ -21,14 +23,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-compileKotlin {
-	kotlinOptions {
-		freeCompilerArgs = ['-Xjsr305=strict']
-		jvmTarget = '1.8'
-	}
-}
-
-compileTestKotlin {
+tasks.withType(KotlinCompile) {
 	kotlinOptions {
 		freeCompilerArgs = ['-Xjsr305=strict']
 		jvmTarget = '1.8'

--- a/initializr-generator-spring/src/test/resources/project/kotlin/standard/build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/standard/build.gradle.kts.gen
@@ -1,0 +1,30 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+	id("org.springframework.boot") version "2.1.1.RELEASE"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+	kotlin("jvm") version "1.1.1"
+	kotlin("plugin.spring") version "1.1.1"
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation("org.springframework.boot:spring-boot-starter")
+	implementation("org.jetbrains.kotlin:kotlin-reflect")
+	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+tasks.withType<KotlinCompile> {
+	kotlinOptions {
+		freeCompilerArgs = listOf("-Xjsr305=strict")
+		jvmTarget = "1.8"
+	}
+}

--- a/initializr-generator-spring/src/test/resources/project/kotlin/standard/war-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/standard/war-build.gradle.gen
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
 	id 'org.springframework.boot' version '2.1.1.RELEASE'
 	id 'war'
@@ -23,14 +25,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-compileKotlin {
-	kotlinOptions {
-		freeCompilerArgs = ['-Xjsr305=strict']
-		jvmTarget = '1.8'
-	}
-}
-
-compileTestKotlin {
+tasks.withType(KotlinCompile) {
 	kotlinOptions {
 		freeCompilerArgs = ['-Xjsr305=strict']
 		jvmTarget = '1.8'

--- a/initializr-generator-spring/src/test/resources/project/kotlin/standard/war-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/standard/war-build.gradle.kts.gen
@@ -1,0 +1,32 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+	id("org.springframework.boot") version "2.1.1.RELEASE"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+	war
+	kotlin("jvm") version "1.1.1"
+	kotlin("plugin.spring") version "1.1.1"
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.jetbrains.kotlin:kotlin-reflect")
+	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+	providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+tasks.withType<KotlinCompile> {
+	kotlinOptions {
+		freeCompilerArgs = listOf("-Xjsr305=strict")
+		jvmTarget = "1.8"
+	}
+}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/Gradle3BuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/Gradle3BuildWriter.java
@@ -19,11 +19,11 @@ package io.spring.initializr.generator.buildsystem.gradle;
 import io.spring.initializr.generator.buildsystem.DependencyScope;
 
 /**
- * A {@link GradleBuildWriter} suitable for Gradle 3.
+ * A {@link GroovyDslGradleBuildWriter} suitable for Gradle 3.
  *
  * @author Stephane Nicoll
  */
-public class Gradle3BuildWriter extends GradleBuildWriter {
+public class Gradle3BuildWriter extends GroovyDslGradleBuildWriter {
 
 	protected String configurationForScope(DependencyScope type) {
 		switch (type) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuild.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuild.java
@@ -19,6 +19,7 @@ package io.spring.initializr.generator.buildsystem.gradle;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -34,6 +35,7 @@ import io.spring.initializr.generator.buildsystem.BuildItemResolver;
  * Gradle build configuration for a project.
  *
  * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
  */
 public class GradleBuild extends Build {
 
@@ -48,6 +50,10 @@ public class GradleBuild extends Build {
 	private final Map<String, ConfigurationCustomization> configurationCustomizations = new LinkedHashMap<>();
 
 	private final Map<String, TaskCustomization> taskCustomizations = new LinkedHashMap<>();
+
+	private final Set<String> importedTypes = new HashSet<>();
+
+	private final Map<String, TaskCustomization> tasksWithTypeCustomizations = new LinkedHashMap<>();
 
 	private final Buildscript buildscript = new Buildscript();
 
@@ -119,6 +125,24 @@ public class GradleBuild extends Build {
 
 	public Map<String, ConfigurationCustomization> getConfigurationCustomizations() {
 		return Collections.unmodifiableMap(this.configurationCustomizations);
+	}
+
+	public void addImportedType(String type) {
+		this.importedTypes.add(type);
+	}
+
+	public Set<String> getImportedTypes() {
+		return Collections.unmodifiableSet(this.importedTypes);
+	}
+
+	public void customizeTasksWithType(String typeName,
+			Consumer<TaskCustomization> customizer) {
+		customizer.accept(this.tasksWithTypeCustomizations.computeIfAbsent(typeName,
+				(name) -> new TaskCustomization()));
+	}
+
+	public Map<String, TaskCustomization> getTasksWithTypeCustomizations() {
+		return Collections.unmodifiableMap(this.tasksWithTypeCustomizations);
 	}
 
 	public void customizeTask(String taskName, Consumer<TaskCustomization> customizer) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
@@ -43,23 +43,26 @@ import io.spring.initializr.generator.version.VersionProperty;
 import io.spring.initializr.generator.version.VersionReference;
 
 /**
- * A {@link GradleBuild} writer for {@code build.gradle}.
+ * A {@link GradleBuild} writer template for build.gradle and build.gradle.kts. A subclass
+ * of this class exists for the Groovy DSL and for the Kotlin DSL.
  *
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  * @author Jean-Baptiste Nizet
  */
-public class GradleBuildWriter {
+public abstract class GradleBuildWriter {
 
-	public void writeTo(IndentingWriter writer, GradleBuild build) throws IOException {
+	public final void writeTo(IndentingWriter writer, GradleBuild build)
+			throws IOException {
 		writeImports(writer, build);
-		boolean buildScriptWritten = writeBuildscript(writer, build);
-		writePlugins(writer, build, buildScriptWritten);
+		writeBuildscript(writer, build);
+		writePlugins(writer, build);
 		writeProperty(writer, "group", build.getGroup());
 		writeProperty(writer, "version", build.getVersion());
-		writeProperty(writer, "sourceCompatibility", build.getSourceCompatibility());
+		writeJavaSourceCompatibility(writer, build);
+		writer.println();
 		writeConfigurations(writer, build);
-		writeRepositories(writer, build, writer::println);
+		writeRepositories(writer, build);
 		writeProperties(writer, build);
 		writeDependencies(writer, build);
 		writeBoms(writer, build);
@@ -75,61 +78,12 @@ public class GradleBuildWriter {
 		}
 	}
 
-	private boolean writeBuildscript(IndentingWriter writer, GradleBuild build) {
-		List<String> dependencies = build.getBuildscript().getDependencies();
-		Map<String, String> ext = build.getBuildscript().getExt();
-		if (dependencies.isEmpty() && ext.isEmpty()) {
-			return false;
-		}
-		writer.println("buildscript {");
-		writer.indented(() -> {
-			writeBuildscriptExt(writer, build);
-			writeBuildscriptRepositories(writer, build);
-			writeBuildscriptDependencies(writer, build);
-		});
-		writer.println("}");
-		return true;
-	}
+	protected abstract void writeBuildscript(IndentingWriter writer, GradleBuild build);
 
-	private void writeBuildscriptExt(IndentingWriter writer, GradleBuild build) {
-		writeNestedMap(writer, "ext", build.getBuildscript().getExt(),
-				(key, value) -> key + " = " + value);
-	}
+	protected abstract void writePlugins(IndentingWriter writer, GradleBuild build);
 
-	private void writeBuildscriptRepositories(IndentingWriter writer, GradleBuild build) {
-		writeRepositories(writer, build);
-	}
-
-	private void writeBuildscriptDependencies(IndentingWriter writer, GradleBuild build) {
-		writeNestedCollection(writer, "dependencies",
-				build.getBuildscript().getDependencies(),
-				(dependency) -> "classpath '" + dependency + "'");
-	}
-
-	private void writePlugins(IndentingWriter writer, GradleBuild build,
-			boolean buildScriptWritten) {
-		writeNestedCollection(writer, "plugins", build.getPlugins(), this::pluginAsString,
-				determineBeforeWriting(buildScriptWritten, writer));
-		writeCollection(writer, build.getAppliedPlugins(),
-				(plugin) -> "apply plugin: '" + plugin + "'", writer::println);
-		writer.println();
-	}
-
-	private Runnable determineBeforeWriting(boolean buildScriptWritten,
-			IndentingWriter writer) {
-		if (buildScriptWritten) {
-			return writer::println;
-		}
-		return null;
-	}
-
-	private String pluginAsString(GradlePlugin plugin) {
-		String string = "id '" + plugin.getId() + "'";
-		if (plugin.getVersion() != null) {
-			string += " version '" + plugin.getVersion() + "'";
-		}
-		return string;
-	}
+	protected abstract void writeJavaSourceCompatibility(IndentingWriter writer,
+			GradleBuild build);
 
 	private void writeConfigurations(IndentingWriter writer, GradleBuild build) {
 		Map<String, ConfigurationCustomization> configurationCustomizations = build
@@ -137,7 +91,6 @@ public class GradleBuildWriter {
 		if (configurationCustomizations.isEmpty()) {
 			return;
 		}
-		writer.println();
 		writer.println("configurations {");
 		writer.indented(() -> {
 			configurationCustomizations.forEach((name, customization) -> {
@@ -145,38 +98,20 @@ public class GradleBuildWriter {
 			});
 		});
 		writer.println("}");
+		writer.println("");
 	}
 
-	private void writeConfiguration(IndentingWriter writer, String configurationName,
-			ConfigurationCustomization configurationCustomization) {
-		if (configurationCustomization.getExtendsFrom().isEmpty()) {
-			writer.println(configurationName);
-		}
-		else {
-			writer.println(configurationName + " {");
-			writer.indented(() -> writer.println(String.format("extendsFrom %s",
-					String.join(", ", configurationCustomization.getExtendsFrom()))));
-			writer.println("}");
-		}
-	}
+	protected abstract void writeConfiguration(IndentingWriter writer,
+			String configurationName,
+			ConfigurationCustomization configurationCustomization);
 
-	private void writeRepositories(IndentingWriter writer, GradleBuild build) {
-		writeRepositories(writer, build, null);
-	}
-
-	private void writeRepositories(IndentingWriter writer, GradleBuild build,
-			Runnable beforeWriting) {
+	protected final void writeRepositories(IndentingWriter writer, GradleBuild build) {
 		writeNestedCollection(writer, "repositories",
 				build.repositories().items().collect(Collectors.toList()),
-				this::repositoryAsString, beforeWriting);
+				this::repositoryAsString);
 	}
 
-	private String repositoryAsString(MavenRepository repository) {
-		if (MavenRepository.MAVEN_CENTRAL.equals(repository)) {
-			return "mavenCentral()";
-		}
-		return "maven { url '" + repository.getUrl() + "' }";
-	}
+	protected abstract String repositoryAsString(MavenRepository repository);
 
 	private void writeProperties(IndentingWriter writer, GradleBuild build) {
 		if (build.getExt().isEmpty() && build.getVersionProperties().isEmpty()) {
@@ -185,17 +120,15 @@ public class GradleBuildWriter {
 		Map<String, String> allProperties = new LinkedHashMap<>(build.getExt());
 		build.getVersionProperties().entrySet().forEach((entry) -> allProperties
 				.put(getVersionPropertyKey(entry), entry.getValue()));
-		writeNestedCollection(writer, "ext", allProperties.entrySet(),
-				(e) -> getFormattedProperty(e.getKey(), e.getValue()), writer::println);
+		writeExtraProperties(writer, allProperties);
 	}
+
+	protected abstract void writeExtraProperties(IndentingWriter writer,
+			Map<String, String> allProperties);
 
 	private String getVersionPropertyKey(Entry<VersionProperty, String> entry) {
 		return entry.getKey().isInternal() ? entry.getKey().toCamelCaseFormat()
 				: entry.getKey().toStandardFormat();
-	}
-
-	private String getFormattedProperty(String key, String value) {
-		return String.format("set('%s', '%s')", key, value);
 	}
 
 	private void writeDependencies(IndentingWriter writer, GradleBuild build) {
@@ -219,15 +152,7 @@ public class GradleBuildWriter {
 				this::dependencyAsString, writer::println);
 	}
 
-	private String dependencyAsString(Dependency dependency) {
-		String quoteStyle = determineQuoteStyle(dependency.getVersion());
-		String version = determineVersion(dependency.getVersion());
-		String type = dependency.getType();
-		return configurationForScope(dependency.getScope()) + " " + quoteStyle
-				+ dependency.getGroupId() + ":" + dependency.getArtifactId()
-				+ ((version != null) ? ":" + version : "")
-				+ ((type != null) ? "@" + type : "") + quoteStyle;
-	}
+	protected abstract String dependencyAsString(Dependency dependency);
 
 	protected String configurationForScope(DependencyScope type) {
 		switch (type) {
@@ -266,23 +191,18 @@ public class GradleBuildWriter {
 	}
 
 	private String bomAsString(BillOfMaterials bom) {
-		String quoteStyle = determineQuoteStyle(bom.getVersion());
 		String version = determineVersion(bom.getVersion());
-		return "mavenBom " + quoteStyle + bom.getGroupId() + ":" + bom.getArtifactId()
-				+ ":" + version + quoteStyle;
+		return bomAsString(bom, version);
 	}
 
-	private String determineQuoteStyle(VersionReference versionReference) {
-		return (versionReference != null && versionReference.isProperty()) ? "\"" : "'";
-	}
+	protected abstract String bomAsString(BillOfMaterials bom, String version);
 
-	private String determineVersion(VersionReference versionReference) {
+	protected final String determineVersion(VersionReference versionReference) {
 		if (versionReference != null) {
 			if (versionReference.isProperty()) {
 				VersionProperty property = versionReference.getProperty();
-				return "${"
-						+ (property.isInternal() ? property.toCamelCaseFormat()
-								: "property('" + property.toStandardFormat() + "')")
+				return "${" + (property.isInternal() ? property.toCamelCaseFormat()
+						: externalVersionPropertyAsString(property.toStandardFormat()))
 						+ "}";
 			}
 			return versionReference.getValue();
@@ -290,34 +210,17 @@ public class GradleBuildWriter {
 		return null;
 	}
 
-	private void writeTasksWithTypeCustomizations(IndentingWriter writer,
-			GradleBuild build) {
-		Map<String, GradleBuild.TaskCustomization> tasksWithTypeCustomizations = build
-				.getTasksWithTypeCustomizations();
+	protected abstract String externalVersionPropertyAsString(String standardFormat);
 
-		tasksWithTypeCustomizations.forEach((typeName, customization) -> {
-			writer.println();
-			writer.println("tasks.withType(" + typeName + ") {");
-			writer.indented(() -> writeTaskCustomization(writer, customization));
-			writer.println("}");
-		});
-	}
+	protected abstract void writeTasksWithTypeCustomizations(IndentingWriter writer,
+			GradleBuild build);
 
-	private void writeTaskCustomizations(IndentingWriter writer, GradleBuild build) {
-		Map<String, TaskCustomization> taskCustomizations = build.getTaskCustomizations();
-		taskCustomizations.forEach((name, customization) -> {
-			writer.println();
-			writer.println(name + " {");
-			writer.indented(() -> writeTaskCustomization(writer, customization));
-			writer.println("}");
-		});
-	}
+	protected abstract void writeTaskCustomizations(IndentingWriter writer,
+			GradleBuild build);
 
-	private void writeTaskCustomization(IndentingWriter writer,
+	protected final void writeTaskCustomization(IndentingWriter writer,
 			TaskCustomization customization) {
-		writeCollection(writer, customization.getInvocations(),
-				(invocation) -> invocation.getTarget() + " "
-						+ String.join(", ", invocation.getArguments()));
+		writeCollection(writer, customization.getInvocations(), this::invocationAsString);
 		writeMap(writer, customization.getAssignments(),
 				(key, value) -> key + " = " + value);
 		customization.getNested().forEach((property, nestedCustomization) -> {
@@ -327,12 +230,14 @@ public class GradleBuildWriter {
 		});
 	}
 
-	private <T> void writeNestedCollection(IndentingWriter writer, String name,
+	protected abstract String invocationAsString(TaskCustomization.Invocation invocation);
+
+	protected final <T> void writeNestedCollection(IndentingWriter writer, String name,
 			Collection<T> collection, Function<T, String> itemToStringConverter) {
 		this.writeNestedCollection(writer, name, collection, itemToStringConverter, null);
 	}
 
-	private <T> void writeNestedCollection(IndentingWriter writer, String name,
+	protected final <T> void writeNestedCollection(IndentingWriter writer, String name,
 			Collection<T> collection, Function<T, String> converter,
 			Runnable beforeWriting) {
 		if (!collection.isEmpty()) {
@@ -351,8 +256,9 @@ public class GradleBuildWriter {
 		writeCollection(writer, collection, converter, null);
 	}
 
-	private <T> void writeCollection(IndentingWriter writer, Collection<T> collection,
-			Function<T, String> itemToStringConverter, Runnable beforeWriting) {
+	protected final <T> void writeCollection(IndentingWriter writer,
+			Collection<T> collection, Function<T, String> itemToStringConverter,
+			Runnable beforeWriting) {
 		if (!collection.isEmpty()) {
 			if (beforeWriting != null) {
 				beforeWriting.run();
@@ -361,25 +267,13 @@ public class GradleBuildWriter {
 		}
 	}
 
-	private <T, U> void writeNestedMap(IndentingWriter writer, String name, Map<T, U> map,
-			BiFunction<T, U, String> converter) {
-		if (!map.isEmpty()) {
-			writer.println(name + " {");
-			writer.indented(() -> writeMap(writer, map, converter));
-			writer.println("}");
-		}
-	}
-
-	private <T, U> void writeMap(IndentingWriter writer, Map<T, U> map,
+	protected final <T, U> void writeMap(IndentingWriter writer, Map<T, U> map,
 			BiFunction<T, U, String> converter) {
 		map.forEach((key, value) -> writer.println(converter.apply(key, value)));
 	}
 
-	private void writeProperty(IndentingWriter writer, String name, String value) {
-		if (value != null) {
-			writer.println(String.format("%s = '%s'", name, value));
-		}
-	}
+	protected abstract void writeProperty(IndentingWriter writer, String name,
+			String value);
 
 	private static Collection<Dependency> filterDependencies(
 			DependencyContainer dependencies, DependencyScope... types) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleKtsBuildSystem.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleKtsBuildSystem.java
@@ -19,17 +19,17 @@ package io.spring.initializr.generator.buildsystem.gradle;
 import io.spring.initializr.generator.buildsystem.BuildSystem;
 
 /**
- * Gradle {@link BuildSystem} using the Groovy DSL (i.e. settings.gradle and
- * build.gradle).
+ * Gradle {@link BuildSystem} using the Kotlin DSL (i.e. settings.gradle.kts and
+ * build.gradle.kts).
  *
- * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
  */
-public final class GradleBuildSystem implements BuildSystem {
+public final class GradleKtsBuildSystem implements BuildSystem {
 
 	/**
-	 * Gradle {@link BuildSystem} identifier.
+	 * Gradle KTS {@link BuildSystem} identifier.
 	 */
-	public static final String ID = "gradle";
+	public static final String ID = "gradle-kts";
 
 	@Override
 	public String id() {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleKtsBuildSystemFactory.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleKtsBuildSystemFactory.java
@@ -17,28 +17,21 @@
 package io.spring.initializr.generator.buildsystem.gradle;
 
 import io.spring.initializr.generator.buildsystem.BuildSystem;
+import io.spring.initializr.generator.buildsystem.BuildSystemFactory;
 
 /**
- * Gradle {@link BuildSystem} using the Groovy DSL (i.e. settings.gradle and
- * build.gradle).
+ * {@link BuildSystemFactory Factory} for {@link GradleKtsBuildSystem}.
  *
- * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
  */
-public final class GradleBuildSystem implements BuildSystem {
-
-	/**
-	 * Gradle {@link BuildSystem} identifier.
-	 */
-	public static final String ID = "gradle";
+class GradleKtsBuildSystemFactory implements BuildSystemFactory {
 
 	@Override
-	public String id() {
-		return ID;
-	}
-
-	@Override
-	public String toString() {
-		return id();
+	public BuildSystem createBuildSystem(String id) {
+		if (GradleKtsBuildSystem.ID.equals(id)) {
+			return new GradleKtsBuildSystem();
+		}
+		return null;
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleSettingsWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleSettingsWriter.java
@@ -22,15 +22,19 @@ import io.spring.initializr.generator.buildsystem.MavenRepository;
 import io.spring.initializr.generator.io.IndentingWriter;
 
 /**
- * A {@link GradleBuild} writer for {@code settings.gradle}.
+ * A {@link GradleBuild} writer template for {@code settings.gradle} and
+ * {@code settings.gradle.kts}. A subclass of this class exists for the Groovy DSL and for
+ * the Kotlin DSL.
  *
  * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
  */
-public class GradleSettingsWriter {
+public abstract class GradleSettingsWriter {
 
-	public void writeTo(IndentingWriter writer, GradleBuild build) throws IOException {
+	public final void writeTo(IndentingWriter writer, GradleBuild build)
+			throws IOException {
 		writePluginManagement(writer, build);
-		writer.println("rootProject.name = '" + build.getArtifact() + "'");
+		writer.println("rootProject.name = " + wrapWithQuotes(build.getArtifact()));
 	}
 
 	private void writePluginManagement(IndentingWriter writer, GradleBuild build) {
@@ -62,7 +66,8 @@ public class GradleSettingsWriter {
 		writer.indented(() -> {
 			writer.println("eachPlugin {");
 			writer.indented(() -> {
-				writer.println("if (requested.id.id == 'org.springframework.boot') {");
+				writer.println("if (requested.id.id == "
+						+ wrapWithQuotes("org.springframework.boot") + ") {");
 				writer.indented(() -> writer.println(
 						"useModule(\"org.springframework.boot:spring-boot-gradle-plugin:${requested.version}\")"));
 				writer.println("}");
@@ -76,7 +81,11 @@ public class GradleSettingsWriter {
 		if (MavenRepository.MAVEN_CENTRAL.equals(repository)) {
 			return "mavenCentral()";
 		}
-		return "maven { url '" + repository.getUrl() + "' }";
+		return "maven { " + urlAssignment(repository.getUrl()) + " }";
 	}
+
+	protected abstract String wrapWithQuotes(String value);
+
+	protected abstract String urlAssignment(String url);
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriter.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.buildsystem.gradle;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import io.spring.initializr.generator.buildsystem.BillOfMaterials;
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.MavenRepository;
+import io.spring.initializr.generator.io.IndentingWriter;
+import io.spring.initializr.generator.version.VersionReference;
+
+/**
+ * A {@link GradleBuild} writer for {@code build.gradle}.
+ *
+ * @author Jean-Baptiste Nizet
+ */
+public class GroovyDslGradleBuildWriter extends GradleBuildWriter {
+
+	@Override
+	protected void writeBuildscript(IndentingWriter writer, GradleBuild build) {
+		List<String> dependencies = build.getBuildscript().getDependencies();
+		Map<String, String> ext = build.getBuildscript().getExt();
+		if (dependencies.isEmpty() && ext.isEmpty()) {
+			return;
+		}
+		writer.println("buildscript {");
+		writer.indented(() -> {
+			writeBuildscriptExt(writer, build);
+			writeBuildscriptRepositories(writer, build);
+			writeBuildscriptDependencies(writer, build);
+		});
+		writer.println("}");
+		writer.println();
+	}
+
+	private void writeBuildscriptExt(IndentingWriter writer, GradleBuild build) {
+		writeNestedMap(writer, "ext", build.getBuildscript().getExt(),
+				(key, value) -> key + " = " + value);
+	}
+
+	private void writeBuildscriptRepositories(IndentingWriter writer, GradleBuild build) {
+		writeRepositories(writer, build);
+	}
+
+	private void writeBuildscriptDependencies(IndentingWriter writer, GradleBuild build) {
+		writeNestedCollection(writer, "dependencies",
+				build.getBuildscript().getDependencies(),
+				(dependency) -> "classpath '" + dependency + "'");
+	}
+
+	@Override
+	protected void writePlugins(IndentingWriter writer, GradleBuild build) {
+		writeNestedCollection(writer, "plugins", build.getPlugins(),
+				this::pluginAsString);
+		writeCollection(writer, build.getAppliedPlugins(),
+				(plugin) -> "apply plugin: '" + plugin + "'", writer::println);
+		writer.println();
+	}
+
+	private String pluginAsString(GradlePlugin plugin) {
+		String string = "id '" + plugin.getId() + "'";
+		if (plugin.getVersion() != null) {
+			string += " version '" + plugin.getVersion() + "'";
+		}
+		return string;
+	}
+
+	@Override
+	protected void writeJavaSourceCompatibility(IndentingWriter writer,
+			GradleBuild build) {
+		writeProperty(writer, "sourceCompatibility", build.getSourceCompatibility());
+	}
+
+	@Override
+	protected void writeConfiguration(IndentingWriter writer, String configurationName,
+			GradleBuild.ConfigurationCustomization configurationCustomization) {
+		if (configurationCustomization.getExtendsFrom().isEmpty()) {
+			writer.println(configurationName);
+		}
+		else {
+			writer.println(configurationName + " {");
+			writer.indented(() -> writer.println(String.format("extendsFrom %s",
+					String.join(", ", configurationCustomization.getExtendsFrom()))));
+			writer.println("}");
+		}
+	}
+
+	@Override
+	protected String repositoryAsString(MavenRepository repository) {
+		if (MavenRepository.MAVEN_CENTRAL.equals(repository)) {
+			return "mavenCentral()";
+		}
+		return "maven { url '" + repository.getUrl() + "' }";
+	}
+
+	@Override
+	protected void writeExtraProperties(IndentingWriter writer,
+			Map<String, String> allProperties) {
+		writeNestedCollection(writer, "ext", allProperties.entrySet(),
+				(e) -> getFormattedExtraProperty(e.getKey(), e.getValue()),
+				writer::println);
+	}
+
+	private String getFormattedExtraProperty(String key, String value) {
+		return String.format("set('%s', '%s')", key, value);
+	}
+
+	@Override
+	protected String dependencyAsString(Dependency dependency) {
+		String quoteStyle = determineQuoteStyle(dependency.getVersion());
+		String version = determineVersion(dependency.getVersion());
+		String type = dependency.getType();
+		return configurationForScope(dependency.getScope()) + " " + quoteStyle
+				+ dependency.getGroupId() + ":" + dependency.getArtifactId()
+				+ ((version != null) ? ":" + version : "")
+				+ ((type != null) ? "@" + type : "") + quoteStyle;
+	}
+
+	private String determineQuoteStyle(VersionReference versionReference) {
+		return (versionReference != null && versionReference.isProperty()) ? "\"" : "'";
+	}
+
+	@Override
+	protected String bomAsString(BillOfMaterials bom, String version) {
+		String quoteStyle = determineQuoteStyle(bom.getVersion());
+		return "mavenBom " + quoteStyle + bom.getGroupId() + ":" + bom.getArtifactId()
+				+ ":" + version + quoteStyle;
+	}
+
+	@Override
+	protected String externalVersionPropertyAsString(String standardFormat) {
+		return "property('" + standardFormat + "')";
+	}
+
+	@Override
+	protected void writeTasksWithTypeCustomizations(IndentingWriter writer,
+			GradleBuild build) {
+		Map<String, GradleBuild.TaskCustomization> tasksWithTypeCustomizations = build
+				.getTasksWithTypeCustomizations();
+
+		tasksWithTypeCustomizations.forEach((typeName, customization) -> {
+			writer.println();
+			writer.println("tasks.withType(" + typeName + ") {");
+			writer.indented(() -> writeTaskCustomization(writer, customization));
+			writer.println("}");
+		});
+	}
+
+	@Override
+	protected void writeTaskCustomizations(IndentingWriter writer, GradleBuild build) {
+		Map<String, GradleBuild.TaskCustomization> taskCustomizations = build
+				.getTaskCustomizations();
+
+		taskCustomizations.forEach((name, customization) -> {
+			writer.println();
+			writer.println(name + " {");
+			writer.indented(() -> writeTaskCustomization(writer, customization));
+			writer.println("}");
+		});
+	}
+
+	@Override
+	protected String invocationAsString(
+			GradleBuild.TaskCustomization.Invocation invocation) {
+		return invocation.getTarget() + " "
+				+ String.join(", ", invocation.getArguments());
+	}
+
+	@Override
+	protected void writeProperty(IndentingWriter writer, String name, String value) {
+		if (value != null) {
+			writer.println(String.format("%s = '%s'", name, value));
+		}
+	}
+
+	private <T, U> void writeNestedMap(IndentingWriter writer, String name, Map<T, U> map,
+			BiFunction<T, U, String> converter) {
+		if (!map.isEmpty()) {
+			writer.println(name + " {");
+			writer.indented(() -> writeMap(writer, map, converter));
+			writer.println("}");
+		}
+	}
+
+}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleSettingsWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleSettingsWriter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.buildsystem.gradle;
+
+/**
+ * A {@link GradleBuild} writer for {@code settings.gradle}.
+ *
+ * @author Jean-Baptiste Nizet
+ */
+public class GroovyDslGradleSettingsWriter extends GradleSettingsWriter {
+
+	@Override
+	protected String wrapWithQuotes(String value) {
+		return "'" + value + "'";
+	}
+
+	@Override
+	protected String urlAssignment(String url) {
+		return "url " + wrapWithQuotes(url);
+	}
+
+}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriter.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.buildsystem.gradle;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.spring.initializr.generator.buildsystem.BillOfMaterials;
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.MavenRepository;
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild.ConfigurationCustomization;
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild.TaskCustomization;
+import io.spring.initializr.generator.io.IndentingWriter;
+
+/**
+ * A {@link GradleBuild} writer for {@code build.gradle.kts}.
+ *
+ * @author Jean-Baptiste Nizet
+ */
+public class KotlinDslGradleBuildWriter extends GradleBuildWriter {
+
+	private static final Map<String, String> sourceCompatibilitiesToJavaVersion = createSourceCompatibilitiesToJavaVersion();
+
+	private static Map<String, String> createSourceCompatibilitiesToJavaVersion() {
+		Map<String, String> result = new HashMap<>();
+		for (int version = 6; version <= 10; version++) {
+			result.put(Integer.toString(version), "VERSION_1_" + version);
+			result.put("1." + version, "VERSION_1_" + version);
+		}
+		for (int version = 11; version <= 12; version++) {
+			result.put(Integer.toString(version), "VERSION_" + version);
+			result.put("1." + version, "VERSION_" + version);
+		}
+
+		return Collections.unmodifiableMap(result);
+	}
+
+	@Override
+	protected void writeBuildscript(IndentingWriter writer, GradleBuild build) {
+		if (!(build.getBuildscript().getDependencies().isEmpty()
+				&& build.getBuildscript().getExt().isEmpty())) {
+			throw new IllegalStateException(
+					"build.gradle.kts scripts shouldn't need a buildscript");
+		}
+	}
+
+	@Override
+	protected void writePlugins(IndentingWriter writer, GradleBuild build) {
+		writeNestedCollection(writer, "plugins", build.getPlugins(), this::pluginAsString,
+				null);
+		writer.println();
+
+		if (!build.getAppliedPlugins().isEmpty()) {
+			throw new IllegalStateException(
+					"build.gradle.kts scripts shouldn't apply plugins. They should use the plugins block instead.");
+		}
+	}
+
+	private String pluginAsString(GradlePlugin plugin) {
+		String result = shortPluginNotation(plugin.getId());
+		if (result == null) {
+			result = "id(\"" + plugin.getId() + "\")";
+		}
+		if (plugin.getVersion() != null) {
+			result += " version \"" + plugin.getVersion() + "\"";
+		}
+		return result;
+	}
+
+	private String shortPluginNotation(String pluginId) {
+		if (pluginId.equals("java") || pluginId.equals("war")
+				|| pluginId.equals("groovy")) {
+			return pluginId;
+		}
+
+		String kotlinPluginPrefix = "org.jetbrains.kotlin.";
+		if (pluginId.startsWith(kotlinPluginPrefix)) {
+			return "kotlin(\"" + pluginId.substring(kotlinPluginPrefix.length()) + "\")";
+		}
+
+		return null;
+	}
+
+	@Override
+	protected void writeJavaSourceCompatibility(IndentingWriter writer,
+			GradleBuild build) {
+		writer.println("java.sourceCompatibility = JavaVersion."
+				+ sourceCompatibilitiesToJavaVersion.get(build.getSourceCompatibility()));
+	}
+
+	@Override
+	protected void writeConfiguration(IndentingWriter writer, String configurationName,
+			ConfigurationCustomization configurationCustomization) {
+		if (configurationCustomization.getExtendsFrom().isEmpty()) {
+			writer.println(configurationName);
+		}
+		else {
+			writer.println(configurationName + " {");
+			writer.indented(() -> writer.println(String.format("extendsFrom(%s)",
+					configurationCustomization.getExtendsFrom().stream()
+							.map((c) -> "configurations." + c + ".get()")
+							.collect(Collectors.joining(", ")))));
+			writer.println("}");
+		}
+	}
+
+	@Override
+	protected String repositoryAsString(MavenRepository repository) {
+		if (MavenRepository.MAVEN_CENTRAL.equals(repository)) {
+			return "mavenCentral()";
+		}
+		return "maven { url = uri(\"" + repository.getUrl() + "\") }";
+	}
+
+	@Override
+	protected String dependencyAsString(Dependency dependency) {
+		String version = determineVersion(dependency.getVersion());
+		String type = dependency.getType();
+		return configurationForScope(dependency.getScope()) + "(\""
+				+ dependency.getGroupId() + ":" + dependency.getArtifactId()
+				+ ((version != null) ? ":" + version : "")
+				+ ((type != null) ? "@" + type : "") + "\")";
+	}
+
+	@Override
+	protected void writeExtraProperties(IndentingWriter writer,
+			Map<String, String> allProperties) {
+		writeCollection(writer, allProperties.entrySet(),
+				(e) -> getFormattedExtraProperty(e.getKey(), e.getValue()),
+				writer::println);
+	}
+
+	private String getFormattedExtraProperty(String key, String value) {
+		return String.format("extra[\"%s\"] = \"%s\"", key, value);
+	}
+
+	@Override
+	protected String bomAsString(BillOfMaterials bom, String version) {
+		return "mavenBom(\"" + bom.getGroupId() + ":" + bom.getArtifactId() + ":"
+				+ version + "\")";
+	}
+
+	@Override
+	protected String externalVersionPropertyAsString(String standardFormat) {
+		return "property(\"" + standardFormat + "\")";
+	}
+
+	@Override
+	protected void writeTasksWithTypeCustomizations(IndentingWriter writer,
+			GradleBuild build) {
+		Map<String, TaskCustomization> tasksWithTypeCustomizations = build
+				.getTasksWithTypeCustomizations();
+
+		tasksWithTypeCustomizations.forEach((typeName, customization) -> {
+			writer.println();
+			writer.println("tasks.withType<" + typeName + "> {");
+			writer.indented(() -> writeTaskCustomization(writer, customization));
+			writer.println("}");
+		});
+	}
+
+	@Override
+	protected void writeTaskCustomizations(IndentingWriter writer, GradleBuild build) {
+		Map<String, TaskCustomization> taskCustomizations = build.getTaskCustomizations();
+
+		taskCustomizations.forEach((name, customization) -> {
+			writer.println();
+			writer.println("tasks." + name + " {");
+			writer.indented(() -> writeTaskCustomization(writer, customization));
+			writer.println("}");
+		});
+	}
+
+	@Override
+	protected String invocationAsString(TaskCustomization.Invocation invocation) {
+		return invocation.getTarget() + "(" + String.join(", ", invocation.getArguments())
+				+ ")";
+	}
+
+	@Override
+	protected void writeProperty(IndentingWriter writer, String name, String value) {
+		if (value != null) {
+			writer.println(String.format("%s = \"%s\"", name, value));
+		}
+	}
+
+}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleSettingsWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleSettingsWriter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.buildsystem.gradle;
+
+/**
+ * A {@link GradleBuild} writer for {@code settings.gradle.kts}.
+ *
+ * @author Jean-Baptiste Nizet
+ */
+public class KotlinDslGradleSettingsWriter extends GradleSettingsWriter {
+
+	@Override
+	protected String wrapWithQuotes(String value) {
+		return "\"" + value + "\"";
+	}
+
+	@Override
+	protected String urlAssignment(String url) {
+		return "url = uri(\"" + url + "\")";
+	}
+
+}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/condition/ConditionalOnBuildSystem.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/condition/ConditionalOnBuildSystem.java
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.Conditional;
  * {@link BuildSystem}.
  *
  * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD })
@@ -38,6 +39,11 @@ import org.springframework.context.annotation.Conditional;
 @Conditional(OnBuildSystemCondition.class)
 public @interface ConditionalOnBuildSystem {
 
-	String value();
+	/**
+	 * The build system IDs that should be checked. The condition matches when at least
+	 * one build system matches.
+	 * @return the build system IDs to check
+	 */
+	String[] value();
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/condition/OnBuildSystemCondition.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/condition/OnBuildSystemCondition.java
@@ -16,7 +16,8 @@
 
 package io.spring.initializr.generator.condition;
 
-import io.spring.initializr.generator.buildsystem.BuildSystem;
+import java.util.Arrays;
+
 import io.spring.initializr.generator.project.ResolvedProjectDescription;
 
 import org.springframework.context.annotation.ConditionContext;
@@ -27,17 +28,18 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
  * {@link ConditionalOnBuildSystem}.
  *
  * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
  */
 class OnBuildSystemCondition extends ProjectGenerationCondition {
 
 	@Override
 	protected boolean matches(ResolvedProjectDescription projectDescription,
 			ConditionContext context, AnnotatedTypeMetadata metadata) {
-		String buildSystemId = (String) metadata
+		String[] buildSystemIds = (String[]) metadata
 				.getAllAnnotationAttributes(ConditionalOnBuildSystem.class.getName())
 				.getFirst("value");
-		BuildSystem buildSystem = BuildSystem.forId(buildSystemId);
-		return projectDescription.getBuildSystem().id().equals(buildSystem.id());
+		return Arrays.asList(buildSystemIds)
+				.contains(projectDescription.getBuildSystem().id());
 	}
 
 }

--- a/initializr-generator/src/main/resources/META-INF/spring.factories
+++ b/initializr-generator/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,6 @@
 io.spring.initializr.generator.buildsystem.BuildSystemFactory=\
 io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystemFactory,\
+io.spring.initializr.generator.buildsystem.gradle.GradleKtsBuildSystemFactory,\
 io.spring.initializr.generator.buildsystem.maven.MavenBuildSystemFactory
 
 io.spring.initializr.generator.language.LanguageFactory=\

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
@@ -30,12 +30,12 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link GradleBuildWriter}
+ * Tests for {@link GroovyDslGradleBuildWriter}
  *
  * @author Andy Wilkinson
  * @author Jean-Baptiste Nizet
  */
-class GradleBuildWriterTests {
+class GroovyDslGradleBuildWriterTests {
 
 	@Test
 	void gradleBuildWithImports() throws IOException {
@@ -426,7 +426,7 @@ class GradleBuildWriterTests {
 	}
 
 	private List<String> generateBuild(GradleBuild build) throws IOException {
-		GradleBuildWriter writer = new GradleBuildWriter();
+		GradleBuildWriter writer = new GroovyDslGradleBuildWriter();
 		StringWriter out = new StringWriter();
 		writer.writeTo(new IndentingWriter(out), build);
 		return Arrays.asList(out.toString().split("\\r?\\n"));

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleSettingsWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleSettingsWriterTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.buildsystem.gradle;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+
+import io.spring.initializr.generator.io.IndentingWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link GroovyDslGradleSettingsWriter}.
+ *
+ * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
+ */
+class GroovyDslGradleSettingsWriterTests {
+
+	@Test
+	void gradleBuildWithMavenCentralPluginRepository() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.pluginRepositories().add("maven-central");
+		List<String> lines = generateSettings(build);
+		assertThat(lines).containsSequence("pluginManagement {", "    repositories {",
+				"        mavenCentral()", "        gradlePluginPortal()", "    }", "}");
+	}
+
+	@Test
+	void gradleBuildWithPluginRepository() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.pluginRepositories().add("spring-milestones", "Spring Milestones",
+				"https://repo.spring.io/milestone");
+		List<String> lines = generateSettings(build);
+		assertThat(lines).containsSequence("pluginManagement {", "    repositories {",
+				"        maven { url 'https://repo.spring.io/milestone' }",
+				"        gradlePluginPortal()", "    }", "    resolutionStrategy {",
+				"        eachPlugin {",
+				"            if (requested.id.id == 'org.springframework.boot') {",
+				"                useModule(\"org.springframework.boot:spring-boot-gradle-plugin:${requested.version}\")",
+				"            }", "        }", "    }", "}");
+	}
+
+	@Test
+	void gradleBuildWithSnapshotPluginRepository() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.pluginRepositories().add("spring-snapshots", "Spring Snapshots",
+				"https://repo.spring.io/snapshot", true);
+		List<String> lines = generateSettings(build);
+		assertThat(lines).containsSequence("pluginManagement {", "    repositories {",
+				"        maven { url 'https://repo.spring.io/snapshot' }",
+				"        gradlePluginPortal()", "    }", "    resolutionStrategy {",
+				"        eachPlugin {",
+				"            if (requested.id.id == 'org.springframework.boot') {",
+				"                useModule(\"org.springframework.boot:spring-boot-gradle-plugin:${requested.version}\")",
+				"            }", "        }", "    }", "}");
+	}
+
+	@Test
+	void artifactIdShouldBeUsedAsTheRootProjectName() throws Exception {
+		GradleBuild build = new GradleBuild();
+		build.setArtifact("my-application");
+		List<String> lines = generateSettings(build);
+		assertThat(lines).containsSequence("rootProject.name = 'my-application'");
+	}
+
+	private List<String> generateSettings(GradleBuild build) throws IOException {
+		GradleSettingsWriter writer = new GroovyDslGradleSettingsWriter();
+		StringWriter out = new StringWriter();
+		writer.writeTo(new IndentingWriter(out), build);
+		return Arrays.asList(out.toString().split("\\r?\\n"));
+	}
+
+}

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriterTests.java
@@ -1,0 +1,457 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.buildsystem.gradle;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+
+import io.spring.initializr.generator.buildsystem.DependencyScope;
+import io.spring.initializr.generator.io.IndentingWriter;
+import io.spring.initializr.generator.version.VersionProperty;
+import io.spring.initializr.generator.version.VersionReference;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+/**
+ * Tests for {@link KotlinDslGradleBuildWriter}
+ *
+ * @author Jean-Baptiste Nizet
+ */
+class KotlinDslGradleBuildWriterTests {
+
+	@Test
+	void gradleBuildWithImports() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.addImportedType(
+				"org.springframework.boot.gradle.tasks.buildinfo.BuildInfo");
+		build.addImportedType("org.jetbrains.kotlin.gradle.tasks.KotlinCompile");
+		build.addImportedType("org.jetbrains.kotlin.gradle.tasks.KotlinCompile"); // same
+																					// import
+																					// added
+																					// twice
+
+		List<String> lines = generateBuild(build);
+		assertThat(lines.subList(0, 3)).containsExactly(
+				"import org.jetbrains.kotlin.gradle.tasks.KotlinCompile",
+				"import org.springframework.boot.gradle.tasks.buildinfo.BuildInfo", "");
+	}
+
+	@Test
+	void gradleBuildWithCoordinates() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.setGroup("com.example");
+		build.setVersion("1.0.1-SNAPSHOT");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).contains("group = \"com.example\"",
+				"version = \"1.0.1-SNAPSHOT\"");
+	}
+
+	@Test
+	void gradleBuildWithSourceCompatibility11() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.setSourceCompatibility("11");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).contains("java.sourceCompatibility = JavaVersion.VERSION_11");
+	}
+
+	@Test
+	void gradleBuildWithSourceCompatibility1Dot8() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.setSourceCompatibility("1.8");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).contains("java.sourceCompatibility = JavaVersion.VERSION_1_8");
+	}
+
+	@Test
+	void gradleBuildWithBuildscriptDependency() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.buildscript((buildscript) -> buildscript.dependency(
+				"org.springframework.boot:spring-boot-gradle-plugin:2.1.0.RELEASE"));
+
+		assertThatIllegalStateException().isThrownBy(() -> {
+			generateBuild(build);
+		});
+	}
+
+	@Test
+	void gradleBuildWithBuildscriptExtProperty() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.buildscript((buildscript) -> buildscript.ext("kotlinVersion", "\1.2.51\""));
+		assertThatIllegalStateException().isThrownBy(() -> {
+			generateBuild(build);
+		});
+	}
+
+	@Test
+	void gradleBuildWithBuiltinPlugin() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.addPlugin("java");
+		build.addPlugin("war");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("plugins {", "    java", "    war", "}");
+	}
+
+	@Test
+	void gradleBuildWithKotlinPluginAndVersion() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.addPlugin("org.jetbrains.kotlin.jvm", "1.3.21");
+		build.addPlugin("org.jetbrains.kotlin.plugin.spring", "1.3.21");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("plugins {",
+				"    kotlin(\"jvm\") version \"1.3.21\"",
+				"    kotlin(\"plugin.spring\") version \"1.3.21\"", "}");
+	}
+
+	@Test
+	void gradleBuildWithPluginAndVersion() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.addPlugin("org.springframework.boot", "2.1.0.RELEASE");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("plugins {",
+				"    id(\"org.springframework.boot\") version \"2.1.0.RELEASE\"", "}");
+	}
+
+	@Test
+	void gradleBuildWithApplyPlugin() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.applyPlugin("io.spring.dependency-management");
+
+		assertThatIllegalStateException().isThrownBy(() -> generateBuild(build));
+	}
+
+	@Test
+	void gradleBuildWithMavenCentralRepository() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.repositories().add("maven-central");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("repositories {", "    mavenCentral()", "}");
+	}
+
+	@Test
+	void gradleBuildWithRepository() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.repositories().add("spring-milestones", "Spring Milestones",
+				"https://repo.spring.io/milestone");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("repositories {",
+				"    maven { url = uri(\"https://repo.spring.io/milestone\") }", "}");
+	}
+
+	@Test
+	void gradleBuildWithSnapshotRepository() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.repositories().add("spring-snapshots", "Spring Snapshots",
+				"https://repo.spring.io/snapshot", true);
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("repositories {",
+				"    maven { url = uri(\"https://repo.spring.io/snapshot\") }", "}");
+	}
+
+	@Test
+	void gradleBuildWithPluginRepository() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.pluginRepositories().add("spring-milestones", "Spring Milestones",
+				"https://repo.spring.io/milestone");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).doesNotContain("repositories {");
+	}
+
+	@Test
+	void gradleBuildWithTaskWithTypesCustomizedWithNestedAssignments()
+			throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.customizeTasksWithType("KotlinCompile", (task) -> {
+			task.nested("kotlinOptions", (kotlinOptions) -> {
+				kotlinOptions.set("freeCompilerArgs", "listOf(\"-Xjsr305=strict\")");
+				kotlinOptions.set("jvmTarget", "\"1.8\"");
+			});
+		});
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("tasks.withType<KotlinCompile> {",
+				"    kotlinOptions {",
+				"        freeCompilerArgs = listOf(\"-Xjsr305=strict\")",
+				"        jvmTarget = \"1.8\"", "    }", "}");
+	}
+
+	@Test
+	void gradleBuildWithTaskCustomizedWithInvocations() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.customizeTask("asciidoctor", (task) -> {
+			task.invoke("inputs.dir", "snippetsDir");
+			task.invoke("dependsOn", "test");
+		});
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("tasks.asciidoctor {",
+				"    inputs.dir(snippetsDir)", "    dependsOn(test)", "}");
+	}
+
+	@Test
+	void gradleBuildWithTaskCustomizedWithAssignments() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.customizeTask("compileKotlin", (task) -> {
+			task.set("kotlinOptions.freeCompilerArgs", "listOf(\"-Xjsr305=strict\")");
+			task.set("kotlinOptions.jvmTarget", "\"1.8\"");
+		});
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("tasks.compileKotlin {",
+				"    kotlinOptions.freeCompilerArgs = listOf(\"-Xjsr305=strict\")",
+				"    kotlinOptions.jvmTarget = \"1.8\"", "}");
+	}
+
+	@Test
+	void gradleBuildWithTaskCustomizedWithNestedCustomization() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.customizeTask("compileKotlin", (compileKotlin) -> compileKotlin
+				.nested("kotlinOptions", (kotlinOptions) -> {
+					kotlinOptions.set("freeCompilerArgs", "listOf(\"-Xjsr305=strict\")");
+					kotlinOptions.set("jvmTarget", "\"1.8\"");
+				}));
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("tasks.compileKotlin {", "    kotlinOptions {",
+				"        freeCompilerArgs = listOf(\"-Xjsr305=strict\")",
+				"        jvmTarget = \"1.8\"", "    }", "}");
+	}
+
+	@Test
+	void gradleBuildWithExt() throws Exception {
+		GradleBuild build = new GradleBuild();
+		build.setGroup("com.example.demo");
+		build.setArtifact("demo");
+		build.ext("java.version", "1.8").ext("alpha", "a");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("extra[\"alpha\"] = \"a\"",
+				"extra[\"java.version\"] = \"1.8\"");
+	}
+
+	@Test
+	void gradleBuildWithVersionProperties() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.addVersionProperty(VersionProperty.of("version.property"), "1.2.3");
+		build.addInternalVersionProperty("internal.property", "4.5.6");
+		build.addExternalVersionProperty("external.property", "7.8.9");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("extra[\"external.property\"] = \"7.8.9\"",
+				"extra[\"internalProperty\"] = \"4.5.6\"",
+				"extra[\"versionProperty\"] = \"1.2.3\"");
+	}
+
+	@Test
+	void gradleBuildWithVersionedDependency() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("kotlin-stdlib", "org.jetbrains.kotlin",
+				"kotlin-stdlib-jdk8", VersionReference.ofProperty("kotlin.version"),
+				DependencyScope.COMPILE);
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("dependencies {",
+				"    implementation(\"org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}\")",
+				"}");
+	}
+
+	@Test
+	void gradleBuildWithExternalVersionedDependency() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("acme", "com.example", "acme",
+				VersionReference.ofProperty(VersionProperty.of("acme.version", false)),
+				DependencyScope.COMPILE);
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("dependencies {",
+				"    implementation(\"com.example:acme:${property(\"acme.version\")}\")",
+				"}");
+	}
+
+	@Test
+	void gradleBuildWithExtAndVersionProperties() throws Exception {
+		GradleBuild build = new GradleBuild();
+		build.setGroup("com.example.demo");
+		build.setArtifact("demo");
+		build.addInternalVersionProperty("test-version", "1.0");
+		build.addExternalVersionProperty("alpha-version", "0.1");
+		build.ext("myProperty", "42");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("extra[\"myProperty\"] = \"42\"",
+				"extra[\"alpha-version\"] = \"0.1\"", "extra[\"testVersion\"] = \"1.0\"");
+	}
+
+	@Test
+	void gradleBuildWithConfiguration() throws Exception {
+		GradleBuild build = new GradleBuild();
+		build.addConfiguration("developmentOnly");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("configurations {", "    developmentOnly",
+				"}");
+	}
+
+	@Test
+	void gradleBuildWithConfigurationCustomization() throws Exception {
+		GradleBuild build = new GradleBuild();
+		build.customizeConfiguration("developmentOnly",
+				(configuration) -> configuration.extendsFrom("compile"));
+		build.customizeConfiguration("developmentOnly",
+				(configuration) -> configuration.extendsFrom("testCompile"));
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("configurations {", "    developmentOnly {",
+				"        extendsFrom(configurations.compile.get(), configurations.testCompile.get())",
+				"    }", "}");
+	}
+
+	@Test
+	void gradleBuildWithConfigurationCustomizations() throws Exception {
+		GradleBuild build = new GradleBuild();
+		build.customizeConfiguration("developmentOnly",
+				(configuration) -> configuration.extendsFrom("compile"));
+		build.customizeConfiguration("testOnly",
+				(configuration) -> configuration.extendsFrom("testCompile"));
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("configurations {", "    developmentOnly {",
+				"        extendsFrom(configurations.compile.get())", "    }",
+				"    testOnly {", "        extendsFrom(configurations.testCompile.get())",
+				"    }", "}");
+	}
+
+	@Test
+	void gradleBuildWithAnnotationProcessorDependency() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("annotation-processor", "org.springframework.boot",
+				"spring-boot-configuration-processor",
+				DependencyScope.ANNOTATION_PROCESSOR);
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("dependencies {",
+				"    annotationProcessor(\"org.springframework.boot:spring-boot-configuration-processor\")",
+				"}");
+	}
+
+	@Test
+	void gradleBuildWithCompileDependency() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("root", "org.springframework.boot",
+				"spring-boot-starter", DependencyScope.COMPILE);
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("dependencies {",
+				"    implementation(\"org.springframework.boot:spring-boot-starter\")",
+				"}");
+	}
+
+	@Test
+	void gradleBuildWithRuntimeDependency() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("driver", "com.example", "jdbc-driver",
+				VersionReference.ofValue("1.0.0"), DependencyScope.RUNTIME);
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("dependencies {",
+				"    runtimeOnly(\"com.example:jdbc-driver:1.0.0\")", "}");
+	}
+
+	@Test
+	void gradleBuildWithProvidedRuntimeDependency() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("tomcat", "org.springframework.boot",
+				"spring-boot-starter-tomcat", DependencyScope.PROVIDED_RUNTIME);
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("dependencies {",
+				"    providedRuntime(\"org.springframework.boot:spring-boot-starter-tomcat\")",
+				"}");
+	}
+
+	@Test
+	void gradleBuildWithTestCompileDependency() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("test", "org.springframework.boot",
+				"spring-boot-starter-test", DependencyScope.TEST_COMPILE);
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("dependencies {",
+				"    testImplementation(\"org.springframework.boot:spring-boot-starter-test\")",
+				"}");
+	}
+
+	@Test
+	void gradleBuildWithCompileOnlyDependency() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("test", "org.springframework.boot",
+				"spring-boot-starter-foobar", DependencyScope.COMPILE_ONLY);
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("dependencies {",
+				"    compileOnly(\"org.springframework.boot:spring-boot-starter-foobar\")",
+				"}");
+	}
+
+	@Test
+	void gradleBuildWithTestRuntimeDependency() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("embed-mongo", "de.flapdoodle.embed",
+				"de.flapdoodle.embed.mongo", DependencyScope.TEST_RUNTIME);
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("dependencies {",
+				"    testRuntimeOnly(\"de.flapdoodle.embed:de.flapdoodle.embed.mongo\")",
+				"}");
+	}
+
+	@Test
+	void gradleBuildWithNonNullArtifactTypeDependency() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("root", "org.springframework.boot",
+				"spring-boot-starter", null, DependencyScope.COMPILE, "tar.gz");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("dependencies {",
+				"    implementation(\"org.springframework.boot:spring-boot-starter@tar.gz\")",
+				"}");
+	}
+
+	@Test
+	void gradleBuildWithBom() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.boms().add("test", "com.example", "my-project-dependencies",
+				VersionReference.ofValue("1.0.0.RELEASE"));
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("dependencyManagement {", "    imports {",
+				"        mavenBom(\"com.example:my-project-dependencies:1.0.0.RELEASE\")",
+				"    }", "}");
+	}
+
+	@Test
+	void gradleBuildWithOrderedBoms() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.boms().add("bom1", "com.example", "my-project-dependencies",
+				VersionReference.ofValue("1.0.0.RELEASE"), 5);
+		build.boms().add("bom2", "com.example", "root-dependencies",
+				VersionReference.ofProperty("root.version"), 2);
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("dependencyManagement {", "    imports {",
+				"        mavenBom(\"com.example:my-project-dependencies:1.0.0.RELEASE\")",
+				"        mavenBom(\"com.example:root-dependencies:${rootVersion}\")",
+				"    }", "}");
+	}
+
+	@Test
+	void gradleBuildWithCustomVersion() throws IOException {
+		GradleBuild build = new GradleBuild();
+		build.setVersion("1.2.4.RELEASE");
+		List<String> lines = generateBuild(build);
+		assertThat(lines).contains("version = \"1.2.4.RELEASE\"");
+	}
+
+	private List<String> generateBuild(GradleBuild build) throws IOException {
+		GradleBuildWriter writer = new KotlinDslGradleBuildWriter();
+		StringWriter out = new StringWriter();
+		writer.writeTo(new IndentingWriter(out), build);
+		return Arrays.asList(out.toString().split("\\r?\\n"));
+	}
+
+}

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleSettingsWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleSettingsWriterTests.java
@@ -27,11 +27,11 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link GradleSettingsWriter}.
+ * Tests for {@link KotlinDslGradleSettingsWriter}.
  *
- * @author Andy Wilkinson
+ * @author Jean-Baptiste Nizet
  */
-class GradleSettingsWriterTests {
+class KotlinDslGradleSettingsWriterTests {
 
 	@Test
 	void gradleBuildWithMavenCentralPluginRepository() throws IOException {
@@ -49,10 +49,10 @@ class GradleSettingsWriterTests {
 				"https://repo.spring.io/milestone");
 		List<String> lines = generateSettings(build);
 		assertThat(lines).containsSequence("pluginManagement {", "    repositories {",
-				"        maven { url 'https://repo.spring.io/milestone' }",
+				"        maven { url = uri(\"https://repo.spring.io/milestone\") }",
 				"        gradlePluginPortal()", "    }", "    resolutionStrategy {",
 				"        eachPlugin {",
-				"            if (requested.id.id == 'org.springframework.boot') {",
+				"            if (requested.id.id == \"org.springframework.boot\") {",
 				"                useModule(\"org.springframework.boot:spring-boot-gradle-plugin:${requested.version}\")",
 				"            }", "        }", "    }", "}");
 	}
@@ -64,10 +64,10 @@ class GradleSettingsWriterTests {
 				"https://repo.spring.io/snapshot", true);
 		List<String> lines = generateSettings(build);
 		assertThat(lines).containsSequence("pluginManagement {", "    repositories {",
-				"        maven { url 'https://repo.spring.io/snapshot' }",
+				"        maven { url = uri(\"https://repo.spring.io/snapshot\") }",
 				"        gradlePluginPortal()", "    }", "    resolutionStrategy {",
 				"        eachPlugin {",
-				"            if (requested.id.id == 'org.springframework.boot') {",
+				"            if (requested.id.id == \"org.springframework.boot\") {",
 				"                useModule(\"org.springframework.boot:spring-boot-gradle-plugin:${requested.version}\")",
 				"            }", "        }", "    }", "}");
 	}
@@ -77,11 +77,11 @@ class GradleSettingsWriterTests {
 		GradleBuild build = new GradleBuild();
 		build.setArtifact("my-application");
 		List<String> lines = generateSettings(build);
-		assertThat(lines).containsSequence("rootProject.name = 'my-application'");
+		assertThat(lines).containsSequence("rootProject.name = \"my-application\"");
 	}
 
 	private List<String> generateSettings(GradleBuild build) throws IOException {
-		GradleSettingsWriter writer = new GradleSettingsWriter();
+		GradleSettingsWriter writer = new KotlinDslGradleSettingsWriter();
 		StringWriter out = new StringWriter();
 		writer.writeTo(new IndentingWriter(out), build);
 		return Arrays.asList(out.toString().split("\\r?\\n"));

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/condition/ConditionalOnBuildSystemTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/condition/ConditionalOnBuildSystemTests.java
@@ -17,6 +17,7 @@
 package io.spring.initializr.generator.condition;
 
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
+import io.spring.initializr.generator.buildsystem.gradle.GradleKtsBuildSystem;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
 import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.test.project.ProjectAssetTester;
@@ -31,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link ConditionalOnBuildSystem}.
  *
  * @author Stephane Nicoll
+ * @author Jean-Baptiste Nizet
  */
 class ConditionalOnBuildSystemTests {
 
@@ -53,6 +55,14 @@ class ConditionalOnBuildSystemTests {
 		assertThat(bean).isEqualTo("testGradle");
 	}
 
+	@Test
+	void outcomeWithGradleKtsBuildSystem() {
+		ProjectDescription projectDescription = new ProjectDescription();
+		projectDescription.setBuildSystem(new GradleKtsBuildSystem());
+		String bean = outcomeFor(projectDescription);
+		assertThat(bean).isEqualTo("testGradle");
+	}
+
 	private String outcomeFor(ProjectDescription projectDescription) {
 		return this.projectTester.generate(projectDescription,
 				(projectGenerationContext) -> {
@@ -66,7 +76,7 @@ class ConditionalOnBuildSystemTests {
 	static class BuildSystemTestConfiguration {
 
 		@Bean
-		@ConditionalOnBuildSystem("gradle")
+		@ConditionalOnBuildSystem({ GradleBuildSystem.ID, GradleKtsBuildSystem.ID })
 		public String gradle() {
 			return "testGradle";
 		}

--- a/initializr-web/src/main/java/io/spring/initializr/web/project/MainController.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/project/MainController.java
@@ -29,7 +29,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.samskivert.mustache.Mustache;
 import io.spring.initializr.generator.buildsystem.BuildSystem;
-import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
+import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
 import io.spring.initializr.generator.io.template.TemplateRenderer;
 import io.spring.initializr.generator.project.ResolvedProjectDescription;
 import io.spring.initializr.generator.version.Version;
@@ -336,8 +336,7 @@ public class MainController extends AbstractInitializrController {
 
 	private static String getWrapperScript(ResolvedProjectDescription description) {
 		BuildSystem buildSystem = description.getBuildSystem();
-		String script = buildSystem.id().equals(GradleBuildSystem.ID) ? "gradlew"
-				: "mvnw";
+		String script = buildSystem.id().equals(MavenBuildSystem.ID) ? "mvnw" : "gradlew";
 		return (description.getBaseDirectory() != null)
 				? description.getBaseDirectory() + "/" + script : script;
 	}


### PR DESCRIPTION
refs #334

This adds support for the Gradle Kotlin DSL in initializr.
I've tried my best to split the changes into atomic commits that can be reviewed and applied one by one.

The first commit applies the recommended way of configuring Kotlin compilation tasks, as suggested in https://github.com/eskatos/start.spring.io-builds/blob/master/new-gradle-groovy-dsl/kotlin-boot-2-minimal/build.gradle

The remaining commits actually add a Gradle KTS build system.

Here are some things I'm not sure about, and that the reviewer should review carefully:

1. The recommended way in .kts build scripts to apply the dependency management plugin is to use the plugins block. This allows using idiomatic Kotlin configuration of the plugin. Unfortunately, it also requires to specify the dependency management plugin version. I used `metadata.getConfiguration().getEnv().getGradle().getDependencyManagementPluginVersion()` to get it, but I'm not actually sure this is correct: the value for this property in start.spring.io is not the one I expected (1.0.6.RELEASE). Maybe it isn't used for now. It is in the Kotlin gradle scripts, so if this is the right property, it will have to be updated. 
2. The Kotlin DSL is only usable with Gradle 5. But choosing an old Spring Boot platform version automatically applies Gradle 3 or Gradle 4. I'm not sure how best to handle the situation. I guess we could add some test that would throw an exception if such an invalid combination is chosen, but I don't know where to do that and which exception to throw (or if it's even the best way). Regarding tests (especially the `BuildComplianceTests`), I've simply disabled such invalid configurations.
3. I don't know exactly how the web part and the metadata work, but the code of the web module most probably needs some additional changes, and the code of start.spring.io too, in order to actually enable and configure the Gradle KTS build system. I guess some plugins might also have to adapt to this new build system.
