### PR TITLE
Add support for removing build plugins

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleConfigurationBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleConfigurationBuildCustomizer.java
@@ -33,7 +33,7 @@ public class GradleConfigurationBuildCustomizer implements BuildCustomizer<Gradl
 	public void customize(GradleBuild build) {
 		boolean providedRuntimeUsed = build.dependencies().items()
 				.anyMatch((dependency) -> DependencyScope.PROVIDED_RUNTIME.equals(dependency.getScope()));
-		boolean war = build.getPlugins().stream().anyMatch((plugin) -> plugin.getId().equals("war"));
+		boolean war = build.plugins().values().anyMatch((plugin) -> plugin.getId().equals("war"));
 		if (providedRuntimeUsed && !war) {
 			build.addConfiguration("providedRuntime");
 		}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfiguration.java
@@ -90,20 +90,20 @@ public class GradleProjectGenerationConfiguration {
 	@Bean
 	@ConditionalOnLanguage(JavaLanguage.ID)
 	public BuildCustomizer<GradleBuild> javaPluginContributor() {
-		return (build) -> build.addPlugin("java");
+		return (build) -> build.plugins().add("java");
 	}
 
 	@Bean
 	@ConditionalOnPackaging(WarPackaging.ID)
 	public BuildCustomizer<GradleBuild> warPluginContributor() {
-		return (build) -> build.addPlugin("war");
+		return (build) -> build.plugins().add("war");
 	}
 
 	@Bean
 	@ConditionalOnPlatformVersion("2.0.0.M1")
 	@ConditionalOnBuildSystem(id = GradleBuildSystem.ID, dialect = GradleBuildSystem.DIALECT_GROOVY)
 	public BuildCustomizer<GradleBuild> applyDependencyManagementPluginContributor() {
-		return (build) -> build.applyPlugin("io.spring.dependency-management");
+		return (build) -> build.plugins().apply("io.spring.dependency-management");
 	}
 
 	@Bean
@@ -149,7 +149,7 @@ public class GradleProjectGenerationConfiguration {
 				build.buildscript(
 						(buildscript) -> buildscript.dependency("org.springframework.boot:spring-boot-gradle-plugin:"
 								+ projectDescription.getPlatformVersion()));
-				build.applyPlugin("org.springframework.boot");
+				build.plugins().apply("org.springframework.boot");
 			};
 		}
 
@@ -206,8 +206,8 @@ public class GradleProjectGenerationConfiguration {
 
 		@Bean
 		BuildCustomizer<GradleBuild> springBootPluginContributor(ResolvedProjectDescription projectDescription) {
-			return (build) -> build.addPlugin("org.springframework.boot",
-					projectDescription.getPlatformVersion().toString());
+			return (build) -> build.plugins().add("org.springframework.boot",
+					(plugin) -> plugin.setVersion(projectDescription.getPlatformVersion().toString()));
 		}
 
 		@Bean
@@ -247,9 +247,10 @@ public class GradleProjectGenerationConfiguration {
 		BuildCustomizer<GradleBuild> springBootPluginContributor(ResolvedProjectDescription projectDescription,
 				InitializrMetadata metadata) {
 			return (build) -> {
-				build.addPlugin("org.springframework.boot", projectDescription.getPlatformVersion().toString());
-				build.addPlugin("io.spring.dependency-management",
-						metadata.getConfiguration().getEnv().getGradle().getDependencyManagementPluginVersion());
+				build.plugins().add("org.springframework.boot",
+						(plugin) -> plugin.setVersion(projectDescription.getPlatformVersion().toString()));
+				build.plugins().add("io.spring.dependency-management", (plugin) -> plugin.setVersion(
+						metadata.getConfiguration().getEnv().getGradle().getDependencyManagementPluginVersion()));
 			};
 		}
 

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/maven/DefaultMavenBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/maven/DefaultMavenBuildCustomizer.java
@@ -46,7 +46,7 @@ public class DefaultMavenBuildCustomizer implements BuildCustomizer<MavenBuild> 
 		build.setName(this.projectDescription.getName());
 		build.setDescription(this.projectDescription.getDescription());
 		build.setProperty("java.version", this.projectDescription.getLanguage().jvmVersion());
-		build.plugin("org.springframework.boot", "spring-boot-maven-plugin");
+		build.plugins().add("org.springframework.boot", "spring-boot-maven-plugin");
 
 		Maven maven = this.metadata.getConfiguration().getEnv().getMaven();
 		String springBootVersion = this.projectDescription.getPlatformVersion().toString();

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/groovy/GroovyMavenBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/groovy/GroovyMavenBuildCustomizer.java
@@ -17,7 +17,6 @@
 package io.spring.initializr.generator.spring.code.groovy;
 
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
-import io.spring.initializr.generator.buildsystem.maven.MavenPlugin;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 
 /**
@@ -29,11 +28,13 @@ class GroovyMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
 
 	@Override
 	public void customize(MavenBuild build) {
-		MavenPlugin groovyMavenPlugin = build.plugin("org.codehaus.gmavenplus", "gmavenplus-plugin", "1.6.3");
-		groovyMavenPlugin.execution(null,
-				(execution) -> execution.goal("addSources").goal("addTestSources").goal("generateStubs").goal("compile")
-						.goal("generateTestStubs").goal("compileTests").goal("removeStubs").goal("removeTestStubs"));
-
+		build.plugins().add("org.codehaus.gmavenplus", "gmavenplus-plugin", (groovyMavenPlugin) -> {
+			groovyMavenPlugin.setVersion("1.6.3");
+			groovyMavenPlugin.execution(null,
+					(execution) -> execution.goal("addSources").goal("addTestSources").goal("generateStubs")
+							.goal("compile").goal("generateTestStubs").goal("compileTests").goal("removeStubs")
+							.goal("removeTestStubs"));
+		});
 	}
 
 }

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinGradleBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinGradleBuildCustomizer.java
@@ -38,8 +38,9 @@ abstract class KotlinGradleBuildCustomizer implements BuildCustomizer<GradleBuil
 
 	@Override
 	public void customize(GradleBuild build) {
-		build.addPlugin("org.jetbrains.kotlin.jvm", this.settings.getVersion());
-		build.addPlugin("org.jetbrains.kotlin.plugin.spring", this.settings.getVersion());
+		build.plugins().add("org.jetbrains.kotlin.jvm", (plugin) -> plugin.setVersion(this.settings.getVersion()));
+		build.plugins().add("org.jetbrains.kotlin.plugin.spring",
+				(plugin) -> plugin.setVersion(this.settings.getVersion()));
 		build.customizeTasksWithType("org.jetbrains.kotlin.gradle.tasks.KotlinCompile",
 				(compile) -> customizeKotlinOptions(this.settings, compile));
 	}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJpaGradleBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJpaGradleBuildCustomizer.java
@@ -42,7 +42,8 @@ public class KotlinJpaGradleBuildCustomizer implements BuildCustomizer<GradleBui
 	@Override
 	public void customize(GradleBuild build) {
 		if (this.buildMetadataResolver.hasFacet(build, "jpa")) {
-			build.addPlugin("org.jetbrains.kotlin.plugin.jpa", this.settings.getVersion());
+			build.plugins().add("org.jetbrains.kotlin.plugin.jpa",
+					(plugin) -> plugin.setVersion(this.settings.getVersion()));
 		}
 	}
 

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJpaMavenBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJpaMavenBuildCustomizer.java
@@ -17,7 +17,6 @@
 package io.spring.initializr.generator.spring.code.kotlin;
 
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
-import io.spring.initializr.generator.buildsystem.maven.MavenPlugin;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 import io.spring.initializr.generator.spring.build.BuildMetadataResolver;
 import io.spring.initializr.metadata.InitializrMetadata;
@@ -40,10 +39,11 @@ public class KotlinJpaMavenBuildCustomizer implements BuildCustomizer<MavenBuild
 	@Override
 	public void customize(MavenBuild build) {
 		if (this.buildMetadataResolver.hasFacet(build, "jpa")) {
-			MavenPlugin kotlinPlugin = build.plugin("org.jetbrains.kotlin", "kotlin-maven-plugin");
-			kotlinPlugin.configuration((configuration) -> configuration.configure("compilerPlugins",
-					(compilerPlugins) -> compilerPlugins.add("plugin", "jpa")));
-			kotlinPlugin.dependency("org.jetbrains.kotlin", "kotlin-maven-noarg", "${kotlin.version}");
+			build.plugins().add("org.jetbrains.kotlin", "kotlin-maven-plugin", (kotlinPlugin) -> {
+				kotlinPlugin.configuration((configuration) -> configuration.configure("compilerPlugins",
+						(compilerPlugins) -> compilerPlugins.add("plugin", "jpa")));
+				kotlinPlugin.dependency("org.jetbrains.kotlin", "kotlin-maven-noarg", "${kotlin.version}");
+			});
 		}
 	}
 

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenBuildCustomizer.java
@@ -17,7 +17,6 @@
 package io.spring.initializr.generator.spring.code.kotlin;
 
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
-import io.spring.initializr.generator.buildsystem.maven.MavenPlugin;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 
 /**
@@ -42,13 +41,15 @@ class KotlinMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
 		build.setProperty("kotlin.version", this.settings.getVersion());
 		build.setSourceDirectory("${project.basedir}/src/main/kotlin");
 		build.setTestSourceDirectory("${project.basedir}/src/test/kotlin");
-		MavenPlugin kotlinMavenPlugin = build.plugin("org.jetbrains.kotlin", "kotlin-maven-plugin");
-		kotlinMavenPlugin.configuration((configuration) -> {
-			configuration.configure("args",
-					(args) -> this.settings.getCompilerArgs().forEach((arg) -> args.add("arg", arg)));
-			configuration.configure("compilerPlugins", (compilerPlugins) -> compilerPlugins.add("plugin", "spring"));
+		build.plugins().add("org.jetbrains.kotlin", "kotlin-maven-plugin", (kotlinMavenPlugin) -> {
+			kotlinMavenPlugin.configuration((configuration) -> {
+				configuration.configure("args",
+						(args) -> this.settings.getCompilerArgs().forEach((arg) -> args.add("arg", arg)));
+				configuration.configure("compilerPlugins",
+						(compilerPlugins) -> compilerPlugins.add("plugin", "spring"));
+			});
+			kotlinMavenPlugin.dependency("org.jetbrains.kotlin", "kotlin-maven-allopen", "${kotlin.version}");
 		});
-		kotlinMavenPlugin.dependency("org.jetbrains.kotlin", "kotlin-maven-allopen", "${kotlin.version}");
 	}
 
 }

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenFullBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenFullBuildCustomizer.java
@@ -17,7 +17,6 @@
 package io.spring.initializr.generator.spring.code.kotlin;
 
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
-import io.spring.initializr.generator.buildsystem.maven.MavenPlugin;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 
 /**
@@ -39,17 +38,21 @@ class KotlinMavenFullBuildCustomizer implements BuildCustomizer<MavenBuild> {
 		build.setProperty("kotlin.version", this.settings.getVersion());
 		build.setSourceDirectory("${project.basedir}/src/main/kotlin");
 		build.setTestSourceDirectory("${project.basedir}/src/test/kotlin");
-		MavenPlugin kotlinMavenPlugin = build.plugin("org.jetbrains.kotlin", "kotlin-maven-plugin",
-				"${kotlin.version}");
-		kotlinMavenPlugin.configuration((configuration) -> {
-			configuration.configure("args",
-					(args) -> this.settings.getCompilerArgs().forEach((arg) -> args.add("arg", arg)));
-			configuration.configure("compilerPlugins", (compilerPlugins) -> compilerPlugins.add("plugin", "spring"));
-			configuration.add("jvmTarget", this.settings.getJvmTarget());
+		build.plugins().add("org.jetbrains.kotlin", "kotlin-maven-plugin", (kotlinMavenPlugin) -> {
+			kotlinMavenPlugin.setVersion("${kotlin.version}");
+			kotlinMavenPlugin.configuration((configuration) -> {
+				configuration.configure("args",
+						(args) -> this.settings.getCompilerArgs().forEach((arg) -> args.add("arg", arg)));
+				configuration.configure("compilerPlugins",
+						(compilerPlugins) -> compilerPlugins.add("plugin", "spring"));
+				configuration.add("jvmTarget", this.settings.getJvmTarget());
+			});
+			kotlinMavenPlugin.execution("compile", (compile) -> compile.phase("compile").goal("compile"));
+			kotlinMavenPlugin.execution("test-compile",
+					(compile) -> compile.phase("test-compile").goal("test-compile"));
+			kotlinMavenPlugin.dependency("org.jetbrains.kotlin", "kotlin-maven-allopen", "${kotlin.version}");
 		});
-		kotlinMavenPlugin.execution("compile", (compile) -> compile.phase("compile").goal("compile"));
-		kotlinMavenPlugin.execution("test-compile", (compile) -> compile.phase("test-compile").goal("test-compile"));
-		kotlinMavenPlugin.dependency("org.jetbrains.kotlin", "kotlin-maven-allopen", "${kotlin.version}");
+
 	}
 
 }

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleBuildProjectContributorTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleBuildProjectContributorTests.java
@@ -96,7 +96,7 @@ class GradleBuildProjectContributorTests {
 		IndentingWriterFactory indentingWriterFactory = IndentingWriterFactory.create(new SimpleIndentStrategy("    "),
 				(factory) -> factory.indentingStrategy("gradle", new SimpleIndentStrategy("  ")));
 		GradleBuild build = new GradleBuild();
-		build.addPlugin("java");
+		build.plugins().add("java");
 		List<String> lines = generateBuild(kotlinDslGradleBuildProjectContributor(build, indentingWriterFactory));
 		assertThat(lines).containsSequence("plugins {", "  java", "}");
 	}

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleConfigurationBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleConfigurationBuildCustomizerTests.java
@@ -41,7 +41,7 @@ class GradleConfigurationBuildCustomizerTests {
 	@Test
 	void providedRuntimeConfigurationIsNotAddedWithWarProject() {
 		GradleBuild build = new GradleBuild();
-		build.addPlugin("war");
+		build.plugins().add("war");
 		build.dependencies().add("lib", "com.example", "lib", DependencyScope.COMPILE);
 		build.dependencies().add("servlet", "javax.servlet", "servlet-api", DependencyScope.PROVIDED_RUNTIME);
 		customize(build);

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/maven/DefaultMavenBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/maven/DefaultMavenBuildCustomizerTests.java
@@ -19,7 +19,6 @@ package io.spring.initializr.generator.spring.build.maven;
 import io.spring.initializr.generator.buildsystem.BomContainer;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
 import io.spring.initializr.generator.buildsystem.maven.MavenParent;
-import io.spring.initializr.generator.buildsystem.maven.MavenPlugin;
 import io.spring.initializr.generator.language.java.JavaLanguage;
 import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.project.ResolvedProjectDescription;
@@ -54,11 +53,12 @@ class DefaultMavenBuildCustomizerTests {
 	void customizeRegisterSpringBootPlugin() {
 		InitializrMetadata metadata = InitializrMetadataTestBuilder.withDefaults().build();
 		MavenBuild build = customizeBuild(metadata);
-		assertThat(build.getPlugins()).hasSize(1);
-		MavenPlugin mavenPlugin = build.getPlugins().get(0);
-		assertThat(mavenPlugin.getGroupId()).isEqualTo("org.springframework.boot");
-		assertThat(mavenPlugin.getArtifactId()).isEqualTo("spring-boot-maven-plugin");
-		assertThat(mavenPlugin.getVersion()).isNull();
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((mavenPlugin) -> {
+			assertThat(mavenPlugin.getGroupId()).isEqualTo("org.springframework.boot");
+			assertThat(mavenPlugin.getArtifactId()).isEqualTo("spring-boot-maven-plugin");
+			assertThat(mavenPlugin.getVersion()).isNull();
+		});
 	}
 
 	@Test

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/groovy/GroovyGradleBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/groovy/GroovyGradleBuildCustomizerTests.java
@@ -32,8 +32,8 @@ class GroovyGradleBuildCustomizerTests {
 	void groovyPluginIsConfigured() {
 		GradleBuild build = new GradleBuild();
 		new GroovyGradleBuildCustomizer().customize(build);
-		assertThat(build.getPlugins()).hasSize(1);
-		assertThat(build.getPlugins().get(0).getId()).isEqualTo("groovy");
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((plugin) -> assertThat(plugin.getId()).isEqualTo("groovy"));
 	}
 
 }

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/groovy/GroovyMavenBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/groovy/GroovyMavenBuildCustomizerTests.java
@@ -17,7 +17,6 @@
 package io.spring.initializr.generator.spring.code.groovy;
 
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
-import io.spring.initializr.generator.buildsystem.maven.MavenPlugin;
 import io.spring.initializr.generator.buildsystem.maven.MavenPlugin.Configuration;
 import io.spring.initializr.generator.buildsystem.maven.MavenPlugin.Execution;
 import org.junit.jupiter.api.Test;
@@ -35,20 +34,21 @@ class GroovyMavenBuildCustomizerTests {
 	void groovyMavenPluginIsConfigured() {
 		MavenBuild build = new MavenBuild();
 		new GroovyMavenBuildCustomizer().customize(build);
-		assertThat(build.getPlugins()).hasSize(1);
-		MavenPlugin groovyPlugin = build.getPlugins().get(0);
-		assertThat(groovyPlugin.getGroupId()).isEqualTo("org.codehaus.gmavenplus");
-		assertThat(groovyPlugin.getArtifactId()).isEqualTo("gmavenplus-plugin");
-		assertThat(groovyPlugin.getVersion()).isEqualTo("1.6.3");
-		Configuration configuration = groovyPlugin.getConfiguration();
-		assertThat(configuration).isNull();
-		assertThat(groovyPlugin.getExecutions()).hasSize(1);
-		Execution execution = groovyPlugin.getExecutions().get(0);
-		assertThat(execution.getId()).isNull();
-		assertThat(execution.getGoals()).containsExactly("addSources", "addTestSources", "generateStubs", "compile",
-				"generateTestStubs", "compileTests", "removeStubs", "removeTestStubs");
-		assertThat(execution.getPhase()).isNull();
-		assertThat(execution.getConfiguration()).isNull();
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((groovyPlugin) -> {
+			assertThat(groovyPlugin.getGroupId()).isEqualTo("org.codehaus.gmavenplus");
+			assertThat(groovyPlugin.getArtifactId()).isEqualTo("gmavenplus-plugin");
+			assertThat(groovyPlugin.getVersion()).isEqualTo("1.6.3");
+			Configuration configuration = groovyPlugin.getConfiguration();
+			assertThat(configuration).isNull();
+			assertThat(groovyPlugin.getExecutions()).hasSize(1);
+			Execution execution = groovyPlugin.getExecutions().get(0);
+			assertThat(execution.getId()).isNull();
+			assertThat(execution.getGoals()).containsExactly("addSources", "addTestSources", "generateStubs", "compile",
+					"generateTestStubs", "compileTests", "removeStubs", "removeTestStubs");
+			assertThat(execution.getPhase()).isNull();
+			assertThat(execution.getConfiguration()).isNull();
+		});
 	}
 
 }

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/GroovyDslKotlinGradleBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/GroovyDslKotlinGradleBuildCustomizerTests.java
@@ -16,8 +16,11 @@
 
 package io.spring.initializr.generator.spring.code.kotlin;
 
+import java.util.Collections;
+
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild.TaskCustomization;
+import io.spring.initializr.generator.buildsystem.gradle.StandardGradlePlugin;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,11 +37,11 @@ class GroovyDslKotlinGradleBuildCustomizerTests {
 	void kotlinPluginsAreConfigured() {
 		GradleBuild build = new GradleBuild();
 		new GroovyDslKotlinGradleBuildCustomizer(new SimpleKotlinProjectSettings("1.2.70")).customize(build);
-		assertThat(build.getPlugins()).hasSize(2);
-		assertThat(build.getPlugins().get(0).getId()).isEqualTo("org.jetbrains.kotlin.jvm");
-		assertThat(build.getPlugins().get(0).getVersion()).isEqualTo("1.2.70");
-		assertThat(build.getPlugins().get(1).getId()).isEqualTo("org.jetbrains.kotlin.plugin.spring");
-		assertThat(build.getPlugins().get(1).getVersion()).isEqualTo("1.2.70");
+		assertThat(build.plugins().values()).hasSize(2);
+		assertThat(build.plugins().values().map(
+				(plugin) -> Collections.singletonMap(plugin.getId(), ((StandardGradlePlugin) plugin).getVersion())))
+						.containsExactlyInAnyOrder(Collections.singletonMap("org.jetbrains.kotlin.jvm", "1.2.70"),
+								Collections.singletonMap("org.jetbrains.kotlin.plugin.spring", "1.2.70"));
 	}
 
 	@Test

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinDslKotlinGradleBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinDslKotlinGradleBuildCustomizerTests.java
@@ -16,8 +16,11 @@
 
 package io.spring.initializr.generator.spring.code.kotlin;
 
+import java.util.Collections;
+
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild.TaskCustomization;
+import io.spring.initializr.generator.buildsystem.gradle.StandardGradlePlugin;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,11 +36,11 @@ class KotlinDslKotlinGradleBuildCustomizerTests {
 	void kotlinPluginsAreConfigured() {
 		GradleBuild build = new GradleBuild();
 		new KotlinDslKotlinGradleBuildCustomizer(new SimpleKotlinProjectSettings("1.2.70")).customize(build);
-		assertThat(build.getPlugins()).hasSize(2);
-		assertThat(build.getPlugins().get(0).getId()).isEqualTo("org.jetbrains.kotlin.jvm");
-		assertThat(build.getPlugins().get(0).getVersion()).isEqualTo("1.2.70");
-		assertThat(build.getPlugins().get(1).getId()).isEqualTo("org.jetbrains.kotlin.plugin.spring");
-		assertThat(build.getPlugins().get(1).getVersion()).isEqualTo("1.2.70");
+		assertThat(build.plugins().values()).hasSize(2);
+		assertThat(build.plugins().values().map(
+				(plugin) -> Collections.singletonMap(plugin.getId(), ((StandardGradlePlugin) plugin).getVersion())))
+						.containsExactlyInAnyOrder(Collections.singletonMap("org.jetbrains.kotlin.jvm", "1.2.70"),
+								Collections.singletonMap("org.jetbrains.kotlin.plugin.spring", "1.2.70"));
 	}
 
 	@Test

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJpaGradleBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJpaGradleBuildCustomizerTests.java
@@ -19,6 +19,7 @@ package io.spring.initializr.generator.spring.code.kotlin;
 import java.util.Collections;
 
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.buildsystem.gradle.StandardGradlePlugin;
 import io.spring.initializr.generator.spring.test.InitializrMetadataTestBuilder;
 import io.spring.initializr.generator.version.Version;
 import io.spring.initializr.metadata.Dependency;
@@ -40,18 +41,20 @@ class KotlinJpaGradleBuildCustomizerTests {
 		Dependency dependency = Dependency.withId("foo");
 		dependency.setFacets(Collections.singletonList("jpa"));
 		GradleBuild build = getCustomizedBuild(dependency);
-		assertThat(build.getAppliedPlugins()).isEmpty();
-		assertThat(build.getPlugins()).hasSize(1);
-		assertThat(build.getPlugins().get(0).getId()).isEqualTo("org.jetbrains.kotlin.plugin.jpa");
-		assertThat(build.getPlugins().get(0).getVersion()).isEqualTo("1.2.70");
+		assertThat(build.plugins().values().filter((plugin) -> plugin.isApply())).isEmpty();
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((plugin) -> {
+			assertThat(plugin.getId()).isEqualTo("org.jetbrains.kotlin.plugin.jpa");
+			assertThat(((StandardGradlePlugin) plugin).getVersion()).isEqualTo("1.2.70");
+		});
 	}
 
 	@Test
 	void customizeWhenJpaFacetAbsentShouldNotAddKotlinJpaPlugin() {
 		Dependency dependency = Dependency.withId("foo");
 		GradleBuild build = getCustomizedBuild(dependency);
-		assertThat(build.getAppliedPlugins()).isEmpty();
-		assertThat(build.getPlugins()).isEmpty();
+		assertThat(build.plugins().values().filter((plugin) -> plugin.isApply())).isEmpty();
+		assertThat(build.plugins().values()).isEmpty();
 	}
 
 	private GradleBuild getCustomizedBuild(Dependency dependency) {

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJpaMavenBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJpaMavenBuildCustomizerTests.java
@@ -42,25 +42,26 @@ class KotlinJpaMavenBuildCustomizerTests {
 		Dependency dependency = Dependency.withId("foo");
 		dependency.setFacets(Collections.singletonList("jpa"));
 		MavenBuild build = getCustomizedBuild(dependency);
-		assertThat(build.getPlugins()).hasSize(1);
-		MavenPlugin plugin = build.getPlugins().get(0);
-		assertThat(plugin.getGroupId()).isEqualTo("org.jetbrains.kotlin");
-		assertThat(plugin.getArtifactId()).isEqualTo("kotlin-maven-plugin");
-		MavenPlugin.Setting settings = plugin.getConfiguration().getSettings().get(0);
-		assertThat(settings.getValue()).asList().element(0).hasFieldOrPropertyWithValue("name", "plugin")
-				.hasFieldOrPropertyWithValue("value", "jpa");
-		assertThat(plugin.getDependencies()).hasSize(1);
-		MavenPlugin.Dependency pluginDependency = plugin.getDependencies().get(0);
-		assertThat(pluginDependency.getGroupId()).isEqualTo("org.jetbrains.kotlin");
-		assertThat(pluginDependency.getArtifactId()).isEqualTo("kotlin-maven-noarg");
-		assertThat(pluginDependency.getVersion()).isEqualTo("${kotlin.version}");
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((plugin) -> {
+			assertThat(plugin.getGroupId()).isEqualTo("org.jetbrains.kotlin");
+			assertThat(plugin.getArtifactId()).isEqualTo("kotlin-maven-plugin");
+			MavenPlugin.Setting settings = plugin.getConfiguration().getSettings().get(0);
+			assertThat(settings.getValue()).asList().element(0).hasFieldOrPropertyWithValue("name", "plugin")
+					.hasFieldOrPropertyWithValue("value", "jpa");
+			assertThat(plugin.getDependencies()).hasSize(1);
+			MavenPlugin.Dependency pluginDependency = plugin.getDependencies().get(0);
+			assertThat(pluginDependency.getGroupId()).isEqualTo("org.jetbrains.kotlin");
+			assertThat(pluginDependency.getArtifactId()).isEqualTo("kotlin-maven-noarg");
+			assertThat(pluginDependency.getVersion()).isEqualTo("${kotlin.version}");
+		});
 	}
 
 	@Test
 	void customizeWhenJpaFacetAbsentShouldNotAddKotlinJpaPlugin() {
 		Dependency dependency = Dependency.withId("foo");
 		MavenBuild build = getCustomizedBuild(dependency);
-		assertThat(build.getPlugins()).hasSize(0);
+		assertThat(build.plugins().values()).hasSize(0);
 	}
 
 	private MavenBuild getCustomizedBuild(Dependency dependency) {

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenBuildCustomizerTests.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
-import io.spring.initializr.generator.buildsystem.maven.MavenPlugin;
 import io.spring.initializr.generator.buildsystem.maven.MavenPlugin.Configuration;
 import io.spring.initializr.generator.buildsystem.maven.MavenPlugin.Dependency;
 import io.spring.initializr.generator.buildsystem.maven.MavenPlugin.Setting;
@@ -55,44 +54,48 @@ class KotlinMavenBuildCustomizerTests {
 	void kotlinMavenPluginIsConfigured() {
 		MavenBuild build = new MavenBuild();
 		new KotlinMavenBuildCustomizer(new SimpleKotlinProjectSettings("1.2.70")).customize(build);
-		assertThat(build.getPlugins()).hasSize(1);
-		MavenPlugin kotlinPlugin = build.getPlugins().get(0);
-		assertThat(kotlinPlugin.getGroupId()).isEqualTo("org.jetbrains.kotlin");
-		assertThat(kotlinPlugin.getArtifactId()).isEqualTo("kotlin-maven-plugin");
-		assertThat(kotlinPlugin.getVersion()).isNull();
-		Configuration configuration = kotlinPlugin.getConfiguration();
-		assertThat(configuration).isNotNull();
-		assertThat(configuration.getSettings()).hasSize(2);
-		Setting args = configuration.getSettings().get(0);
-		assertThat(args.getName()).isEqualTo("args");
-		assertThat(args.getValue()).asList().hasSize(1);
-		assertThat(args.getValue()).asList().element(0).hasFieldOrPropertyWithValue("name", "arg")
-				.hasFieldOrPropertyWithValue("value", "-Xjsr305=strict");
-		Setting compilerPlugins = configuration.getSettings().get(1);
-		assertThat(compilerPlugins.getName()).isEqualTo("compilerPlugins");
-		assertThat(compilerPlugins.getValue()).asList().hasSize(1);
-		assertThat(compilerPlugins.getValue()).asList().element(0).hasFieldOrPropertyWithValue("name", "plugin")
-				.hasFieldOrPropertyWithValue("value", "spring");
-		assertThat(kotlinPlugin.getExecutions()).isEmpty();
-		assertThat(kotlinPlugin.getDependencies()).hasSize(1);
-		Dependency allOpen = kotlinPlugin.getDependencies().get(0);
-		assertThat(allOpen.getGroupId()).isEqualTo("org.jetbrains.kotlin");
-		assertThat(allOpen.getArtifactId()).isEqualTo("kotlin-maven-allopen");
-		assertThat(allOpen.getVersion()).isEqualTo("${kotlin.version}");
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((kotlinPlugin) -> {
+			assertThat(kotlinPlugin.getGroupId()).isEqualTo("org.jetbrains.kotlin");
+			assertThat(kotlinPlugin.getArtifactId()).isEqualTo("kotlin-maven-plugin");
+			assertThat(kotlinPlugin.getVersion()).isNull();
+			Configuration configuration = kotlinPlugin.getConfiguration();
+			assertThat(configuration).isNotNull();
+			assertThat(configuration.getSettings()).hasSize(2);
+			Setting args = configuration.getSettings().get(0);
+			assertThat(args.getName()).isEqualTo("args");
+			assertThat(args.getValue()).asList().hasSize(1);
+			assertThat(args.getValue()).asList().element(0).hasFieldOrPropertyWithValue("name", "arg")
+					.hasFieldOrPropertyWithValue("value", "-Xjsr305=strict");
+			Setting compilerPlugins = configuration.getSettings().get(1);
+			assertThat(compilerPlugins.getName()).isEqualTo("compilerPlugins");
+			assertThat(compilerPlugins.getValue()).asList().hasSize(1);
+			assertThat(compilerPlugins.getValue()).asList().element(0).hasFieldOrPropertyWithValue("name", "plugin")
+					.hasFieldOrPropertyWithValue("value", "spring");
+			assertThat(kotlinPlugin.getExecutions()).isEmpty();
+			assertThat(kotlinPlugin.getDependencies()).hasSize(1);
+			Dependency allOpen = kotlinPlugin.getDependencies().get(0);
+			assertThat(allOpen.getGroupId()).isEqualTo("org.jetbrains.kotlin");
+			assertThat(allOpen.getArtifactId()).isEqualTo("kotlin-maven-allopen");
+			assertThat(allOpen.getVersion()).isEqualTo("${kotlin.version}");
+		});
 	}
 
 	@Test
 	void kotlinMavenPluginWithSeveralArgs() {
 		MavenBuild build = new MavenBuild();
 		new KotlinMavenBuildCustomizer(new TestKotlinProjectSettings()).customize(build);
-		Configuration configuration = build.getPlugins().get(0).getConfiguration();
-		Setting args = configuration.getSettings().get(0);
-		assertThat(args.getName()).isEqualTo("args");
-		assertThat(args.getValue()).asList().hasSize(2);
-		assertThat(args.getValue()).asList().element(0).hasFieldOrPropertyWithValue("name", "arg")
-				.hasFieldOrPropertyWithValue("value", "-Done=1");
-		assertThat(args.getValue()).asList().element(1).hasFieldOrPropertyWithValue("name", "arg")
-				.hasFieldOrPropertyWithValue("value", "-Dtwo=2");
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((kotlinPlugin) -> {
+			Configuration configuration = kotlinPlugin.getConfiguration();
+			Setting args = configuration.getSettings().get(0);
+			assertThat(args.getName()).isEqualTo("args");
+			assertThat(args.getValue()).asList().hasSize(2);
+			assertThat(args.getValue()).asList().element(0).hasFieldOrPropertyWithValue("name", "arg")
+					.hasFieldOrPropertyWithValue("value", "-Done=1");
+			assertThat(args.getValue()).asList().element(1).hasFieldOrPropertyWithValue("name", "arg")
+					.hasFieldOrPropertyWithValue("value", "-Dtwo=2");
+		});
 	}
 
 	private static class TestKotlinProjectSettings extends SimpleKotlinProjectSettings {

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenFullBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenFullBuildCustomizerTests.java
@@ -17,7 +17,6 @@
 package io.spring.initializr.generator.spring.code.kotlin;
 
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
-import io.spring.initializr.generator.buildsystem.maven.MavenPlugin;
 import io.spring.initializr.generator.buildsystem.maven.MavenPlugin.Configuration;
 import io.spring.initializr.generator.buildsystem.maven.MavenPlugin.Dependency;
 import io.spring.initializr.generator.buildsystem.maven.MavenPlugin.Execution;
@@ -53,43 +52,44 @@ class KotlinMavenFullBuildCustomizerTests {
 	void kotlinMavenPluginIsConfigured() {
 		MavenBuild build = new MavenBuild();
 		new KotlinMavenFullBuildCustomizer(new SimpleKotlinProjectSettings("1.2.70")).customize(build);
-		assertThat(build.getPlugins()).hasSize(1);
-		MavenPlugin kotlinPlugin = build.getPlugins().get(0);
-		assertThat(kotlinPlugin.getGroupId()).isEqualTo("org.jetbrains.kotlin");
-		assertThat(kotlinPlugin.getArtifactId()).isEqualTo("kotlin-maven-plugin");
-		assertThat(kotlinPlugin.getVersion()).isEqualTo("${kotlin.version}");
-		Configuration configuration = kotlinPlugin.getConfiguration();
-		assertThat(configuration).isNotNull();
-		assertThat(configuration.getSettings()).hasSize(3);
-		Setting args = configuration.getSettings().get(0);
-		assertThat(args.getName()).isEqualTo("args");
-		assertThat(args.getValue()).asList().hasSize(1);
-		assertThat(args.getValue()).asList().element(0).hasFieldOrPropertyWithValue("name", "arg")
-				.hasFieldOrPropertyWithValue("value", "-Xjsr305=strict");
-		Setting compilerPlugins = configuration.getSettings().get(1);
-		assertThat(compilerPlugins.getName()).isEqualTo("compilerPlugins");
-		assertThat(compilerPlugins.getValue()).asList().hasSize(1);
-		assertThat(compilerPlugins.getValue()).asList().element(0).hasFieldOrPropertyWithValue("name", "plugin")
-				.hasFieldOrPropertyWithValue("value", "spring");
-		Setting jvmTarget = configuration.getSettings().get(2);
-		assertThat(jvmTarget.getName()).isEqualTo("jvmTarget");
-		assertThat(jvmTarget.getValue()).isEqualTo("1.8");
-		assertThat(kotlinPlugin.getExecutions()).hasSize(2);
-		Execution compile = kotlinPlugin.getExecutions().get(0);
-		assertThat(compile.getId()).isEqualTo("compile");
-		assertThat(compile.getGoals()).containsExactly("compile");
-		assertThat(compile.getPhase()).isEqualTo("compile");
-		assertThat(compile.getConfiguration()).isNull();
-		Execution testCompile = kotlinPlugin.getExecutions().get(1);
-		assertThat(testCompile.getId()).isEqualTo("test-compile");
-		assertThat(testCompile.getGoals()).containsExactly("test-compile");
-		assertThat(testCompile.getPhase()).isEqualTo("test-compile");
-		assertThat(testCompile.getConfiguration()).isNull();
-		assertThat(kotlinPlugin.getDependencies()).hasSize(1);
-		Dependency allOpen = kotlinPlugin.getDependencies().get(0);
-		assertThat(allOpen.getGroupId()).isEqualTo("org.jetbrains.kotlin");
-		assertThat(allOpen.getArtifactId()).isEqualTo("kotlin-maven-allopen");
-		assertThat(allOpen.getVersion()).isEqualTo("${kotlin.version}");
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((kotlinPlugin) -> {
+			assertThat(kotlinPlugin.getGroupId()).isEqualTo("org.jetbrains.kotlin");
+			assertThat(kotlinPlugin.getArtifactId()).isEqualTo("kotlin-maven-plugin");
+			assertThat(kotlinPlugin.getVersion()).isEqualTo("${kotlin.version}");
+			Configuration configuration = kotlinPlugin.getConfiguration();
+			assertThat(configuration).isNotNull();
+			assertThat(configuration.getSettings()).hasSize(3);
+			Setting args = configuration.getSettings().get(0);
+			assertThat(args.getName()).isEqualTo("args");
+			assertThat(args.getValue()).asList().hasSize(1);
+			assertThat(args.getValue()).asList().element(0).hasFieldOrPropertyWithValue("name", "arg")
+					.hasFieldOrPropertyWithValue("value", "-Xjsr305=strict");
+			Setting compilerPlugins = configuration.getSettings().get(1);
+			assertThat(compilerPlugins.getName()).isEqualTo("compilerPlugins");
+			assertThat(compilerPlugins.getValue()).asList().hasSize(1);
+			assertThat(compilerPlugins.getValue()).asList().element(0).hasFieldOrPropertyWithValue("name", "plugin")
+					.hasFieldOrPropertyWithValue("value", "spring");
+			Setting jvmTarget = configuration.getSettings().get(2);
+			assertThat(jvmTarget.getName()).isEqualTo("jvmTarget");
+			assertThat(jvmTarget.getValue()).isEqualTo("1.8");
+			assertThat(kotlinPlugin.getExecutions()).hasSize(2);
+			Execution compile = kotlinPlugin.getExecutions().get(0);
+			assertThat(compile.getId()).isEqualTo("compile");
+			assertThat(compile.getGoals()).containsExactly("compile");
+			assertThat(compile.getPhase()).isEqualTo("compile");
+			assertThat(compile.getConfiguration()).isNull();
+			Execution testCompile = kotlinPlugin.getExecutions().get(1);
+			assertThat(testCompile.getId()).isEqualTo("test-compile");
+			assertThat(testCompile.getGoals()).containsExactly("test-compile");
+			assertThat(testCompile.getPhase()).isEqualTo("test-compile");
+			assertThat(testCompile.getConfiguration()).isNull();
+			assertThat(kotlinPlugin.getDependencies()).hasSize(1);
+			Dependency allOpen = kotlinPlugin.getDependencies().get(0);
+			assertThat(allOpen.getGroupId()).isEqualTo("org.jetbrains.kotlin");
+			assertThat(allOpen.getArtifactId()).isEqualTo("kotlin-maven-allopen");
+			assertThat(allOpen.getVersion()).isEqualTo("${kotlin.version}");
+		});
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuild.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuild.java
@@ -46,10 +46,6 @@ public class GradleBuild extends Build {
 
 	private final Map<String, String> ext = new TreeMap<>();
 
-	private final List<GradlePlugin> plugins = new ArrayList<>();
-
-	private final List<String> appliedPlugins = new ArrayList<>();
-
 	private final List<String> configurations = new ArrayList<>();
 
 	private final Map<String, ConfigurationCustomization> configurationCustomizations = new LinkedHashMap<>();
@@ -61,6 +57,8 @@ public class GradleBuild extends Build {
 	private final Map<String, TaskCustomization> tasksWithTypeCustomizations = new LinkedHashMap<>();
 
 	private final Buildscript buildscript = new Buildscript();
+
+	private final GradlePluginContainer plugins = new GradlePluginContainer();
 
 	public GradleBuild(BuildItemResolver buildItemResolver) {
 		super(buildItemResolver);
@@ -87,26 +85,8 @@ public class GradleBuild extends Build {
 		return Collections.unmodifiableMap(this.ext);
 	}
 
-	public GradlePlugin addPlugin(String id) {
-		return this.addPlugin(id, null);
-	}
-
-	public GradlePlugin addPlugin(String id, String version) {
-		GradlePlugin plugin = new GradlePlugin(id, version);
-		this.plugins.add(plugin);
-		return plugin;
-	}
-
-	public void applyPlugin(String id) {
-		this.appliedPlugins.add(id);
-	}
-
-	public List<GradlePlugin> getPlugins() {
-		return Collections.unmodifiableList(this.plugins);
-	}
-
-	public List<String> getAppliedPlugins() {
-		return Collections.unmodifiableList(this.appliedPlugins);
+	public GradlePluginContainer plugins() {
+		return this.plugins;
 	}
 
 	public void buildscript(Consumer<Buildscript> customizer) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
@@ -168,6 +168,11 @@ public abstract class GradleBuildWriter {
 		}
 	}
 
+	protected List<StandardGradlePlugin> extractStandardPlugin(GradleBuild build) {
+		return (List<StandardGradlePlugin>) (List<? extends GradlePlugin>) build.plugins().values()
+				.filter((plugin) -> plugin instanceof StandardGradlePlugin).collect(Collectors.toList());
+	}
+
 	private void writeBoms(IndentingWriter writer, GradleBuild build) {
 		if (build.boms().isEmpty()) {
 			return;

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradlePlugin.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradlePlugin.java
@@ -25,19 +25,19 @@ public class GradlePlugin {
 
 	private final String id;
 
-	private final String version;
+	private boolean apply;
 
-	public GradlePlugin(String id, String version) {
+	public GradlePlugin(String id, boolean apply) {
 		this.id = id;
-		this.version = version;
+		this.apply = apply;
 	}
 
 	public String getId() {
 		return this.id;
 	}
 
-	public String getVersion() {
-		return this.version;
+	public boolean isApply() {
+		return this.apply;
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradlePluginContainer.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradlePluginContainer.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.buildsystem.gradle;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * A container for {@link GradlePlugin}s.
+ *
+ * @author HaiTao Zhang
+ */
+public class GradlePluginContainer {
+
+	private final Map<String, GradlePlugin> plugins;
+
+	public GradlePluginContainer() {
+		this.plugins = new LinkedHashMap<>();
+	}
+
+	/**
+	 * Specify if this container is empty.
+	 * @return {@code true} if no {@link GradlePlugin} is added
+	 */
+	public boolean isEmpty() {
+		return this.plugins.isEmpty();
+	}
+
+	/**
+	 * Specify if this container has a GradlePlugin with the specified id.
+	 * @param id id associated with the {@link GradlePlugin}
+	 * @return {@code true} if an object with the specified id is added
+	 */
+	public boolean has(String id) {
+		return this.plugins.containsKey(id);
+	}
+
+	/**
+	 * Returns a {@link Stream} of added {@link GradlePlugin}s.
+	 * @return a stream of {@link GradlePlugin}s
+	 */
+	public Stream<GradlePlugin> values() {
+		return this.plugins.values().stream();
+	}
+
+	/**
+	 * Add a {@link GradlePlugin} to the Gradle's legacy apply block by specifying the id.
+	 * @param id id associated with the {@link GradlePlugin}
+	 */
+	public void apply(String id) {
+		addPlugin(id, (pluginId) -> new GradlePlugin(pluginId, true));
+	}
+
+	/**
+	 * Add a {@link GradlePlugin} to the Gradle's standard plugins DSL block by specifying
+	 * the id.
+	 * @param id id associated with the {@link GradlePlugin}
+	 */
+	public void add(String id) {
+		addPlugin(id, (pluginId) -> new StandardGradlePlugin(pluginId));
+	}
+
+	/**
+	 * Add a {@link GradlePlugin} to the Gradle's standard plugins DSL block by specifying
+	 * the id, along with a {@link Consumer} to customize the object.
+	 * @param id id associated with the {@link GradlePlugin}
+	 * @param plugin consumer to customize the {@link GradlePlugin}
+	 */
+	public void add(String id, Consumer<StandardGradlePlugin> plugin) {
+		GradlePlugin gradlePlugin = addPlugin(id, (pluginId) -> new StandardGradlePlugin(pluginId));
+		if (gradlePlugin instanceof StandardGradlePlugin) {
+			plugin.accept((StandardGradlePlugin) gradlePlugin);
+		}
+	}
+
+	public boolean remove(String id) {
+		return this.plugins.remove(id) != null;
+	}
+
+	private GradlePlugin addPlugin(String id, Function<String, GradlePlugin> pluginId) {
+		return this.plugins.computeIfAbsent(id, pluginId);
+	}
+
+}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriter.java
@@ -19,6 +19,7 @@ package io.spring.initializr.generator.buildsystem.gradle;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 import io.spring.initializr.generator.buildsystem.BillOfMaterials;
 import io.spring.initializr.generator.buildsystem.Dependency;
@@ -68,13 +69,17 @@ public class GroovyDslGradleBuildWriter extends GradleBuildWriter {
 
 	@Override
 	protected void writePlugins(IndentingWriter writer, GradleBuild build) {
-		writeNestedCollection(writer, "plugins", build.getPlugins(), this::pluginAsString);
-		writeCollection(writer, build.getAppliedPlugins(), (plugin) -> "apply plugin: '" + plugin + "'",
+		writeNestedCollection(writer, "plugins", extractStandardPlugin(build), this::pluginAsString);
+		writeCollection(writer, extractApplyPlugins(build), (plugin) -> "apply plugin: '" + plugin.getId() + "'",
 				writer::println);
 		writer.println();
 	}
 
-	private String pluginAsString(GradlePlugin plugin) {
+	private List<GradlePlugin> extractApplyPlugins(GradleBuild build) {
+		return build.plugins().values().filter((plugin) -> plugin.isApply()).collect(Collectors.toList());
+	}
+
+	private String pluginAsString(StandardGradlePlugin plugin) {
 		String string = "id '" + plugin.getId() + "'";
 		if (plugin.getVersion() != null) {
 			string += " version '" + plugin.getVersion() + "'";

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriter.java
@@ -65,16 +65,19 @@ public class KotlinDslGradleBuildWriter extends GradleBuildWriter {
 
 	@Override
 	protected void writePlugins(IndentingWriter writer, GradleBuild build) {
-		writeNestedCollection(writer, "plugins", build.getPlugins(), this::pluginAsString, null);
+		writeNestedCollection(writer, "plugins", extractStandardPlugin(build), this::pluginAsString, null);
 		writer.println();
-
-		if (!build.getAppliedPlugins().isEmpty()) {
+		if (checkForApplyPlugins(build)) {
 			throw new IllegalStateException(
 					"build.gradle.kts scripts shouldn't apply plugins. They should use the plugins block instead.");
 		}
 	}
 
-	private String pluginAsString(GradlePlugin plugin) {
+	private boolean checkForApplyPlugins(GradleBuild build) {
+		return build.plugins().values().anyMatch((gradlePlugin) -> gradlePlugin.isApply());
+	}
+
+	private String pluginAsString(StandardGradlePlugin plugin) {
 		String result = shortPluginNotation(plugin.getId());
 		if (result == null) {
 			result = "id(\"" + plugin.getId() + "\")";

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/StandardGradlePlugin.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/StandardGradlePlugin.java
@@ -14,21 +14,22 @@
  * limitations under the License.
  */
 
-package io.spring.initializr.generator.spring.code.groovy;
+package io.spring.initializr.generator.buildsystem.gradle;
 
-import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
-import io.spring.initializr.generator.spring.build.BuildCustomizer;
+public class StandardGradlePlugin extends GradlePlugin {
 
-/**
- * {@link BuildCustomizer} for Groovy projects build with Gradle.
- *
- * @author Stephane Nicoll
- */
-class GroovyGradleBuildCustomizer implements BuildCustomizer<GradleBuild> {
+	private String version;
 
-	@Override
-	public void customize(GradleBuild build) {
-		build.plugins().add("groovy");
+	public StandardGradlePlugin(String id) {
+		super(id, false);
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	public String getVersion() {
+		return this.version;
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuild.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuild.java
@@ -16,10 +16,7 @@
 
 package io.spring.initializr.generator.buildsystem.maven;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -45,7 +42,7 @@ public class MavenBuild extends Build {
 
 	private final Map<String, String> properties = new TreeMap<>();
 
-	private final Map<String, MavenPlugin> plugins = new LinkedHashMap<>();
+	private MavenPluginContainer plugins = new MavenPluginContainer();
 
 	private String packaging;
 
@@ -106,24 +103,8 @@ public class MavenBuild extends Build {
 		this.testSourceDirectory = testSourceDirectory;
 	}
 
-	public MavenPlugin plugin(String groupId, String artifactId) {
-		return this.plugins.computeIfAbsent(pluginKey(groupId, artifactId),
-				(id) -> new MavenPlugin(groupId, artifactId));
-	}
-
-	public MavenPlugin plugin(String groupId, String artifactId, String version) {
-		MavenPlugin mavenPlugin = this.plugins.computeIfAbsent(pluginKey(groupId, artifactId),
-				(id) -> new MavenPlugin(groupId, artifactId));
-		mavenPlugin.setVersion(version);
-		return mavenPlugin;
-	}
-
-	private String pluginKey(String groupId, String artifactId) {
-		return String.format("%s:%s", groupId, artifactId);
-	}
-
-	public List<MavenPlugin> getPlugins() {
-		return Collections.unmodifiableList(new ArrayList<>(this.plugins.values()));
+	public MavenPluginContainer plugins() {
+		return this.plugins;
 	}
 
 	public void setPackaging(String packaging) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
@@ -240,8 +240,7 @@ public class MavenBuildWriter {
 	}
 
 	private void writeBuild(IndentingWriter writer, MavenBuild build) {
-		if (build.getSourceDirectory() == null && build.getTestSourceDirectory() == null
-				&& build.getPlugins().isEmpty()) {
+		if (build.getSourceDirectory() == null && build.getTestSourceDirectory() == null && build.plugins().isEmpty()) {
 			return;
 		}
 		writer.println();
@@ -254,10 +253,11 @@ public class MavenBuildWriter {
 	}
 
 	private void writePlugins(IndentingWriter writer, MavenBuild build) {
-		if (build.getPlugins().isEmpty()) {
+		if (build.plugins().isEmpty()) {
 			return;
 		}
-		writeElement(writer, "plugins", () -> writeCollection(writer, build.getPlugins(), this::writePlugin));
+		writeElement(writer, "plugins", () -> writeCollection(writer,
+				build.plugins().values().collect(Collectors.toList()), this::writePlugin));
 	}
 
 	private void writePlugin(IndentingWriter writer, MavenPlugin plugin) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenPluginContainer.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenPluginContainer.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.buildsystem.maven;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * A container for {@link MavenPlugin}s.
+ *
+ * @author HaiTao Zhang
+ */
+public class MavenPluginContainer {
+
+	private final Map<String, MavenPlugin> plugins;
+
+	public MavenPluginContainer() {
+		this.plugins = new LinkedHashMap<>();
+	}
+
+	/**
+	 * Specify if this container is empty.
+	 * @return {@code true} if no {@link MavenPlugin} is added
+	 */
+	public boolean isEmpty() {
+		return this.plugins.isEmpty();
+	}
+
+	/**
+	 * Specify if this container has a MavenPlugin with the specified groupId and
+	 * artifactId.
+	 * @param groupId groupId associated with the {@link MavenPlugin}
+	 * @param artifactId artifactId associated with the {@link MavenPlugin}
+	 * @return {@code true} if an item with the specified {@code groupId} and
+	 * {@code artifactId} is added
+	 */
+	public boolean has(String groupId, String artifactId) {
+		return this.plugins.containsKey(pluginKey(groupId, artifactId));
+	}
+
+	/**
+	 * Returns a {@link Stream} of added {@link MavenPlugin}s.
+	 * @return a stream of {@link MavenPlugin}s
+	 */
+	public Stream<MavenPlugin> values() {
+		return this.plugins.values().stream();
+	}
+
+	/**
+	 * Add a {@link MavenPlugin} by specifying the groupId and artifactId.
+	 * @param groupId groupId associated with the {@link MavenPlugin}
+	 * @param artifactId artifactId associated with the {@link MavenPlugin}
+	 */
+	public void add(String groupId, String artifactId) {
+		addPlugin(groupId, artifactId);
+	}
+
+	/**
+	 * Add a {@link MavenPlugin} by specifying the groupId and artifactId, along with a
+	 * {@link Consumer} to customize the object.
+	 * @param groupId groupId associated with the {@link MavenPlugin}
+	 * @param artifactId artifactId associated with the {@link MavenPlugin}
+	 * @param plugin {@link Consumer} to customize the object
+	 */
+	public void add(String groupId, String artifactId, Consumer<MavenPlugin> plugin) {
+		MavenPlugin mavenPlugin = addPlugin(groupId, artifactId);
+		plugin.accept(mavenPlugin);
+	}
+
+	/**
+	 * Remove a {@link MavenPlugin} by specifying the groupId and artifactId.
+	 * @param groupId groupId associated with the {@link MavenPlugin}
+	 * @param artifactId artifactId associated with the {@link MavenPlugin}
+	 * @return {@code true} if an object was removed
+	 */
+	public boolean remove(String groupId, String artifactId) {
+		return this.plugins.remove(pluginKey(groupId, artifactId)) != null;
+	}
+
+	private String pluginKey(String groupId, String artifactId) {
+		return String.format("%s:%s", groupId, artifactId);
+	}
+
+	private MavenPlugin addPlugin(String groupId, String artifactId) {
+		return this.plugins.computeIfAbsent(pluginKey(groupId, artifactId),
+				(pluginId) -> new MavenPlugin(groupId, artifactId));
+	}
+
+}

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GradlePluginContainerTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GradlePluginContainerTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.buildsystem.gradle;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link GradlePluginContainer}.
+ *
+ * @author HaITao Zhang
+ */
+public class GradlePluginContainerTests {
+
+	@Test
+	void addGradlePluginWithOnlyId() {
+		GradlePluginContainer pluginContainer = new GradlePluginContainer();
+		pluginContainer.add("com.example");
+		assertThat(pluginContainer.values()).hasSize(1);
+		pluginContainer.values().findFirst().ifPresent((plugin) -> {
+			assertThat(plugin.getId()).isEqualTo("com.example");
+			assertThat(plugin.isApply()).isFalse();
+		});
+	}
+
+	@Test
+	void addGradlePluginWithConsumer() {
+		GradlePluginContainer pluginContainer = new GradlePluginContainer();
+		pluginContainer.add("com.example", (plugin) -> plugin.setVersion("1.0"));
+		assertThat(pluginContainer.values()).hasSize(1);
+		pluginContainer.values().findFirst().ifPresent((plugin) -> {
+			assertThat(plugin.getId()).isEqualTo("com.example");
+			assertThat(plugin).isInstanceOf(StandardGradlePlugin.class);
+			assertThat(((StandardGradlePlugin) plugin).getVersion()).isEqualTo("1.0");
+			assertThat(plugin.isApply()).isFalse();
+		});
+
+	}
+
+	@Test
+	void applyGradlePlugin() {
+		GradlePluginContainer pluginContainer = new GradlePluginContainer();
+		pluginContainer.apply("com.example");
+		assertThat(pluginContainer.values()).hasSize(1);
+		pluginContainer.values().findFirst().ifPresent((plugin) -> {
+			assertThat(plugin.getId()).isEqualTo("com.example");
+			assertThat(plugin.isApply()).isTrue();
+		});
+	}
+
+	@Test
+	void applyGradlePluginShouldNotOverrideGradlePluginThatWasAlreadyAdded() {
+		GradlePluginContainer pluginContainer = new GradlePluginContainer();
+		pluginContainer.add("com.example");
+		pluginContainer.apply("com.example");
+		assertThat(pluginContainer.values()).hasSize(1);
+		pluginContainer.values().findFirst().ifPresent((plugin) -> {
+			assertThat(plugin.getId()).isEqualTo("com.example");
+			assertThat(plugin.isApply()).isFalse();
+		});
+	}
+
+	@Test
+	void addGradlePluginShouldNotOverrideGradlePluginThatWasAlreadyApplied() {
+		GradlePluginContainer pluginContainer = new GradlePluginContainer();
+		pluginContainer.apply("com.example");
+		pluginContainer.add("com.example");
+		assertThat(pluginContainer.values()).hasSize(1);
+		pluginContainer.values().findFirst().ifPresent((plugin) -> {
+			assertThat(plugin.getId()).isEqualTo("com.example");
+			assertThat(plugin.isApply()).isTrue();
+		});
+	}
+
+}

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
@@ -81,7 +81,7 @@ class GroovyDslGradleBuildWriterTests {
 	@Test
 	void gradleBuildWithPlugin() throws IOException {
 		GradleBuild build = new GradleBuild();
-		build.addPlugin("java");
+		build.plugins().add("java");
 		List<String> lines = generateBuild(build);
 		assertThat(lines).containsSequence("plugins {", "    id 'java'", "}");
 	}
@@ -89,7 +89,8 @@ class GroovyDslGradleBuildWriterTests {
 	@Test
 	void gradleBuildWithPluginAndVersion() throws IOException {
 		GradleBuild build = new GradleBuild();
-		build.addPlugin("org.springframework.boot", "2.1.0.RELEASE");
+		build.plugins().add("org.springframework.boot",
+				(StandardGradlePlugin standardGradlePlugin) -> standardGradlePlugin.setVersion("2.1.0.RELEASE"));
 		List<String> lines = generateBuild(build);
 		assertThat(lines).containsSequence("plugins {", "    id 'org.springframework.boot' version '2.1.0.RELEASE'",
 				"}");
@@ -98,7 +99,7 @@ class GroovyDslGradleBuildWriterTests {
 	@Test
 	void gradleBuildWithApplyPlugin() throws IOException {
 		GradleBuild build = new GradleBuild();
-		build.applyPlugin("io.spring.dependency-management");
+		build.plugins().apply("io.spring.dependency-management");
 		List<String> lines = generateBuild(build);
 		assertThat(lines).containsSequence("apply plugin: 'io.spring.dependency-management'");
 	}

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriterTests.java
@@ -82,8 +82,8 @@ class KotlinDslGradleBuildWriterTests {
 	@Test
 	void gradleBuildWithBuiltinPlugin() throws IOException {
 		GradleBuild build = new GradleBuild();
-		build.addPlugin("java");
-		build.addPlugin("war");
+		build.plugins().add("java");
+		build.plugins().add("war");
 		List<String> lines = generateBuild(build);
 		assertThat(lines).containsSequence("plugins {", "    java", "    war", "}");
 	}
@@ -91,8 +91,10 @@ class KotlinDslGradleBuildWriterTests {
 	@Test
 	void gradleBuildWithKotlinPluginAndVersion() throws IOException {
 		GradleBuild build = new GradleBuild();
-		build.addPlugin("org.jetbrains.kotlin.jvm", "1.3.21");
-		build.addPlugin("org.jetbrains.kotlin.plugin.spring", "1.3.21");
+		build.plugins().add("org.jetbrains.kotlin.jvm",
+				(StandardGradlePlugin standardGradlePlugin) -> standardGradlePlugin.setVersion("1.3.21"));
+		build.plugins().add("org.jetbrains.kotlin.plugin.spring",
+				(StandardGradlePlugin standardGradlePlugin) -> standardGradlePlugin.setVersion("1.3.21"));
 		List<String> lines = generateBuild(build);
 		assertThat(lines).containsSequence("plugins {", "    kotlin(\"jvm\") version \"1.3.21\"",
 				"    kotlin(\"plugin.spring\") version \"1.3.21\"", "}");
@@ -101,7 +103,8 @@ class KotlinDslGradleBuildWriterTests {
 	@Test
 	void gradleBuildWithPluginAndVersion() throws IOException {
 		GradleBuild build = new GradleBuild();
-		build.addPlugin("org.springframework.boot", "2.1.0.RELEASE");
+		build.plugins().add("org.springframework.boot",
+				(StandardGradlePlugin standardGradlePlugin) -> standardGradlePlugin.setVersion("2.1.0.RELEASE"));
 		List<String> lines = generateBuild(build);
 		assertThat(lines).containsSequence("plugins {",
 				"    id(\"org.springframework.boot\") version \"2.1.0.RELEASE\"", "}");
@@ -110,7 +113,7 @@ class KotlinDslGradleBuildWriterTests {
 	@Test
 	void gradleBuildWithApplyPlugin() {
 		GradleBuild build = new GradleBuild();
-		build.applyPlugin("io.spring.dependency-management");
+		build.plugins().apply("io.spring.dependency-management");
 		assertThatIllegalStateException().isThrownBy(() -> generateBuild(build));
 	}
 

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildTests.java
@@ -31,83 +31,96 @@ class MavenBuildTests {
 	@Test
 	void mavenPluginCanBeConfigured() {
 		MavenBuild build = new MavenBuild();
-		build.plugin("com.example", "test-plugin").execution("first", (first) -> first.goal("run-this"));
-		assertThat(build.getPlugins()).hasSize(1);
-		MavenPlugin testPlugin = build.getPlugins().get(0);
-		assertThat(testPlugin.getGroupId()).isEqualTo("com.example");
-		assertThat(testPlugin.getArtifactId()).isEqualTo("test-plugin");
-		assertThat(testPlugin.getVersion()).isNull();
-		assertThat(testPlugin.getExecutions()).hasSize(1);
-		assertThat(testPlugin.getExecutions().get(0).getId()).isEqualTo("first");
-		assertThat(testPlugin.getExecutions().get(0).getGoals()).containsExactly("run-this");
+		build.plugins().add("com.example", "test-plugin",
+				(plugin) -> plugin.execution("first", (first) -> first.goal("run-this")));
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((testPlugin) -> {
+			assertThat(testPlugin.getGroupId()).isEqualTo("com.example");
+			assertThat(testPlugin.getArtifactId()).isEqualTo("test-plugin");
+			assertThat(testPlugin.getVersion()).isNull();
+			assertThat(testPlugin.getExecutions()).hasSize(1);
+			assertThat(testPlugin.getExecutions().get(0).getId()).isEqualTo("first");
+			assertThat(testPlugin.getExecutions().get(0).getGoals()).containsExactly("run-this");
+		});
 	}
 
 	@Test
 	void mavenPluginVersionCanBeAmended() {
 		MavenBuild build = new MavenBuild();
-		build.plugin("com.example", "test-plugin");
-		build.plugin("com.example", "test-plugin", "1.0.0");
-		assertThat(build.getPlugins()).hasSize(1);
-		MavenPlugin testPlugin = build.getPlugins().get(0);
-		assertThat(testPlugin.getGroupId()).isEqualTo("com.example");
-		assertThat(testPlugin.getArtifactId()).isEqualTo("test-plugin");
-		assertThat(testPlugin.getVersion()).isEqualTo("1.0.0");
+		build.plugins().add("com.example", "test-plugin");
+		build.plugins().add("com.example", "test-plugin", (plugin) -> plugin.setVersion("1.0.0"));
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((testPlugin) -> {
+			assertThat(testPlugin.getGroupId()).isEqualTo("com.example");
+			assertThat(testPlugin.getArtifactId()).isEqualTo("test-plugin");
+			assertThat(testPlugin.getVersion()).isEqualTo("1.0.0");
+		});
+
 	}
 
 	@Test
 	void mavenPluginVersionCanBeAmendedWithCustomizer() {
 		MavenBuild build = new MavenBuild();
-		build.plugin("com.example", "test-plugin", "1.0.0");
-		build.plugin("com.example", "test-plugin").setVersion(null);
-		assertThat(build.getPlugins()).hasSize(1);
-		MavenPlugin testPlugin = build.getPlugins().get(0);
-		assertThat(testPlugin.getGroupId()).isEqualTo("com.example");
-		assertThat(testPlugin.getArtifactId()).isEqualTo("test-plugin");
-		assertThat(testPlugin.getVersion()).isNull();
+		build.plugins().add("com.example", "test-plugin", (plugin) -> plugin.setVersion("1.0.0"));
+		build.plugins().add("com.example", "test-plugin", (plugin) -> plugin.setVersion(null));
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((testPlugin) -> {
+			assertThat(testPlugin.getGroupId()).isEqualTo("com.example");
+			assertThat(testPlugin.getArtifactId()).isEqualTo("test-plugin");
+			assertThat(testPlugin.getVersion()).isNull();
+		});
 	}
 
 	@Test
 	void mavenPluginVersionIsNotLostOnAmend() {
 		MavenBuild build = new MavenBuild();
-		build.plugin("com.example", "test-plugin", "1.0.0");
-		build.plugin("com.example", "test-plugin");
-		assertThat(build.getPlugins()).hasSize(1);
-		MavenPlugin testPlugin = build.getPlugins().get(0);
-		assertThat(testPlugin.getGroupId()).isEqualTo("com.example");
-		assertThat(testPlugin.getArtifactId()).isEqualTo("test-plugin");
-		assertThat(testPlugin.getVersion()).isEqualTo("1.0.0");
+		build.plugins().add("com.example", "test-plugin", (plugin) -> plugin.setVersion("1.0.0"));
+		build.plugins().add("com.example", "test-plugin");
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((testPlugin) -> {
+			assertThat(testPlugin.getGroupId()).isEqualTo("com.example");
+			assertThat(testPlugin.getArtifactId()).isEqualTo("test-plugin");
+			assertThat(testPlugin.getVersion()).isEqualTo("1.0.0");
+		});
+	}
+
+	@Test
+	void mavenPluginCanBeRemoved() {
+		MavenBuild build = new MavenBuild();
+		build.plugins().add("com.example", "test-plugin");
+		build.plugins().remove("com.example", "test-plugin");
+		assertThat(build.plugins().values()).hasSize(0);
 	}
 
 	@Test
 	void mavenPluginExecutionCanBeAmended() {
 		MavenBuild build = new MavenBuild();
-		build.plugin("com.example", "test-plugin").execution("first", (first) -> first.goal("run-this"));
-		build.plugin("com.example", "test-plugin").execution("first", (first) -> first.goal("run-that"));
-		assertThat(build.getPlugins()).hasSize(1);
-		MavenPlugin testPlugin = build.getPlugins().get(0);
-		assertThat(testPlugin.getExecutions()).hasSize(1);
-		assertThat(testPlugin.getExecutions().get(0).getId()).isEqualTo("first");
-		assertThat(testPlugin.getExecutions().get(0).getGoals()).containsExactly("run-this", "run-that");
+		build.plugins().add("com.example", "test-plugin",
+				(plugin) -> plugin.execution("first", (first) -> first.goal("run-this")));
+		build.plugins().add("com.example", "test-plugin",
+				(plugin) -> plugin.execution("first", (first) -> first.goal("run-that")));
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((testPlugin) -> {
+			assertThat(testPlugin.getExecutions()).hasSize(1);
+			assertThat(testPlugin.getExecutions().get(0).getId()).isEqualTo("first");
+			assertThat(testPlugin.getExecutions().get(0).getGoals()).containsExactly("run-this", "run-that");
+		});
 	}
 
 	@Test
 	void mavenPluginExtensionsNotLoadedByDefault() {
 		MavenBuild build = new MavenBuild();
-		build.plugin("com.example", "test-plugin");
-
-		MavenPlugin testPlugin = build.getPlugins().get(0);
-
-		assertThat(testPlugin.isExtensions()).isFalse();
+		build.plugins().add("com.example", "test-plugin");
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((testPlugin) -> assertThat(testPlugin.isExtensions()).isFalse());
 	}
 
 	@Test
 	void mavenPluginExtensionsCanBeLoaded() {
 		MavenBuild build = new MavenBuild();
-		build.plugin("com.example", "test-plugin").extensions();
-
-		MavenPlugin testPlugin = build.getPlugins().get(0);
-
-		assertThat(testPlugin.isExtensions()).isTrue();
+		build.plugins().add("com.example", "test-plugin", (plugin) -> plugin.extensions());
+		assertThat(build.plugins().values()).hasSize(1);
+		build.plugins().values().findFirst().ifPresent((testPlugin) -> assertThat(testPlugin.isExtensions()).isTrue());
 	}
 
 }

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriterTests.java
@@ -350,7 +350,7 @@ class MavenBuildWriterTests {
 		MavenBuild build = new MavenBuild();
 		build.setGroup("com.example.demo");
 		build.setArtifact("demo");
-		build.plugin("org.springframework.boot", "spring-boot-maven-plugin");
+		build.plugins().add("org.springframework.boot", "spring-boot-maven-plugin");
 		generatePom(build, (pom) -> {
 			NodeAssert plugin = pom.nodeAtPath("/project/build/plugins/plugin");
 			assertThat(plugin).textAtPath("groupId").isEqualTo("org.springframework.boot");
@@ -365,11 +365,12 @@ class MavenBuildWriterTests {
 		MavenBuild build = new MavenBuild();
 		build.setGroup("com.example.demo");
 		build.setArtifact("demo");
-		MavenPlugin kotlin = build.plugin("org.jetbrains.kotlin", "kotlin-maven-plugin");
-		kotlin.configuration((configuration) -> {
-			configuration.configure("args", (args) -> args.add("arg", "-Xjsr305=strict"));
-			configuration.configure("compilerPlugins", (compilerPlugins) -> compilerPlugins.add("plugin", "spring"));
-		});
+		build.plugins().add("org.jetbrains.kotlin", "kotlin-maven-plugin",
+				(plugin) -> plugin.configuration((configuration) -> {
+					configuration.configure("args", (args) -> args.add("arg", "-Xjsr305=strict"));
+					configuration.configure("compilerPlugins",
+							(compilerPlugins) -> compilerPlugins.add("plugin", "spring"));
+				}));
 		generatePom(build, (pom) -> {
 			NodeAssert plugin = pom.nodeAtPath("/project/build/plugins/plugin");
 			assertThat(plugin).textAtPath("groupId").isEqualTo("org.jetbrains.kotlin");
@@ -386,13 +387,15 @@ class MavenBuildWriterTests {
 		MavenBuild build = new MavenBuild();
 		build.setGroup("com.example.demo");
 		build.setArtifact("demo");
-		MavenPlugin asciidoctor = build.plugin("org.asciidoctor", "asciidoctor-maven-plugin", "1.5.3");
-		asciidoctor.execution("generateProject-docs", (execution) -> {
-			execution.goal("process-asciidoc");
-			execution.phase("generateProject-resources");
-			execution.configuration((configuration) -> {
-				configuration.add("doctype", "book");
-				configuration.add("backend", "html");
+		build.plugins().add("org.asciidoctor", "asciidoctor-maven-plugin", (plugin) -> {
+			plugin.setVersion("1.5.3");
+			plugin.execution("generateProject-docs", (execution) -> {
+				execution.goal("process-asciidoc");
+				execution.phase("generateProject-resources");
+				execution.configuration((configuration) -> {
+					configuration.add("doctype", "book");
+					configuration.add("backend", "html");
+				});
 			});
 		});
 		generatePom(build, (pom) -> {
@@ -415,8 +418,8 @@ class MavenBuildWriterTests {
 		MavenBuild build = new MavenBuild();
 		build.setGroup("com.example.demo");
 		build.setArtifact("demo");
-		MavenPlugin kotlin = build.plugin("org.jetbrains.kotlin", "kotlin-maven-plugin");
-		kotlin.dependency("org.jetbrains.kotlin", "kotlin-maven-allopen", "${kotlin.version}");
+		build.plugins().add("org.jetbrains.kotlin", "kotlin-maven-plugin",
+				(plugin) -> plugin.dependency("org.jetbrains.kotlin", "kotlin-maven-allopen", "${kotlin.version}"));
 		generatePom(build, (pom) -> {
 			NodeAssert plugin = pom.nodeAtPath("/project/build/plugins/plugin");
 			assertThat(plugin).textAtPath("groupId").isEqualTo("org.jetbrains.kotlin");
@@ -433,8 +436,7 @@ class MavenBuildWriterTests {
 		MavenBuild build = new MavenBuild();
 		build.setGroup("com.example.demo");
 		build.setArtifact("demo");
-		MavenPlugin demoPlugin = build.plugin("com.example.demo", "demo-plugin");
-		demoPlugin.extensions();
+		build.plugins().add("com.example.demo", "demo-plugin", (plugin) -> plugin.extensions());
 		generatePom(build, (pom) -> {
 			NodeAssert plugin = pom.nodeAtPath("/project/build/plugins/plugin");
 			assertThat(plugin).textAtPath("groupId").isEqualTo("com.example.demo");

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenPluginContainerTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenPluginContainerTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.buildsystem.maven;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MavenPluginContainer}.
+ *
+ * @author HaiTao Zhang
+ */
+public class MavenPluginContainerTests {
+
+	@Test
+	void addMavenPlugin() {
+		MavenPluginContainer pluginContainer = new MavenPluginContainer();
+		pluginContainer.add("com.example", "test-plugin");
+		assertThat(pluginContainer.values()).hasSize(1);
+		pluginContainer.values().findFirst().ifPresent((plugin) -> {
+			assertThat(plugin.getGroupId()).isEqualTo("com.example");
+			assertThat(plugin.getArtifactId()).isEqualTo("test-plugin");
+			assertThat(plugin.getVersion()).isNull();
+		});
+	}
+
+	@Test
+	void addMavenPluginWithConsumer() {
+		MavenPluginContainer pluginContainer = new MavenPluginContainer();
+		pluginContainer.add("com.example", "test-plugin", (plugin) -> {
+			plugin.setVersion("1.0");
+			plugin.execution("first", (first) -> first.goal("run-this"));
+		});
+		assertThat(pluginContainer.values()).hasSize(1);
+		pluginContainer.values().findFirst().ifPresent((plugin) -> {
+			assertThat(plugin.getGroupId()).isEqualTo("com.example");
+			assertThat(plugin.getArtifactId()).isEqualTo("test-plugin");
+			assertThat(plugin.getVersion()).isEqualTo("1.0");
+			assertThat(plugin.getExecutions()).hasSize(1);
+			assertThat(plugin.getExecutions().get(0).getId()).isEqualTo("first");
+			assertThat(plugin.getExecutions().get(0).getGoals()).containsExactly("run-this");
+		});
+	}
+
+}

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenPluginTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenPluginTests.java
@@ -57,11 +57,13 @@ class MavenPluginTests {
 	@SuppressWarnings("unchecked")
 	void configurationParameterWithNestedValuesCanBeCustomized() {
 		MavenPlugin plugin = new MavenPlugin("com.example", "test-plugin");
-		plugin.configuration((configuration) -> configuration.configure("items", (items) -> items.add("item", "one")));
-		plugin.configuration((configuration) -> configuration.configure("items", (items) -> items.add("item", "two")));
+		plugin.configuration(
+				(configuration) -> configuration.configure("plugins", (items) -> items.add("item", "one")));
+		plugin.configuration(
+				(configuration) -> configuration.configure("plugins", (items) -> items.add("item", "two")));
 		assertThat(plugin.getConfiguration().getSettings()).hasSize(1);
 		Setting setting = plugin.getConfiguration().getSettings().get(0);
-		assertThat(setting.getName()).isEqualTo("items");
+		assertThat(setting.getName()).isEqualTo("plugins");
 		assertThat(setting.getValue()).isInstanceOf(List.class);
 		List<Setting> values = (List<Setting>) setting.getValue();
 		assertThat(values.stream().map(Setting::getName)).containsExactly("item", "item");
@@ -72,13 +74,13 @@ class MavenPluginTests {
 	@SuppressWarnings("unchecked")
 	void configurationParameterWithSeveralLevelOfNestedValuesCanBeCustomized() {
 		MavenPlugin plugin = new MavenPlugin("com.example", "test-plugin");
-		plugin.configuration((configuration) -> configuration.configure("items",
+		plugin.configuration((configuration) -> configuration.configure("plugins",
 				(items) -> items.configure("item", (subItems) -> subItems.add("subItem", "one"))));
-		plugin.configuration((configuration) -> configuration.configure("items", (items) -> items.configure("item",
+		plugin.configuration((configuration) -> configuration.configure("plugins", (items) -> items.configure("item",
 				(subItems) -> subItems.add("subItem", "two").add("subItem", "three"))));
 		assertThat(plugin.getConfiguration().getSettings()).hasSize(1);
 		Setting setting = plugin.getConfiguration().getSettings().get(0);
-		assertThat(setting.getName()).isEqualTo("items");
+		assertThat(setting.getName()).isEqualTo("plugins");
 		assertThat(setting.getValue()).isInstanceOf(List.class);
 		List<Setting> items = (List<Setting>) setting.getValue();
 		assertThat(items).hasSize(1);


### PR DESCRIPTION
This is a fix to GitHub issue #909. `MavenPluginContainer` and `GradlePluginContainer` were created to help manage build plugins which include adding and removing of plugins. Includes added functionality in both containers to customize plugins using a `Consumer`.