### PR TITLE
Package name containing reserved Java keyword is not cleaned up 

### DIFF
--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/InitializrConfiguration.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/InitializrConfiguration.java
@@ -25,6 +25,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.lang.model.SourceVersion;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.spring.initializr.generator.version.InvalidVersionException;
 import io.spring.initializr.generator.version.Version;
@@ -38,6 +40,7 @@ import org.springframework.util.StringUtils;
  * Various configuration options used by the service.
  *
  * @author Stephane Nicoll
+ * @author Chris Bono
  */
 public class InitializrConfiguration {
 
@@ -113,6 +116,9 @@ public class InitializrConfiguration {
 		if (hasInvalidChar(candidate.replace(".", "")) || this.env.invalidPackageNames.contains(candidate)) {
 			return defaultPackageName;
 		}
+		if (hasReservedKeyword(candidate)) {
+			return defaultPackageName;
+		}
 		else {
 			return candidate;
 		}
@@ -153,6 +159,10 @@ public class InitializrConfiguration {
 			}
 		}
 		return false;
+	}
+
+	private static boolean hasReservedKeyword(final String packageName) {
+		return Arrays.stream(packageName.split("\\.")).anyMatch(SourceVersion::isKeyword);
 	}
 
 	/**


### PR DESCRIPTION
This PR adds Java reserved keywords to package name cleaning and fixes gh-983.

### Verification

* Added thorough parameterized unit tests

* Ran curl against locally running `initializr-service-sample` using custom package name with reserved keyword - verified it uses default name instead:

```
curl localhost:8080/starter.zip -o demo.zip -d packageName=com.import.bar
```
which contains...
```
IT-USA-10850:temp cbono$ unzip demo.zip
Archive:  demo.zip
  inflating: mvnw.cmd
  inflating: pom.xml
  inflating: .gitignore
   creating: .mvn/
   creating: .mvn/wrapper/
  inflating: .mvn/wrapper/MavenWrapperDownloader.java
  inflating: .mvn/wrapper/maven-wrapper.properties
  inflating: .mvn/wrapper/maven-wrapper.jar
  inflating: mvnw
   creating: src/
   creating: src/test/
   creating: src/test/java/
   creating: src/test/java/org/
   creating: src/test/java/org/acme/
   creating: src/test/java/org/acme/demo/
  inflating: src/test/java/org/acme/demo/DemoApplicationTests.java
   creating: src/main/
   creating: src/main/resources/
  inflating: src/main/resources/application.properties
   creating: src/main/java/
   creating: src/main/java/org/
   creating: src/main/java/org/acme/
   creating: src/main/java/org/acme/demo/
  inflating: src/main/java/org/acme/demo/DemoApplication.java
```
