### PR TITLE
Enhance MavenBuildWriter to escape special characters in POM file

### DIFF
--- a/initializr-generator/pom.xml
+++ b/initializr-generator/pom.xml
@@ -27,6 +27,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>com.samskivert</groupId>
 			<artifactId>jmustache</artifactId>
 			<optional>true</optional>

--- a/initializr-generator/pom.xml
+++ b/initializr-generator/pom.xml
@@ -27,11 +27,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-text</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>com.samskivert</groupId>
 			<artifactId>jmustache</artifactId>
 			<optional>true</optional>

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
@@ -44,6 +44,7 @@ import io.spring.initializr.generator.buildsystem.maven.MavenPlugin.Setting;
 import io.spring.initializr.generator.io.IndentingWriter;
 import io.spring.initializr.generator.version.VersionProperty;
 import io.spring.initializr.generator.version.VersionReference;
+import org.apache.commons.text.StringEscapeUtils;
 
 import org.springframework.util.ObjectUtils;
 
@@ -485,7 +486,7 @@ public class MavenBuildWriter {
 	private void writeSingleElement(IndentingWriter writer, String name, String text) {
 		if (text != null) {
 			writer.print(String.format("<%s>", name));
-			writer.print(text);
+			writer.print(StringEscapeUtils.escapeXml10(text));
 			writer.println(String.format("</%s>", name));
 		}
 	}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
@@ -44,7 +44,6 @@ import io.spring.initializr.generator.buildsystem.maven.MavenPlugin.Setting;
 import io.spring.initializr.generator.io.IndentingWriter;
 import io.spring.initializr.generator.version.VersionProperty;
 import io.spring.initializr.generator.version.VersionReference;
-import org.apache.commons.text.StringEscapeUtils;
 
 import org.springframework.util.ObjectUtils;
 
@@ -486,7 +485,7 @@ public class MavenBuildWriter {
 	private void writeSingleElement(IndentingWriter writer, String name, String text) {
 		if (text != null) {
 			writer.print(String.format("<%s>", name));
-			writer.print(StringEscapeUtils.escapeXml10(text));
+			writer.print(escapeString(text));
 			writer.println(String.format("</%s>", name));
 		}
 	}
@@ -514,6 +513,34 @@ public class MavenBuildWriter {
 		if (!collection.isEmpty()) {
 			collection.forEach((item) -> itemWriter.accept(writer, item));
 		}
+	}
+
+	private String escapeString(String inputString) {
+		StringBuilder stringBuilder = new StringBuilder();
+		for (int i = 0; i < inputString.length(); i++) {
+			char character = inputString.charAt(i);
+			switch (character) {
+			case '\'':
+				stringBuilder.append("&apos;");
+				break;
+			case '\"':
+				stringBuilder.append("&quot;");
+				break;
+			case '<':
+				stringBuilder.append("&lt;");
+				break;
+			case '>':
+				stringBuilder.append("&gt;");
+				break;
+			case '&':
+				stringBuilder.append("&amp;");
+				break;
+			default:
+				stringBuilder.append(character);
+			}
+		}
+
+		return stringBuilder.toString();
 	}
 
 }

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriterTests.java
@@ -707,13 +707,13 @@ class MavenBuildWriterTests {
 	}
 
 	@Test
-	void powWithDistributionManagementEmpty() {
+	void pomWithDistributionManagementEmpty() {
 		MavenBuild build = new MavenBuild();
 		generatePom(build, (pom) -> assertThat(pom).nodeAtPath("/project/distributionManagement").isNull());
 	}
 
 	@Test
-	void powWithDistributionManagementDownloadUrl() {
+	void pomWithDistributionManagementDownloadUrl() {
 		MavenBuild build = new MavenBuild();
 		build.distributionManagement().downloadUrl("https://example.com/download");
 		generatePom(build, (pom) -> {
@@ -727,7 +727,7 @@ class MavenBuildWriterTests {
 	}
 
 	@Test
-	void powWithDistributionManagementRepository() {
+	void pomWithDistributionManagementRepository() {
 		MavenBuild build = new MavenBuild();
 		build.distributionManagement().repository((repository) -> repository.id("released-repo").name("released repo")
 				.url("https://upload.example.com/releases"));
@@ -747,7 +747,7 @@ class MavenBuildWriterTests {
 	}
 
 	@Test
-	void powWithDistributionManagementSnapshotRepository() {
+	void pomWithDistributionManagementSnapshotRepository() {
 		MavenBuild build = new MavenBuild();
 		build.distributionManagement().snapshotRepository((repository) -> repository.id("snapshot-repo")
 				.name("snapshot repo").url("scp://upload.example.com/snapshots").layout("legacy").uniqueVersion(true));
@@ -767,7 +767,7 @@ class MavenBuildWriterTests {
 	}
 
 	@Test
-	void powWithDistributionManagementSite() {
+	void pomWithDistributionManagementSite() {
 		MavenBuild build = new MavenBuild();
 		build.distributionManagement().site((site) -> site.id("website").name("web site"))
 				.site((site) -> site.url("scp://www.example.com/www/docs/project"));
@@ -785,7 +785,7 @@ class MavenBuildWriterTests {
 	}
 
 	@Test
-	void powWithDistributionManagementRelocation() {
+	void pomWithDistributionManagementRelocation() {
 		MavenBuild build = new MavenBuild();
 		build.distributionManagement().relocation((relocation) -> relocation.groupId("com.example.new")
 				.artifactId("project").version("1.0.0").message("moved"));

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriterTests.java
@@ -802,11 +802,39 @@ class MavenBuildWriterTests {
 		});
 	}
 
+	@Test
+	void pomWithEscapedCharacters() {
+		MavenBuild build = new MavenBuild();
+		build.settings().coordinates("com.example.demo", "demo").name("<demo project>")
+				.description("A \"demo\" project for 'developers' & 'testers'");
+
+		generatePomString(build, (pomString) -> {
+			String separator = System.lineSeparator();
+			assertThat(pomString).isEqualTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + separator
+					+ "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
+					+ separator
+					+ "    xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd\">"
+					+ separator + "    <modelVersion>4.0.0</modelVersion>" + separator
+					+ "    <groupId>com.example.demo</groupId>" + separator + "    <artifactId>demo</artifactId>"
+					+ separator + "    <version>0.0.1-SNAPSHOT</version>" + separator
+					+ "    <name>&lt;demo project&gt;</name>" + separator
+					+ "    <description>A &quot;demo&quot; project for &apos;developers&apos; &amp; &apos;testers&apos;</description>"
+					+ separator + separator + "</project>" + separator);
+		});
+	}
+
 	private void generatePom(MavenBuild mavenBuild, Consumer<NodeAssert> consumer) {
 		MavenBuildWriter writer = new MavenBuildWriter();
 		StringWriter out = new StringWriter();
 		writer.writeTo(new IndentingWriter(out), mavenBuild);
 		consumer.accept(new NodeAssert(out.toString()));
+	}
+
+	private void generatePomString(MavenBuild mavenBuild, Consumer<String> consumer) {
+		MavenBuildWriter writer = new MavenBuildWriter();
+		StringWriter out = new StringWriter();
+		writer.writeTo(new IndentingWriter(out), mavenBuild);
+		consumer.accept(out.toString());
 	}
 
 }


### PR DESCRIPTION
Hello people,

This pull request fixes the issue of escaping special characters in attributes' values inside generated POM file.  Furthermore, it also fixes some typos for some of the methods' names inside the test class for `MavenBuildWriter`. It has been submitted as a response to issue #1066

There's just one problem that I couldn't solve, and that is that I couldn't write a test case for this change. When I attempted to write a test case against this code, I couldn't get the escaped values for special characters when I had used them in the POM's attributes. Instead, I kept on getting the unescaped values in our test class.

Analyzing the code in our test class, I found out that we use Java's native `DocumentBuilder` API in order to parse the generated POM output and that is where the issue lies. When the POM file is parsed through that API, it unescapes the values for those attributes that have special characters inside them. So there is no way we can determine the actual values of the attributes that were created by our `MavenBuildWriter`.

Therefore, if you have any idea to test this code, please let me know and I would be happy to incorporate those changes in order to get this completed.

PS:
I agree that adding a library only for the sake of escaping strings seems to be an overkill and I could have probably written custom code inside `MavenBuildWriter` in order to escape special characters. However, in my opinion, writing custom code for doing such a thing for a well-known spec like XML can break things. I, even, had a peek at some of Java's own XML APIs but my quest for finding such an API miserably failed. Therefore, I went with the option of choosing the library and the library has already been used in `initializr-web`.