### PR TITLE
Upgrade to gmavenplus-plugin 1.6.3

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/groovy/GroovyMavenBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/groovy/GroovyMavenBuildCustomizer.java
@@ -35,8 +35,8 @@ class GroovyMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
 		groovyMavenPlugin.execution(null,
 				(execution) -> execution.goal("addSources").goal("addTestSources")
 						.goal("generateStubs").goal("compile").goal("generateTestStubs")
-						.goal("compileTests").goal("removeStubs").goal("removeTestStubs"));
-
+						.goal("compileTests").goal("removeStubs")
+						.goal("removeTestStubs"));
 	}
 
 }

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/groovy/GroovyMavenBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/groovy/GroovyMavenBuildCustomizer.java
@@ -24,17 +24,18 @@ import io.spring.initializr.generator.spring.build.BuildCustomizer;
  * {@link BuildCustomizer} for Kotlin projects build with Maven.
  *
  * @author Stephane Nicoll
+ * @author Abdelghani Roussi
  */
 class GroovyMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
 
 	@Override
 	public void customize(MavenBuild build) {
 		MavenPlugin groovyMavenPlugin = build.plugin("org.codehaus.gmavenplus",
-				"gmavenplus-plugin", "1.5");
+				"gmavenplus-plugin", "1.6.3");
 		groovyMavenPlugin.execution(null,
 				(execution) -> execution.goal("addSources").goal("addTestSources")
-						.goal("generateStubs").goal("compile").goal("testGenerateStubs")
-						.goal("testCompile").goal("removeStubs").goal("removeTestStubs"));
+						.goal("generateStubs").goal("compile").goal("generateTestStubs")
+						.goal("compileTests").goal("removeStubs").goal("removeTestStubs"));
 
 	}
 

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/groovy/GroovyMavenBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/groovy/GroovyMavenBuildCustomizerTests.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link GroovyMavenBuildCustomizer}.
  *
  * @author Stephane Nicoll
+ * @author Abdelghani Roussi
  */
 class GroovyMavenBuildCustomizerTests {
 
@@ -39,14 +40,14 @@ class GroovyMavenBuildCustomizerTests {
 		MavenPlugin groovyPlugin = build.getPlugins().get(0);
 		assertThat(groovyPlugin.getGroupId()).isEqualTo("org.codehaus.gmavenplus");
 		assertThat(groovyPlugin.getArtifactId()).isEqualTo("gmavenplus-plugin");
-		assertThat(groovyPlugin.getVersion()).isEqualTo("1.5");
+		assertThat(groovyPlugin.getVersion()).isEqualTo("1.6.3");
 		Configuration configuration = groovyPlugin.getConfiguration();
 		assertThat(configuration).isNull();
 		assertThat(groovyPlugin.getExecutions()).hasSize(1);
 		Execution execution = groovyPlugin.getExecutions().get(0);
 		assertThat(execution.getId()).isNull();
 		assertThat(execution.getGoals()).containsExactly("addSources", "addTestSources",
-				"generateStubs", "compile", "testGenerateStubs", "testCompile",
+				"generateStubs", "compile", "generateTestStubs", "compileTests",
 				"removeStubs", "removeTestStubs");
 		assertThat(execution.getPhase()).isNull();
 		assertThat(execution.getConfiguration()).isNull();

--- a/initializr-generator-spring/src/test/resources/project/groovy/previous/pom.xml.gen
+++ b/initializr-generator-spring/src/test/resources/project/groovy/previous/pom.xml.gen
@@ -44,7 +44,7 @@
 			<plugin>
 				<groupId>org.codehaus.gmavenplus</groupId>
 				<artifactId>gmavenplus-plugin</artifactId>
-				<version>1.5</version>
+				<version>1.6.3</version>
 				<executions>
 					<execution>
 						<goals>
@@ -52,8 +52,8 @@
 							<goal>addTestSources</goal>
 							<goal>generateStubs</goal>
 							<goal>compile</goal>
-							<goal>testGenerateStubs</goal>
-							<goal>testCompile</goal>
+							<goal>generateTestStubs</goal>
+							<goal>compileTests</goal>
 							<goal>removeStubs</goal>
 							<goal>removeTestStubs</goal>
 						</goals>

--- a/initializr-generator-spring/src/test/resources/project/groovy/standard/pom.xml.gen
+++ b/initializr-generator-spring/src/test/resources/project/groovy/standard/pom.xml.gen
@@ -44,7 +44,7 @@
 			<plugin>
 				<groupId>org.codehaus.gmavenplus</groupId>
 				<artifactId>gmavenplus-plugin</artifactId>
-				<version>1.5</version>
+				<version>1.6.3</version>
 				<executions>
 					<execution>
 						<goals>
@@ -52,8 +52,8 @@
 							<goal>addTestSources</goal>
 							<goal>generateStubs</goal>
 							<goal>compile</goal>
-							<goal>testGenerateStubs</goal>
-							<goal>testCompile</goal>
+							<goal>generateTestStubs</goal>
+							<goal>compileTests</goal>
 							<goal>removeStubs</goal>
 							<goal>removeTestStubs</goal>
 						</goals>

--- a/initializr-generator-spring/src/test/resources/project/groovy/standard/war-pom.xml.gen
+++ b/initializr-generator-spring/src/test/resources/project/groovy/standard/war-pom.xml.gen
@@ -50,7 +50,7 @@
 			<plugin>
 				<groupId>org.codehaus.gmavenplus</groupId>
 				<artifactId>gmavenplus-plugin</artifactId>
-				<version>1.5</version>
+				<version>1.6.3</version>
 				<executions>
 					<execution>
 						<goals>
@@ -58,8 +58,8 @@
 							<goal>addTestSources</goal>
 							<goal>generateStubs</goal>
 							<goal>compile</goal>
-							<goal>testGenerateStubs</goal>
-							<goal>testCompile</goal>
+							<goal>generateTestStubs</goal>
+							<goal>compileTests</goal>
 							<goal>removeStubs</goal>
 							<goal>removeTestStubs</goal>
 						</goals>


### PR DESCRIPTION
This commit upgrades to gmavenplus-plugin 1.6.3
and changes the old goals with the new ones (version 1.6.3).

(testGenerateStubs to generateTestStubs, testCompile to compileTests)