### PR TITLE
Avoid applying Kotlin JPA plugin

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJpaGradleBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJpaGradleBuildCustomizer.java
@@ -45,7 +45,6 @@ public class KotlinJpaGradleBuildCustomizer implements BuildCustomizer<GradleBui
 		if (this.buildMetadataResolver.hasFacet(build, "jpa")) {
 			build.addPlugin("org.jetbrains.kotlin.plugin.jpa",
 					this.settings.getVersion());
-			build.applyPlugin("kotlin-jpa");
 		}
 	}
 

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJpaGradleBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJpaGradleBuildCustomizerTests.java
@@ -39,7 +39,7 @@ class KotlinJpaGradleBuildCustomizerTests {
 		Dependency dependency = Dependency.withId("foo");
 		dependency.setFacets(Collections.singletonList("jpa"));
 		GradleBuild build = getCustomizedBuild(dependency);
-		assertThat(build.getAppliedPlugins()).contains("kotlin-jpa");
+		assertThat(build.getAppliedPlugins()).isEmpty();
 		assertThat(build.getPlugins()).hasSize(1);
 		assertThat(build.getPlugins().get(0).getId())
 				.isEqualTo("org.jetbrains.kotlin.plugin.jpa");
@@ -50,7 +50,6 @@ class KotlinJpaGradleBuildCustomizerTests {
 	void customizeWhenJpaFacetAbsentShouldNotAddKotlinJpaPlugin() {
 		Dependency dependency = Dependency.withId("foo");
 		GradleBuild build = getCustomizedBuild(dependency);
-		assertThat(build.getAppliedPlugins()).hasSize(0);
 		assertThat(build.getPlugins()).hasSize(0);
 	}
 


### PR DESCRIPTION
Applying plugins imperatively is discouraged, and since the plugin is added to the plugins block anyway, it is applied already.