### PR TITLE
Requests to /dependencies with an unexpected Boot version fail with an internal server error

### DIFF
--- a/initializr-metadata/src/test/java/io/spring/initializr/metadata/BillOfMaterialsTests.java
+++ b/initializr-metadata/src/test/java/io/spring/initializr/metadata/BillOfMaterialsTests.java
@@ -124,6 +124,15 @@ class BillOfMaterialsTests {
 	}
 
 	@Test
+	void noRangeAvailableSafe() {
+		BillOfMaterials bom = BillOfMaterials.create("com.example", "bom");
+		bom.getMappings().add(Mapping.create("[1.2.0.RELEASE,1.3.0.M1)", "1.1.0"));
+		bom.getMappings().add(Mapping.create("[1.3.0.M1, 1.4.0.M1)", "1.2.0"));
+		bom.validate();
+		assertThat(bom.resolveSafe(Version.parse("1.4.1.RELEASE"))).isEmpty();
+	}
+
+	@Test
 	void resolveRangeWithVariablePatch() {
 		BillOfMaterials bom = BillOfMaterials.create("com.example", "bom", "1.0.0");
 		bom.getMappings().add(Mapping.create("[1.3.0.RELEASE,1.3.x.RELEASE]", "1.1.0"));

--- a/initializr-web/src/main/java/io/spring/initializr/web/controller/InvalidMetadataRequestException.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/controller/InvalidMetadataRequestException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.web.controller;
+
+/**
+ * Thrown when a metadata request is invalid.
+ *
+ * @author Chris Bono
+ */
+@SuppressWarnings("serial")
+public class InvalidMetadataRequestException extends RuntimeException {
+
+	public InvalidMetadataRequestException(String message) {
+		super(message);
+	}
+
+}

--- a/initializr-web/src/main/java/io/spring/initializr/web/controller/ProjectMetadataController.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/controller/ProjectMetadataController.java
@@ -16,7 +16,10 @@
 
 package io.spring.initializr.web.controller;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+
+import javax.servlet.http.HttpServletResponse;
 
 import io.spring.initializr.generator.version.Version;
 import io.spring.initializr.metadata.DependencyMetadata;
@@ -30,9 +33,11 @@ import io.spring.initializr.web.mapper.InitializrMetadataV2JsonMapper;
 import io.spring.initializr.web.mapper.InitializrMetadataVersion;
 
 import org.springframework.http.CacheControl;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -83,6 +88,12 @@ public class ProjectMetadataController extends AbstractMetadataController {
 	@RequestMapping(path = "/dependencies", produces = { "application/vnd.initializr.v2.1+json", "application/json" })
 	public ResponseEntity<String> dependenciesV21(@RequestParam(required = false) String bootVersion) {
 		return dependenciesFor(InitializrMetadataVersion.V2_1, bootVersion);
+	}
+
+	@ExceptionHandler
+	public void invalidMetadaRequest(HttpServletResponse response, InvalidMetadataRequestException ex)
+			throws IOException {
+		response.sendError(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
 	}
 
 	/**

--- a/initializr-web/src/main/java/io/spring/initializr/web/support/DefaultDependencyMetadataProvider.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/support/DefaultDependencyMetadataProvider.java
@@ -26,6 +26,7 @@ import io.spring.initializr.metadata.DependencyMetadata;
 import io.spring.initializr.metadata.DependencyMetadataProvider;
 import io.spring.initializr.metadata.InitializrMetadata;
 import io.spring.initializr.metadata.Repository;
+import io.spring.initializr.web.controller.InvalidMetadataRequestException;
 
 import org.springframework.cache.annotation.Cacheable;
 
@@ -57,8 +58,12 @@ public class DefaultDependencyMetadataProvider implements DependencyMetadataProv
 		Map<String, BillOfMaterials> boms = new LinkedHashMap<>();
 		for (Dependency dependency : dependencies.values()) {
 			if (dependency.getBom() != null) {
-				boms.put(dependency.getBom(),
-						metadata.getConfiguration().getEnv().getBoms().get(dependency.getBom()).resolve(bootVersion));
+				BillOfMaterials bom = metadata.getConfiguration().getEnv().getBoms().get(dependency.getBom())
+						.resolveSafe(bootVersion)
+						.orElseThrow(() -> new InvalidMetadataRequestException(String.format(
+								"Dependency '%s' points to Bom '%s' that is not compatible with requested platform version '%s'.",
+								dependency.getId(), dependency.getBom(), bootVersion)));
+				boms.put(dependency.getBom(), bom);
 			}
 		}
 		// Each resolved bom may require additional repositories

--- a/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerIntegrationTests.java
@@ -61,6 +61,18 @@ public class ProjectMetadataControllerIntegrationTests extends AbstractInitializ
 	}
 
 	@Test
+	void metadataWithInvalidBootVersion() {
+		try {
+			execute("/dependencies?bootVersion=1.5.17.RELEASE", String.class, "application/vnd.initializr.v2.1+json",
+					"application/json");
+		}
+		catch (HttpClientErrorException ex) {
+			assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+			assertThat(ex.getResponseBodyAsString().contains("1.5.17.RELEASE"));
+		}
+	}
+
+	@Test
 	void metadataWithCurrentAcceptHeader() {
 		getRequests().setFields("_links.maven-project", "dependencies.values[0]", "type.values[0]",
 				"javaVersion.values[0]", "packaging.values[0]", "bootVersion.values[0]", "language.values[0]");

--- a/initializr-web/src/test/java/io/spring/initializr/web/support/DefaultDependencyMetadataProviderTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/support/DefaultDependencyMetadataProviderTests.java
@@ -23,9 +23,11 @@ import io.spring.initializr.metadata.Dependency;
 import io.spring.initializr.metadata.DependencyMetadata;
 import io.spring.initializr.metadata.DependencyMetadataProvider;
 import io.spring.initializr.metadata.InitializrMetadata;
+import io.spring.initializr.web.controller.InvalidMetadataRequestException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Stephane Nicoll
@@ -72,6 +74,21 @@ class DefaultDependencyMetadataProviderTests {
 		assertThat(anotherDependencyMetadata.getDependencies().get("first").getGroupId()).isEqualTo("org.biz");
 		assertThat(anotherDependencyMetadata.getDependencies().get("first").getArtifactId()).isEqualTo("third");
 		assertThat(anotherDependencyMetadata.getDependencies().get("first").getVersion()).isEqualTo("0.2.0.RELEASE");
+	}
+
+	@Test
+	void resolveBomInvalidBootVersion() {
+		Dependency first = Dependency.withId("first", "org.foo", "first");
+		first.setRepository("repo-foo");
+		first.setBom("bom-foo");
+		BillOfMaterials bom = BillOfMaterials.create("org.foo", "bom");
+		bom.getMappings()
+				.add(BillOfMaterials.Mapping.create("[1.0.0.RELEASE, 1.1.0.RELEASE)", "2.0.0.RELEASE", "repo-foo"));
+		InitializrMetadata metadata = InitializrMetadataTestBuilder.withDefaults().addBom("bom-foo", bom)
+				.addRepository("repo-foo", "foo", "http://localhost", false).addDependencyGroup("test", first).build();
+		assertThatExceptionOfType(InvalidMetadataRequestException.class)
+				.isThrownBy(() -> this.provider.get(metadata, Version.parse("1.1.5.RELEASE")))
+				.withMessageContainingAll(first.getId(), first.getBom(), "1.1.5.RELEASE");
 	}
 
 	@Test


### PR DESCRIPTION
Fixes gh-1033

Invalid `bootVersion` request now results in the following 400 response.

```json
{
  "timestamp": "2019-11-17T01:06:13.415+0000",
  "status": 400,
  "error": "Bad Request",
  "message": "Dependency 'my-api' points to BOM 'my-api-bom' that is not compatible with requested platform version '1.5.2'.",
  "trace": "io.spring.initializr.web.controller.InvalidMetadataRequestException: Dependency 'my-api' points to BOM 'my-api-bom' that is not compatible with requested platform version '1.5.2'.\n\tat io.spring.initializr.web.support.DefaultDependencyMetadataProvider.lambda$get$0(DefaultDependencyMetadataProvider.java:63)\n\tat
...
}
```