### PR TITLE
Fixed a heading format problem

### DIFF
--- a/initializr-docs/src/main/asciidoc/metadata-format.adoc
+++ b/initializr-docs/src/main/asciidoc/metadata-format.adoc
@@ -10,7 +10,7 @@ sent to the service. A good structure for a user agent is `clientId/clientVersio
 
 
 
-== Content
+== The Content
 Any third party client can retrieve the capabilities of the service by issuing a
 `GET` on the root URL using the following `Accept` header:
 `application/vnd.initializr.v2.1+json`. Please note that the metadata may evolve in a


### PR DESCRIPTION
The "Content" heading in metadata-format.adoc was being rendered to the right, because (I think) Asciidoctor treats a header named "Content" as a ToC heading. I changed it to "The Content". That makes it render correctly.