### PR TITLE
Avoid writing plugin repositories section if no plugin repository is configured

### DIFF
--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/SettingsGradleProjectContributorTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/SettingsGradleProjectContributorTests.java
@@ -66,8 +66,7 @@ class SettingsGradleProjectContributorTests {
 		GradleBuild build = new GradleBuild();
 		build.repositories().add("maven-central");
 		List<String> lines = generateSettings(build);
-		assertThat(lines).containsSequence("pluginManagement {", "    repositories {",
-				"        gradlePluginPortal()", "    }", "}");
+		assertThat(lines).doesNotContain("pluginManagement");
 	}
 
 	private List<String> generateSettings(GradleBuild build) throws IOException {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleSettingsWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleSettingsWriter.java
@@ -34,6 +34,9 @@ public class GradleSettingsWriter {
 	}
 
 	private void writePluginManagement(IndentingWriter writer, GradleBuild build) {
+		if (build.pluginRepositories().isEmpty()) {
+			return;
+		}
 		writer.println("pluginManagement {");
 		writer.indented(() -> {
 			writeRepositories(writer, build);

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GradleSettingsWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GradleSettingsWriterTests.java
@@ -43,6 +43,13 @@ class GradleSettingsWriterTests {
 	}
 
 	@Test
+	void gradleBuildWithoutPluginRepository() throws IOException {
+		GradleBuild build = new GradleBuild();
+		List<String> lines = generateSettings(build);
+		assertThat(lines).doesNotContain("pluginManagement");
+	}
+
+	@Test
 	void gradleBuildWithPluginRepository() throws IOException {
 		GradleBuild build = new GradleBuild();
 		build.pluginRepositories().add("spring-milestones", "Spring Milestones",


### PR DESCRIPTION
Avoid writing plugin repositories section (in `settings.gradle`) if no plugin repository is configured using Gradle