### PR TITLE
Rename versionRange attribute to compatibilityRange

### DIFF
--- a/initializr-actuator/src/main/java/io/spring/initializr/actuate/info/BomRangesInfoContributor.java
+++ b/initializr-actuator/src/main/java/io/spring/initializr/actuate/info/BomRangesInfoContributor.java
@@ -45,7 +45,7 @@ public class BomRangesInfoContributor implements InfoContributor {
 			if (v.getMappings() != null && !v.getMappings().isEmpty()) {
 				Map<String, Object> bom = new LinkedHashMap<>();
 				v.getMappings().forEach((it) -> {
-					String requirement = "Spring Boot " + it.determineVersionRangeRequirement();
+					String requirement = "Spring Boot " + it.determineCompatibilityRangeRequirement();
 					bom.put(it.getVersion(), requirement);
 				});
 				details.put(k, bom);

--- a/initializr-actuator/src/test/java/io/spring/initializr/actuate/info/DependencyRangesInfoContributorTests.java
+++ b/initializr-actuator/src/test/java/io/spring/initializr/actuate/info/DependencyRangesInfoContributorTests.java
@@ -80,7 +80,7 @@ class DependencyRangesInfoContributorTests {
 	@Test
 	void dependencyNoMappingSimpleRange() {
 		Dependency dependency = Dependency.withId("foo", "com.example", "foo", "1.2.3.RELEASE");
-		dependency.setVersionRange("[1.1.0.RELEASE, 1.5.0.RELEASE)");
+		dependency.setCompatibilityRange("[1.1.0.RELEASE, 1.5.0.RELEASE)");
 		InitializrMetadata metadata = InitializrMetadataTestBuilder.withDefaults().addDependencyGroup("foo", dependency)
 				.build();
 		Info info = getInfo(metadata);

--- a/initializr-generator/src/test/resources/application-test-default.yml
+++ b/initializr-generator/src/test/resources/application-test-default.yml
@@ -11,10 +11,10 @@ initializr:
         versionProperty: my-api.version
         additionalBoms: ['my-api-dependencies-bom']
         mappings:
-          - versionRange: "[2.0.0.RELEASE,2.1.6.RELEASE)"
+          - compatibilityRange: "[2.0.0.RELEASE,2.1.6.RELEASE)"
             version: 1.0.0.RELEASE
             repositories: my-api-repo-1
-          - versionRange: "2.2.1.RELEASE"
+          - compatibilityRange: "2.2.1.RELEASE"
             version: 2.0.0.RELEASE
             repositories: my-api-repo-2
       my-api-dependencies-bom:
@@ -25,9 +25,9 @@ initializr:
     kotlin:
       defaultVersion: 1.2
       mappings:
-        - versionRange: "[1.5.0.RELEASE,2.0.0.M1)"
+        - compatibilityRange: "[1.5.0.RELEASE,2.0.0.M1)"
           version: 1.0
-        - versionRange: "[2.0.0.M1,2.1.0.M1)"
+        - compatibilityRange: "[2.0.0.M1,2.1.0.M1)"
           version: 1.1
     repositories:
       my-api-repo-1:
@@ -85,12 +85,12 @@ initializr:
           artifactId: biz
           scope: runtime
           version: 1.3.5
-          versionRange: 2.2.0.BUILD-SNAPSHOT
+          compatibilityRange: 2.2.0.BUILD-SNAPSHOT
         - name: Bur
           id: org.acme:bur
           version: 2.1.0
           scope: test
-          versionRange: "[2.1.4.RELEASE,2.2.0.BUILD-SNAPSHOT)"
+          compatibilityRange: "[2.1.4.RELEASE,2.2.0.BUILD-SNAPSHOT)"
         - name: My API
           id : my-api
           groupId: org.acme

--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/BillOfMaterials.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/BillOfMaterials.java
@@ -160,17 +160,17 @@ public class BillOfMaterials {
 		if (this.version == null && this.mappings.isEmpty()) {
 			throw new InvalidInitializrMetadataException("No version available for " + this);
 		}
-		updateVersionRange(VersionParser.DEFAULT);
+		updateCompatibilityRange(VersionParser.DEFAULT);
 	}
 
-	public void updateVersionRange(VersionParser versionParser) {
+	public void updateCompatibilityRange(VersionParser versionParser) {
 		this.mappings.forEach((it) -> {
 			try {
-				it.range = versionParser.parseRange(it.versionRange);
+				it.range = versionParser.parseRange(it.compatibilityRange);
 			}
 			catch (InvalidVersionException ex) {
 				throw new InvalidInitializrMetadataException(
-						"Invalid version range " + it.versionRange + " for " + this, ex);
+						"Invalid compatibility range " + it.compatibilityRange + " for " + this, ex);
 			}
 		});
 	}
@@ -229,7 +229,7 @@ public class BillOfMaterials {
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	public static class Mapping {
 
-		private String versionRange;
+		private String compatibilityRange;
 
 		/**
 		 * The groupId to use for this mapping or {@code null} to use the default.
@@ -254,12 +254,12 @@ public class BillOfMaterials {
 		}
 
 		private Mapping(String range, String version, String... repositories) {
-			this.versionRange = range;
+			this.compatibilityRange = range;
 			this.version = version;
 			this.repositories.addAll(Arrays.asList(repositories));
 		}
 
-		public String determineVersionRangeRequirement() {
+		public String determineCompatibilityRangeRequirement() {
 			return this.range.toString();
 		}
 
@@ -271,12 +271,12 @@ public class BillOfMaterials {
 			return new Mapping(range, version, repositories);
 		}
 
-		public String getVersionRange() {
-			return this.versionRange;
+		public String getCompatibilityRange() {
+			return this.compatibilityRange;
 		}
 
-		public void setVersionRange(String versionRange) {
-			this.versionRange = versionRange;
+		public void setCompatibilityRange(String compatibilityRange) {
+			this.compatibilityRange = compatibilityRange;
 		}
 
 		public String getGroupId() {
@@ -329,7 +329,8 @@ public class BillOfMaterials {
 
 		@Override
 		public String toString() {
-			return "Mapping [" + ((this.versionRange != null) ? "versionRange=" + this.versionRange + ", " : "")
+			return "Mapping ["
+					+ ((this.compatibilityRange != null) ? "compatibilityRange=" + this.compatibilityRange + ", " : "")
 					+ ((this.groupId != null) ? "groupId=" + this.groupId + ", " : "")
 					+ ((this.artifactId != null) ? "artifactId=" + this.artifactId + ", " : "")
 					+ ((this.version != null) ? "version=" + this.version + ", " : "")

--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/DependenciesCapability.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/DependenciesCapability.java
@@ -73,8 +73,8 @@ public class DependenciesCapability extends ServiceCapability<List<DependencyGro
 		index();
 	}
 
-	public void updateVersionRange(VersionParser versionParser) {
-		this.indexedDependencies.values().forEach((it) -> it.updateVersionRanges(versionParser));
+	public void updateCompatibilityRange(VersionParser versionParser) {
+		this.indexedDependencies.values().forEach((it) -> it.updateCompatibilityRange(versionParser));
 	}
 
 	@Override
@@ -92,8 +92,8 @@ public class DependenciesCapability extends ServiceCapability<List<DependencyGro
 		this.indexedDependencies.clear();
 		this.content.forEach((group) -> group.content.forEach((dependency) -> {
 			// Apply defaults
-			if (dependency.getVersionRange() == null && group.getVersionRange() != null) {
-				dependency.setVersionRange(group.getVersionRange());
+			if (dependency.getCompatibilityRange() == null && group.getCompatibilityRange() != null) {
+				dependency.setCompatibilityRange(group.getCompatibilityRange());
 			}
 			if (dependency.getBom() == null && group.getBom() != null) {
 				dependency.setBom(group.getBom());

--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/Dependency.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/Dependency.java
@@ -94,7 +94,7 @@ public class Dependency extends MetadataElement implements Describable {
 
 	private String description;
 
-	private String versionRange;
+	private String compatibilityRange;
 
 	@JsonIgnore
 	private String versionRequirement;
@@ -133,7 +133,7 @@ public class Dependency extends MetadataElement implements Describable {
 		this.mappings.addAll(dependency.mappings);
 		this.scope = dependency.scope;
 		this.description = dependency.description;
-		this.versionRange = dependency.versionRange;
+		this.compatibilityRange = dependency.compatibilityRange;
 		this.versionRequirement = dependency.versionRequirement;
 		this.range = dependency.range;
 		this.bom = dependency.bom;
@@ -151,8 +151,8 @@ public class Dependency extends MetadataElement implements Describable {
 		this.scope = scope;
 	}
 
-	public void setVersionRange(String versionRange) {
-		this.versionRange = (StringUtils.hasText(versionRange) ? versionRange.trim() : null);
+	public void setCompatibilityRange(String compatibilityRange) {
+		this.compatibilityRange = (StringUtils.hasText(compatibilityRange) ? compatibilityRange.trim() : null);
 	}
 
 	/**
@@ -209,28 +209,28 @@ public class Dependency extends MetadataElement implements Describable {
 			}
 		}
 		this.links.forEach(Link::resolve);
-		updateVersionRanges(VersionParser.DEFAULT);
+		updateCompatibilityRange(VersionParser.DEFAULT);
 	}
 
-	public void updateVersionRanges(VersionParser versionParser) {
-		if (this.versionRange != null) {
+	public void updateCompatibilityRange(VersionParser versionParser) {
+		if (this.compatibilityRange != null) {
 			try {
-				this.range = versionParser.parseRange(this.versionRange);
-				this.versionRange = this.range.toRangeString();
+				this.range = versionParser.parseRange(this.compatibilityRange);
+				this.compatibilityRange = this.range.toRangeString();
 				this.versionRequirement = this.range.toString();
 			}
 			catch (InvalidVersionException ex) {
-				throw new InvalidInitializrMetadataException("Invalid version range '" + this.versionRange + " for "
-						+ "dependency with id '" + getId() + "'", ex);
+				throw new InvalidInitializrMetadataException("Invalid compatibility range '" + this.compatibilityRange
+						+ " for " + "dependency with id '" + getId() + "'", ex);
 			}
 		}
 		this.mappings.forEach((it) -> {
 			try {
-				it.range = versionParser.parseRange(it.versionRange);
+				it.range = versionParser.parseRange(it.compatibilityRange);
 			}
 			catch (InvalidVersionException ex) {
 				throw new InvalidInitializrMetadataException(
-						"Invalid version range " + it.versionRange + " for " + this, ex);
+						"Invalid compatibility range " + it.compatibilityRange + " for " + this, ex);
 			}
 		});
 	}
@@ -431,8 +431,8 @@ public class Dependency extends MetadataElement implements Describable {
 		return this.scope;
 	}
 
-	public String getVersionRange() {
-		return this.versionRange;
+	public String getCompatibilityRange() {
+		return this.compatibilityRange;
 	}
 
 	@Override
@@ -476,14 +476,14 @@ public class Dependency extends MetadataElement implements Describable {
 	}
 
 	/**
-	 * Map several attribute of the dependency for a given version range.
+	 * Map several attribute of the dependency for a given compatibility range.
 	 */
 	public static class Mapping {
 
 		/**
-		 * The version range of this mapping.
+		 * The compatibility range of this mapping.
 		 */
-		private String versionRange;
+		private String compatibilityRange;
 
 		/**
 		 * The version to use for this mapping or {@code null} to use the default.
@@ -544,17 +544,17 @@ public class Dependency extends MetadataElement implements Describable {
 			return this.range;
 		}
 
-		public String getVersionRange() {
-			return this.versionRange;
+		public String getCompatibilityRange() {
+			return this.compatibilityRange;
 		}
 
-		public void setVersionRange(String versionRange) {
-			this.versionRange = versionRange;
+		public void setCompatibilityRange(String compatibilityRange) {
+			this.compatibilityRange = compatibilityRange;
 		}
 
 		public static Mapping create(String range, String groupId, String artifactId, String version, Boolean starter) {
 			Mapping mapping = new Mapping();
-			mapping.versionRange = range;
+			mapping.compatibilityRange = range;
 			mapping.groupId = groupId;
 			mapping.artifactId = artifactId;
 			mapping.version = version;

--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/DependencyGroup.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/DependencyGroup.java
@@ -31,7 +31,7 @@ public class DependencyGroup {
 	private String name;
 
 	@JsonIgnore
-	private String versionRange;
+	private String compatibilityRange;
 
 	@JsonIgnore
 	private String bom;
@@ -54,16 +54,16 @@ public class DependencyGroup {
 	}
 
 	/**
-	 * Return the default version range to apply to all dependencies of this group unless
-	 * specified otherwise.
-	 * @return the version range
+	 * Return the default compatibility range to apply to all dependencies of this group
+	 * unless specified otherwise.
+	 * @return the compatibility range
 	 */
-	public String getVersionRange() {
-		return this.versionRange;
+	public String getCompatibilityRange() {
+		return this.compatibilityRange;
 	}
 
-	public void setVersionRange(String versionRange) {
-		this.versionRange = versionRange;
+	public void setCompatibilityRange(String compatibilityRange) {
+		this.compatibilityRange = compatibilityRange;
 	}
 
 	/**

--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/InitializrConfiguration.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/InitializrConfiguration.java
@@ -413,11 +413,11 @@ public class InitializrConfiguration {
 			public void validate() {
 				VersionParser simpleParser = new VersionParser(Collections.emptyList());
 				this.mappings.forEach((m) -> {
-					if (m.versionRange == null) {
+					if (m.compatibilityRange == null) {
 						throw new InvalidInitializrMetadataException(
-								"VersionRange is mandatory, invalid version mapping for " + this);
+								"CompatibilityRange is mandatory, invalid version mapping for " + this);
 					}
-					m.range = simpleParser.parseRange(m.versionRange);
+					m.range = simpleParser.parseRange(m.compatibilityRange);
 					if (m.version == null) {
 						throw new InvalidInitializrMetadataException(
 								"Version is mandatory, invalid version mapping for " + this);
@@ -425,14 +425,14 @@ public class InitializrConfiguration {
 				});
 			}
 
-			public void updateVersionRange(VersionParser versionParser) {
+			public void updateCompatibilityRange(VersionParser versionParser) {
 				this.mappings.forEach((it) -> {
 					try {
-						it.range = versionParser.parseRange(it.versionRange);
+						it.range = versionParser.parseRange(it.compatibilityRange);
 					}
 					catch (InvalidVersionException ex) {
 						throw new InvalidInitializrMetadataException(
-								"Invalid version range " + it.versionRange + " for " + this, ex);
+								"Invalid compatibility range " + it.compatibilityRange + " for " + this, ex);
 					}
 				});
 			}
@@ -444,14 +444,14 @@ public class InitializrConfiguration {
 			}
 
 			/**
-			 * Map several attribute of the dependency for a given version range.
+			 * Map several attribute of the dependency for a given compatibility range.
 			 */
 			public static class Mapping {
 
 				/**
-				 * The version range of this mapping.
+				 * The compatibility range of this mapping.
 				 */
-				private String versionRange;
+				private String compatibilityRange;
 
 				/**
 				 * The kotlin version for this mapping.
@@ -461,12 +461,12 @@ public class InitializrConfiguration {
 				@JsonIgnore
 				private VersionRange range;
 
-				public String getVersionRange() {
-					return this.versionRange;
+				public String getCompatibilityRange() {
+					return this.compatibilityRange;
 				}
 
-				public void setVersionRange(String versionRange) {
-					this.versionRange = versionRange;
+				public void setCompatibilityRange(String compatibilityRange) {
+					this.compatibilityRange = compatibilityRange;
 				}
 
 				public String getVersion() {

--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/InitializrMetadata.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/InitializrMetadata.java
@@ -205,9 +205,9 @@ public class InitializrMetadata {
 		List<Version> bootVersions = this.bootVersions.getContent().stream().map((it) -> Version.parse(it.getId()))
 				.collect(Collectors.toList());
 		VersionParser parser = new VersionParser(bootVersions);
-		this.dependencies.updateVersionRange(parser);
-		this.configuration.getEnv().getBoms().values().forEach((it) -> it.updateVersionRange(parser));
-		this.configuration.getEnv().getKotlin().updateVersionRange(parser);
+		this.dependencies.updateCompatibilityRange(parser);
+		this.configuration.getEnv().getBoms().values().forEach((it) -> it.updateCompatibilityRange(parser));
+		this.configuration.getEnv().getKotlin().updateCompatibilityRange(parser);
 	}
 
 	/**

--- a/initializr-metadata/src/test/java/io/spring/initializr/metadata/BillOfMaterialsTests.java
+++ b/initializr-metadata/src/test/java/io/spring/initializr/metadata/BillOfMaterialsTests.java
@@ -130,12 +130,12 @@ class BillOfMaterialsTests {
 		bom.getMappings().add(BillOfMaterials.Mapping.create("[1.3.x.BUILD-SNAPSHOT,1.4.0.RELEASE)", "1.1.1-SNAPSHOT"));
 		bom.validate();
 
-		bom.updateVersionRange(new VersionParser(
+		bom.updateCompatibilityRange(new VersionParser(
 				Arrays.asList(Version.parse("1.3.8.RELEASE"), Version.parse("1.3.9.BUILD-SNAPSHOT"))));
 		assertThat(bom.resolve(Version.parse("1.3.8.RELEASE")).getVersion()).isEqualTo("1.1.0");
 		assertThat(bom.resolve(Version.parse("1.3.9.RELEASE")).getVersion()).isEqualTo("1.1.1-SNAPSHOT");
 
-		bom.updateVersionRange(new VersionParser(
+		bom.updateCompatibilityRange(new VersionParser(
 				Arrays.asList(Version.parse("1.3.9.RELEASE"), Version.parse("1.3.10.BUILD-SNAPSHOT"))));
 		assertThat(bom.resolve(Version.parse("1.3.8.RELEASE")).getVersion()).isEqualTo("1.1.0");
 		assertThat(bom.resolve(Version.parse("1.3.9.RELEASE")).getVersion()).isEqualTo("1.1.0");

--- a/initializr-metadata/src/test/java/io/spring/initializr/metadata/DependenciesCapabilityTests.java
+++ b/initializr-metadata/src/test/java/io/spring/initializr/metadata/DependenciesCapabilityTests.java
@@ -90,19 +90,19 @@ class DependenciesCapabilityTests {
 	}
 
 	@Test
-	void addDefaultVersionRange() {
+	void addDefaultCompatibilityRange() {
 		Dependency first = Dependency.withId("first");
 		Dependency second = Dependency.withId("second");
-		second.setVersionRange("1.2.3.RELEASE");
+		second.setCompatibilityRange("1.2.3.RELEASE");
 		DependencyGroup group = createDependencyGroup("test", first, second);
-		group.setVersionRange("1.2.0.RELEASE");
+		group.setCompatibilityRange("1.2.0.RELEASE");
 
 		DependenciesCapability capability = new DependenciesCapability();
 		capability.getContent().add(group);
 		capability.validate();
 
-		assertThat(capability.get("first").getVersionRange()).isEqualTo("1.2.0.RELEASE");
-		assertThat(capability.get("second").getVersionRange()).isEqualTo("1.2.3.RELEASE");
+		assertThat(capability.get("first").getCompatibilityRange()).isEqualTo("1.2.0.RELEASE");
+		assertThat(capability.get("second").getCompatibilityRange()).isEqualTo("1.2.3.RELEASE");
 	}
 
 	@Test

--- a/initializr-metadata/src/test/java/io/spring/initializr/metadata/DependencyTests.java
+++ b/initializr-metadata/src/test/java/io/spring/initializr/metadata/DependencyTests.java
@@ -107,7 +107,7 @@ class DependencyTests {
 	@Test
 	void invalidSpringBootRange() {
 		Dependency dependency = Dependency.withId("web");
-		dependency.setVersionRange("A.B.C");
+		dependency.setCompatibilityRange("A.B.C");
 		assertThatExceptionOfType(InvalidInitializrMetadataException.class).isThrownBy(dependency::resolve)
 				.withMessageContaining("A.B.C");
 	}
@@ -219,7 +219,7 @@ class DependencyTests {
 				Dependency.Mapping.create("[1.1.x.BUILD-SNAPSHOT, 1.2.0.RELEASE)", null, null, "0.2.0.RELEASE", null));
 		dependency.resolve();
 
-		dependency.updateVersionRanges(new VersionParser(
+		dependency.updateCompatibilityRange(new VersionParser(
 				Arrays.asList(Version.parse("1.1.5.RELEASE"), Version.parse("1.1.6.BUILD-SNAPSHOT"))));
 		validateResolvedWebDependency(dependency.resolve(Version.parse("1.1.5.RELEASE")), "org.springframework.boot",
 				"spring-boot-starter-web", "0.1.0.RELEASE", true);
@@ -228,7 +228,7 @@ class DependencyTests {
 		validateResolvedWebDependency(dependency.resolve(Version.parse("2.1.3.M1")), "org.springframework.boot",
 				"spring-boot-starter-web", "0.3.0.RELEASE", true); // default
 
-		dependency.updateVersionRanges(new VersionParser(
+		dependency.updateCompatibilityRange(new VersionParser(
 				Arrays.asList(Version.parse("1.1.6.RELEASE"), Version.parse("1.1.7.BUILD-SNAPSHOT"))));
 		validateResolvedWebDependency(dependency.resolve(Version.parse("1.1.5.RELEASE")), "org.springframework.boot",
 				"spring-boot-starter-web", "0.1.0.RELEASE", true);
@@ -278,17 +278,17 @@ class DependencyTests {
 	@Test
 	void resolveVersionWithX() {
 		Dependency dependency1 = Dependency.withId("foo1", "com.acme", "foo1", "0.3.0.RELEASE");
-		dependency1.setVersionRange("1.2.x.RELEASE");
+		dependency1.setCompatibilityRange("1.2.x.RELEASE");
 		dependency1.resolve();
-		assertThat(dependency1.getVersionRange()).isEqualTo("1.2.999.RELEASE");
+		assertThat(dependency1.getCompatibilityRange()).isEqualTo("1.2.999.RELEASE");
 	}
 
 	@Test
-	void resolveVersionRangeWithX() {
+	void resolveCompatibilityRangeWithX() {
 		Dependency dependency = Dependency.withId("foo1", "com.acme", "foo1", "0.3.0.RELEASE");
-		dependency.setVersionRange("[1.1.0.RELEASE, 1.2.x.RELEASE)");
+		dependency.setCompatibilityRange("[1.1.0.RELEASE, 1.2.x.RELEASE)");
 		dependency.resolve();
-		assertThat(dependency.getVersionRange()).isEqualTo("[1.1.0.RELEASE,1.2.999.RELEASE)");
+		assertThat(dependency.getCompatibilityRange()).isEqualTo("[1.1.0.RELEASE,1.2.999.RELEASE)");
 	}
 
 	private static void validateResolvedWebDependency(Dependency dependency, String expectedGroupId,

--- a/initializr-metadata/src/test/java/io/spring/initializr/metadata/InitializrConfigurationTests.java
+++ b/initializr-metadata/src/test/java/io/spring/initializr/metadata/InitializrConfigurationTests.java
@@ -196,9 +196,9 @@ class InitializrConfigurationTests {
 		assertThat(kotlin.resolveKotlinVersion(Version.parse("1.3.2.RELEASE"))).isEqualTo("1.2.3");
 	}
 
-	private Kotlin.Mapping createKotlinVersionMapping(String versionRange, String kotlinVersion) {
+	private Kotlin.Mapping createKotlinVersionMapping(String compatibilityRange, String kotlinVersion) {
 		Kotlin.Mapping mapping = new Kotlin.Mapping();
-		mapping.setVersionRange(versionRange);
+		mapping.setCompatibilityRange(compatibilityRange);
 		mapping.setVersion(kotlinVersion);
 		return mapping;
 	}

--- a/initializr-metadata/src/test/java/io/spring/initializr/metadata/InitializrMetadataTests.java
+++ b/initializr-metadata/src/test/java/io/spring/initializr/metadata/InitializrMetadataTests.java
@@ -92,7 +92,7 @@ class InitializrMetadataTests {
 	}
 
 	@Test
-	void invalidBomVersionRangeMapping() {
+	void invalidBomCompatibilityRangeMapping() {
 		InitializrMetadata metadata = initializeMetadata();
 		BillOfMaterials bom = BillOfMaterials.create("org.acme", "foo-bom");
 		bom.getMappings().add(Mapping.create("[1.2.0.RELEASE,1.3.0.M1)", "1.0.0"));
@@ -103,7 +103,7 @@ class InitializrMetadataTests {
 	}
 
 	@Test
-	void invalidBomVersionRangeMappingUnknownRepo() {
+	void invalidBomCompatibilityRangeMappingUnknownRepo() {
 		InitializrMetadata metadata = initializeMetadata();
 		BillOfMaterials bom = BillOfMaterials.create("org.acme", "foo-bom");
 		bom.getMappings().add(Mapping.create("[1.0.0.RELEASE,1.3.0.M1)", "1.0.0"));
@@ -117,7 +117,7 @@ class InitializrMetadataTests {
 	}
 
 	@Test
-	void invalidBomVersionRangeMappingUnknownAdditionalBom() {
+	void invalidBomCompatibilityRangeMappingUnknownAdditionalBom() {
 		InitializrMetadata metadata = initializeMetadata();
 		BillOfMaterials bom = BillOfMaterials.create("org.acme", "foo-bom");
 		bom.getMappings().add(Mapping.create("[1.0.0.RELEASE,1.3.0.M1)", "1.0.0"));
@@ -201,9 +201,9 @@ class InitializrMetadataTests {
 		metadata.getDependencies().getContent().add(group);
 	}
 
-	private Kotlin.Mapping createKotlinVersionMapping(String versionRange, String kotlinVersion) {
+	private Kotlin.Mapping createKotlinVersionMapping(String compatibilityRange, String kotlinVersion) {
 		Kotlin.Mapping mapping = new Kotlin.Mapping();
-		mapping.setVersionRange(versionRange);
+		mapping.setCompatibilityRange(compatibilityRange);
 		mapping.setVersion(kotlinVersion);
 		return mapping;
 	}

--- a/initializr-metadata/src/test/java/io/spring/initializr/metadata/support/MetadataBuildItemResolverTests.java
+++ b/initializr-metadata/src/test/java/io/spring/initializr/metadata/support/MetadataBuildItemResolverTests.java
@@ -57,7 +57,7 @@ class MetadataBuildItemResolverTests {
 	}
 
 	@Test
-	void resoleDependencyWithMatchingEntryAndVersionRange() {
+	void resoleDependencyWithMatchingEntryAndCompatibilityRange() {
 		InitializrMetadata metadata = new InitializrMetadata();
 		DependencyGroup group = DependencyGroup.create("test");
 		Dependency dependency = Dependency.withId("test-dep", "com.example", "test");
@@ -102,7 +102,7 @@ class MetadataBuildItemResolverTests {
 	}
 
 	@Test
-	void resoleBomWithMatchingEntryAndVersionRange() throws MalformedURLException {
+	void resoleBomWithMatchingEntryAndCompatibilityRange() throws MalformedURLException {
 		InitializrMetadata metadata = new InitializrMetadata();
 		BillOfMaterials bom = BillOfMaterials.create("com.example", "bom", "0.0.1");
 		bom.getMappings().add(BillOfMaterials.Mapping.create("[1.0.0.RELEASE, 2.0.0.RELEASE)", "1.0.0"));

--- a/initializr-metadata/src/test/resources/application-test-default.yml
+++ b/initializr-metadata/src/test/resources/application-test-default.yml
@@ -11,10 +11,10 @@ initializr:
         versionProperty: my-api.version
         additionalBoms: ['my-api-dependencies-bom']
         mappings:
-          - versionRange: "[2.0.0.RELEASE,2.1.6.RELEASE)"
+          - compatibilityRange: "[2.0.0.RELEASE,2.1.6.RELEASE)"
             version: 1.0.0.RELEASE
             repositories: my-api-repo-1
-          - versionRange: "2.2.1.RELEASE"
+          - compatibilityRange: "2.2.1.RELEASE"
             version: 2.0.0.RELEASE
             repositories: my-api-repo-2
       my-api-dependencies-bom:
@@ -25,9 +25,9 @@ initializr:
     kotlin:
       defaultVersion: 1.2
       mappings:
-        - versionRange: "[1.5.0.RELEASE,2.0.0.M1)"
+        - compatibilityRange: "[1.5.0.RELEASE,2.0.0.M1)"
           version: 1.0
-        - versionRange: "[2.0.0.M1,2.1.0.M1)"
+        - compatibilityRange: "[2.0.0.M1,2.1.0.M1)"
           version: 1.1
     repositories:
       my-api-repo-1:
@@ -85,12 +85,12 @@ initializr:
           artifactId: biz
           scope: runtime
           version: 1.3.5
-          versionRange: 2.2.0.BUILD-SNAPSHOT
+          compatibilityRange: 2.2.0.BUILD-SNAPSHOT
         - name: Bur
           id: org.acme:bur
           version: 2.1.0
           scope: test
-          versionRange: "[2.1.4.RELEASE,2.2.0.BUILD-SNAPSHOT)"
+          compatibilityRange: "[2.1.4.RELEASE,2.2.0.BUILD-SNAPSHOT)"
         - name: My API
           id : my-api
           groupId: org.acme

--- a/initializr-web/src/main/java/io/spring/initializr/web/mapper/InitializrMetadataV21JsonMapper.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/mapper/InitializrMetadataV21JsonMapper.java
@@ -55,8 +55,8 @@ public class InitializrMetadataV21JsonMapper extends InitializrMetadataV2JsonMap
 	@Override
 	protected ObjectNode mapDependency(Dependency dependency) {
 		ObjectNode content = mapValue(dependency);
-		if (dependency.getVersionRange() != null) {
-			content.put("versionRange", dependency.getVersionRange());
+		if (dependency.getCompatibilityRange() != null) {
+			content.put("versionRange", dependency.getCompatibilityRange());
 		}
 		if (dependency.getLinks() != null && !dependency.getLinks().isEmpty()) {
 			content.set("_links", LinkMapper.mapLinks(dependency.getLinks()));

--- a/initializr-web/src/main/java/io/spring/initializr/web/mapper/InitializrMetadataV2JsonMapper.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/mapper/InitializrMetadataV2JsonMapper.java
@@ -173,8 +173,8 @@ public class InitializrMetadataV2JsonMapper implements InitializrMetadataJsonMap
 	}
 
 	protected ObjectNode mapDependency(Dependency dependency) {
-		if (dependency.getVersionRange() == null) {
-			// only map the dependency if no versionRange is set
+		if (dependency.getCompatibilityRange() == null) {
+			// only map the dependency if no compatibilityRange is set
 			return mapValue(dependency);
 		}
 		return null;

--- a/initializr-web/src/test/java/io/spring/initializr/web/support/CommandLineHelpGeneratorTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/support/CommandLineHelpGeneratorTests.java
@@ -159,13 +159,13 @@ class CommandLineHelpGeneratorTests {
 	}
 
 	@Test
-	void generateCapabilitiesWithVersionRange() throws IOException {
+	void generateCapabilitiesWithCompatibilityRange() throws IOException {
 		Dependency first = Dependency.withId("first");
 		first.setDescription("first desc");
-		first.setVersionRange("1.2.0.RELEASE");
+		first.setCompatibilityRange("1.2.0.RELEASE");
 		Dependency second = Dependency.withId("second");
 		second.setDescription("second desc");
-		second.setVersionRange(" [1.2.0.RELEASE,1.3.0.M1)  ");
+		second.setCompatibilityRange(" [1.2.0.RELEASE,1.3.0.M1)  ");
 		InitializrMetadata metadata = InitializrMetadataTestBuilder.withDefaults()
 				.addDependencyGroup("test", first, second).build();
 		String content = this.generator.generateSpringBootCliCapabilities(metadata, "https://fake-service");

--- a/initializr-web/src/test/java/io/spring/initializr/web/support/DefaultDependencyMetadataProviderTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/support/DefaultDependencyMetadataProviderTests.java
@@ -37,10 +37,10 @@ class DefaultDependencyMetadataProviderTests {
 	@Test
 	void filterDependencies() {
 		Dependency first = Dependency.withId("first", "org.foo", "first");
-		first.setVersionRange("2.1.4.RELEASE");
+		first.setCompatibilityRange("2.1.4.RELEASE");
 		Dependency second = Dependency.withId("second", "org.foo", "second");
 		Dependency third = Dependency.withId("third", "org.foo", "third");
-		third.setVersionRange("2.1.8.RELEASE");
+		third.setCompatibilityRange("2.1.8.RELEASE");
 		InitializrMetadata metadata = InitializrMetadataTestBuilder.withDefaults()
 				.addDependencyGroup("test", first, second, third).build();
 		DependencyMetadata dependencyMetadata = this.provider.get(metadata, Version.parse("2.1.5.RELEASE"));

--- a/initializr-web/src/test/resources/metadata/config/test-default.json
+++ b/initializr-web/src/test/resources/metadata/config/test-default.json
@@ -40,11 +40,11 @@
       "defaultVersion": "1.2",
       "mappings": [
         {
-          "versionRange": "[1.5.0.RELEASE,2.0.0.M1)",
+          "compatibilityRange": "[1.5.0.RELEASE,2.0.0.M1)",
           "version": "1.0"
         },
         {
-          "versionRange": "[2.0.0.M1,2.1.0.M1)",
+          "compatibilityRange": "[2.0.0.M1,2.1.0.M1)",
           "version": "1.1"
         }
       ]
@@ -102,14 +102,14 @@
         ],
         "mappings": [
           {
-            "versionRange": "[2.0.0.RELEASE,2.1.6.RELEASE)",
+            "compatibilityRange": "[2.0.0.RELEASE,2.1.6.RELEASE)",
             "repositories": [
               "my-api-repo-1"
             ],
             "version": "1.0.0.RELEASE"
           },
           {
-            "versionRange": "2.2.1.RELEASE",
+            "compatibilityRange": "2.2.1.RELEASE",
             "repositories": [
               "my-api-repo-2"
             ],
@@ -219,7 +219,7 @@
             "name": "Biz",
             "scope": "runtime",
             "version": "1.3.5",
-            "versionRange": "2.2.0.BUILD-SNAPSHOT"
+            "compatibilityRange": "2.2.0.BUILD-SNAPSHOT"
           },
           {
             "starter": true,
@@ -229,7 +229,7 @@
             "name": "Bur",
             "scope": "test",
             "version": "2.1.0",
-            "versionRange": "[2.1.4.RELEASE,2.2.0.BUILD-SNAPSHOT)"
+            "compatibilityRange": "[2.1.4.RELEASE,2.2.0.BUILD-SNAPSHOT)"
           },
           {
             "starter": true,


### PR DESCRIPTION
This is a fix to GitHub issue #418. The versionRange attribute has been renamed to compatibilityRange.