### PR TITLE
Invalid array declaration for Annotation attributes with Groovy

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovySourceCodeWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovySourceCodeWriter.java
@@ -179,7 +179,7 @@ public class GroovySourceCodeWriter implements SourceCodeWriter<GroovySourceCode
 
 	private String formatValues(List<String> values, Function<String, String> formatter) {
 		String result = values.stream().map(formatter).collect(Collectors.joining(", "));
-		return (values.size() > 1) ? "{ " + result + " }" : result;
+		return (values.size() > 1) ? "[ " + result + " ]" : result;
 	}
 
 	private void writeFieldDeclaration(IndentingWriter writer, GroovyFieldDeclaration fieldDeclaration) {


### PR DESCRIPTION
The generated Groovy files were declaring arrays as : {1, 2} instead of [1,2]. This changes fixes the array declaration.