### PR TITLE
Do not add snapshot repo unless absolutely necessary 

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/SpringBootVersionRepositoriesBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/SpringBootVersionRepositoriesBuildCustomizer.java
@@ -39,16 +39,17 @@ class SpringBootVersionRepositoriesBuildCustomizer implements BuildCustomizer<Bu
 		build.repositories().add("maven-central");
 		String qualifier = this.springBootVersion.getQualifier().getQualifier();
 		if (!"RELEASE".equals(qualifier)) {
-			MavenRepository snapshotRepository = new MavenRepository("spring-snapshots", "Spring Snapshots",
-					"https://repo.spring.io/snapshot", true);
-			build.repositories().add(snapshotRepository);
-			build.pluginRepositories().add(snapshotRepository);
+			if ("BUILD-SNAPSHOT".equals(qualifier)) {
+				MavenRepository snapshotRepository = new MavenRepository("spring-snapshots", "Spring Snapshots",
+						"https://repo.spring.io/snapshot", true);
+				build.repositories().add(snapshotRepository);
+				build.pluginRepositories().add(snapshotRepository);
+			}
 			MavenRepository milestoneRepository = new MavenRepository("spring-milestones", "Spring Milestones",
 					"https://repo.spring.io/milestone");
 			build.repositories().add(milestoneRepository);
 			build.pluginRepositories().add(milestoneRepository);
 		}
-
 	}
 
 }

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/SpringBootVersionRepositoriesBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/SpringBootVersionRepositoriesBuildCustomizerTests.java
@@ -41,17 +41,17 @@ class SpringBootVersionRepositoriesBuildCustomizerTests {
 	}
 
 	@Test
-	void addMavenCentralAndNonReleaseWhenUsingMilestone() {
+	void addMavenCentralAndMilestonesWhenUsingMilestone() {
 		MavenBuild build = new MavenBuild();
 		new SpringBootVersionRepositoriesBuildCustomizer(Version.parse("2.1.0.M1")).customize(build);
-		assertNonReleaseRepositories(build);
+		assertMavenCentralAndMilestonesRepositories(build);
 	}
 
 	@Test
-	void addMavenCentralAndNonReleaseWhenUsingReleaseCandidate() {
+	void addMavenCentralAndMilestonesWhenUsingReleaseCandidate() {
 		MavenBuild build = new MavenBuild();
 		new SpringBootVersionRepositoriesBuildCustomizer(Version.parse("2.1.0.RC1")).customize(build);
-		assertNonReleaseRepositories(build);
+		assertMavenCentralAndMilestonesRepositories(build);
 	}
 
 	@Test
@@ -70,6 +70,16 @@ class SpringBootVersionRepositoriesBuildCustomizerTests {
 				.hasFieldOrPropertyWithValue("url", "https://repo.spring.io/snapshot")
 				.hasFieldOrPropertyWithValue("snapshotsEnabled", true);
 		assertThat(repositories.get(2)).hasFieldOrPropertyWithValue("id", "spring-milestones")
+				.hasFieldOrPropertyWithValue("name", "Spring Milestones")
+				.hasFieldOrPropertyWithValue("url", "https://repo.spring.io/milestone")
+				.hasFieldOrPropertyWithValue("snapshotsEnabled", false);
+	}
+
+	private void assertMavenCentralAndMilestonesRepositories(MavenBuild build) {
+		List<MavenRepository> repositories = build.repositories().items().collect(Collectors.toList());
+		assertThat(repositories).hasSize(2);
+		assertThat(repositories.get(0)).isEqualTo(MavenRepository.MAVEN_CENTRAL);
+		assertThat(repositories.get(1)).hasFieldOrPropertyWithValue("id", "spring-milestones")
 				.hasFieldOrPropertyWithValue("name", "Spring Milestones")
 				.hasFieldOrPropertyWithValue("url", "https://repo.spring.io/milestone")
 				.hasFieldOrPropertyWithValue("snapshotsEnabled", false);

--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.gen
@@ -11,7 +11,6 @@ sourceCompatibility = '1.8'
 
 repositories {
 	mavenCentral()
-	maven { url 'https://repo.spring.io/snapshot' }
 	maven { url 'https://repo.spring.io/milestone' }
 }
 

--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.kts.gen
@@ -10,7 +10,6 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
 	mavenCentral()
-	maven { url = uri("https://repo.spring.io/snapshot") }
 	maven { url = uri("https://repo.spring.io/milestone") }
 }
 

--- a/initializr-generator-spring/src/test/resources/project/maven/repositories-milestone-pom.xml.gen
+++ b/initializr-generator-spring/src/test/resources/project/maven/repositories-milestone-pom.xml.gen
@@ -42,28 +42,12 @@
 
 	<repositories>
 		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
 			<url>https://repo.spring.io/milestone</url>
 		</repository>
 	</repositories>
 	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
 		<pluginRepository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>


### PR DESCRIPTION
This is a fix to GitHub issue #784. `SpringBootVersionRepositoriesBuildCustomizer` will check for dependencies that require `Spring Snapshots` and/or `Spring Milestones` and add them accordingly. Therefore any additional repository is added only when absolutely necessary.