### PR TITLE
add support for nested annotation attribute

### DIFF
--- a/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/GroovyDslGradleBuildAssert.java
+++ b/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/GroovyDslGradleBuildAssert.java
@@ -91,12 +91,12 @@ public class GroovyDslGradleBuildAssert extends AbstractTextAssert<GroovyDslGrad
 	 * @return this for method chaining.
 	 */
 	public GroovyDslGradleBuildAssert containsOnlyExtProperties(String... values) {
-		StringBuilder builder = new StringBuilder(String.format("ext {%n"));
+		StringBuilder builder = new StringBuilder(String.format("ext {\n"));
 		if (values.length % 2 == 1) {
 			throw new IllegalArgumentException("Size must be even, it is a set of property=value pairs");
 		}
 		for (int i = 0; i < values.length; i += 2) {
-			builder.append(String.format("\tset('%s', \"%s\")%n", values[i], values[i + 1]));
+			builder.append(String.format("\tset('%s', \"%s\")\n", values[i], values[i + 1]));
 		}
 		builder.append("}");
 		return contains(builder.toString());

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/Annotation.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/Annotation.java
@@ -96,6 +96,7 @@ public final class Annotation {
 		private final Class<?> type;
 
 		private final List<String> values;
+
 		private final List<Annotation> nestedAnnotations;
 
 		private Attribute(String name, Class<?> type, String... values) {
@@ -108,7 +109,7 @@ public final class Annotation {
 		private Attribute(String name, Class<?> type, Annotation... values) {
 			this.name = name;
 			this.type = type;
-			this.values =  Collections.emptyList();
+			this.values = Collections.emptyList();
 			this.nestedAnnotations = Arrays.asList(values);
 		}
 
@@ -127,6 +128,7 @@ public final class Annotation {
 		public List<Annotation> getNestedAnnotations() {
 			return this.nestedAnnotations;
 		}
+
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/Annotation.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/Annotation.java
@@ -79,6 +79,11 @@ public final class Annotation {
 			return this;
 		}
 
+		public Builder attribute(String name, Class<?> type, Annotation... values) {
+			this.attributes.put(name, new Attribute(name, type, values));
+			return this;
+		}
+
 	}
 
 	/**
@@ -91,11 +96,20 @@ public final class Annotation {
 		private final Class<?> type;
 
 		private final List<String> values;
+		private final List<Annotation> nestedAnnotations;
 
 		private Attribute(String name, Class<?> type, String... values) {
 			this.name = name;
 			this.type = type;
 			this.values = Arrays.asList(values);
+			this.nestedAnnotations = Collections.emptyList();
+		}
+
+		private Attribute(String name, Class<?> type, Annotation... values) {
+			this.name = name;
+			this.type = type;
+			this.values =  Collections.emptyList();
+			this.nestedAnnotations = Arrays.asList(values);
 		}
 
 		public String getName() {
@@ -110,6 +124,9 @@ public final class Annotation {
 			return this.values;
 		}
 
+		public List<Annotation> getNestedAnnotations() {
+			return this.nestedAnnotations;
+		}
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriter.java
@@ -18,7 +18,6 @@ package io.spring.initializr.generator.language.java;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.io.Writer;
 import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -184,7 +183,7 @@ public class JavaSourceCodeWriter implements SourceCodeWriter<JavaSourceCode> {
 			return formatValues(values, (value) -> String.format("\"%s\"", value));
 		}
 		if (attribute.getType().isAnnotation()) {
-			return formatAttributes(attribute.getNestedAnnotations(), this::formatAnnotation);
+			return formatNestedAnnotation(attribute.getNestedAnnotations(), this::formatAnnotation);
 		}
 		return formatValues(values, (value) -> String.format("%s", value));
 	}
@@ -194,7 +193,7 @@ public class JavaSourceCodeWriter implements SourceCodeWriter<JavaSourceCode> {
 		return (values.size() > 1) ? "{ " + result + " }" : result;
 	}
 
-	private String formatAttributes(List<Annotation> annotations, Function<Annotation, String> formatter) {
+	private String formatNestedAnnotation(List<Annotation> annotations, Function<Annotation, String> formatter) {
 		String result = annotations.stream().map(formatter).collect(Collectors.joining(", "));
 		return (annotations.size() > 1) ? "{ " + result + " }" : result;
 	}
@@ -308,7 +307,6 @@ public class JavaSourceCodeWriter implements SourceCodeWriter<JavaSourceCode> {
 			if (attribute.getType().isAnnotation()) {
 				imports.add(attribute.getType().getCanonicalName());
 			}
-
 		});
 		return imports;
 	}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriter.java
@@ -16,18 +16,29 @@
 
 package io.spring.initializr.generator.language.kotlin;
 
-import io.spring.initializr.generator.io.IndentingWriter;
-import io.spring.initializr.generator.io.IndentingWriterFactory;
-import io.spring.initializr.generator.language.*;
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import io.spring.initializr.generator.io.IndentingWriter;
+import io.spring.initializr.generator.io.IndentingWriterFactory;
+import io.spring.initializr.generator.language.Annotatable;
+import io.spring.initializr.generator.language.Annotation;
+import io.spring.initializr.generator.language.Parameter;
+import io.spring.initializr.generator.language.SourceCode;
+import io.spring.initializr.generator.language.SourceCodeWriter;
+import io.spring.initializr.generator.language.SourceStructure;
 
 /**
  * A {@link SourceCodeWriter} that writes {@link SourceCode} in Kotlin.
@@ -249,7 +260,6 @@ public class KotlinSourceCodeWriter implements SourceCodeWriter<KotlinSourceCode
 		String result = annotations.stream().map(formatter).collect(Collectors.joining(", "));
 		return (annotations.size() > 1) ? "[" + result + "]" : result;
 	}
-
 
 	private void writeModifiers(IndentingWriter writer, List<KotlinModifier> declaredModifiers) {
 		String modifiers = declaredModifiers.stream().filter((entry) -> !entry.equals(KotlinModifier.PUBLIC)).sorted()

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriter.java
@@ -16,28 +16,18 @@
 
 package io.spring.initializr.generator.language.kotlin;
 
+import io.spring.initializr.generator.io.IndentingWriter;
+import io.spring.initializr.generator.io.IndentingWriterFactory;
+import io.spring.initializr.generator.language.*;
+
 import java.io.IOException;
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import io.spring.initializr.generator.io.IndentingWriter;
-import io.spring.initializr.generator.io.IndentingWriterFactory;
-import io.spring.initializr.generator.language.Annotatable;
-import io.spring.initializr.generator.language.Annotation;
-import io.spring.initializr.generator.language.Parameter;
-import io.spring.initializr.generator.language.SourceCode;
-import io.spring.initializr.generator.language.SourceCodeWriter;
-import io.spring.initializr.generator.language.SourceStructure;
 
 /**
  * A {@link SourceCodeWriter} that writes {@link SourceCode} in Kotlin.
@@ -201,26 +191,32 @@ public class KotlinSourceCodeWriter implements SourceCodeWriter<KotlinSourceCode
 	}
 
 	private void writeAnnotation(IndentingWriter writer, Annotation annotation, boolean newLine) {
-		writer.print("@" + getUnqualifiedName(annotation.getName()));
-		List<Annotation.Attribute> attributes = annotation.getAttributes();
-		if (!attributes.isEmpty()) {
-			writer.print("(");
-			if (attributes.size() == 1 && attributes.get(0).getName().equals("value")) {
-				writer.print(formatAnnotationAttribute(attributes.get(0)));
-			}
-			else {
-				writer.print(attributes.stream()
-						.map((attribute) -> attribute.getName() + " = " + formatAnnotationAttribute(attribute))
-						.collect(Collectors.joining(", ")));
-			}
-			writer.print(")");
-		}
+		writer.print(formatAnnotation(annotation));
 		if (newLine) {
 			writer.println();
 		}
 		else {
 			writer.print(" ");
 		}
+	}
+
+	private String formatAnnotation(Annotation annotation) {
+		StringWriter writer = new StringWriter();
+		writer.write("@" + getUnqualifiedName(annotation.getName()));
+		List<Annotation.Attribute> attributes = annotation.getAttributes();
+		if (!attributes.isEmpty()) {
+			writer.write("(");
+			if (attributes.size() == 1 && attributes.get(0).getName().equals("value")) {
+				writer.write(formatAnnotationAttribute(attributes.get(0)));
+			}
+			else {
+				writer.write(attributes.stream()
+						.map((attribute) -> attribute.getName() + " = " + formatAnnotationAttribute(attribute))
+						.collect(Collectors.joining(", ")));
+			}
+			writer.write(")");
+		}
+		return writer.toString();
 	}
 
 	private String formatAnnotationAttribute(Annotation.Attribute attribute) {
@@ -238,6 +234,9 @@ public class KotlinSourceCodeWriter implements SourceCodeWriter<KotlinSourceCode
 		if (attribute.getType().equals(String.class)) {
 			return formatValues(values, (value) -> String.format("\"%s\"", value));
 		}
+		if (attribute.getType().isAnnotation()) {
+			return formatNestedAnnotation(attribute.getNestedAnnotations(), this::formatAnnotation);
+		}
 		return formatValues(values, (value) -> String.format("%s", value));
 	}
 
@@ -245,6 +244,12 @@ public class KotlinSourceCodeWriter implements SourceCodeWriter<KotlinSourceCode
 		String result = values.stream().map(formatter).collect(Collectors.joining(", "));
 		return (values.size() > 1) ? "[" + result + "]" : result;
 	}
+
+	private String formatNestedAnnotation(List<Annotation> annotations, Function<Annotation, String> formatter) {
+		String result = annotations.stream().map(formatter).collect(Collectors.joining(", "));
+		return (annotations.size() > 1) ? "[" + result + "]" : result;
+	}
+
 
 	private void writeModifiers(IndentingWriter writer, List<KotlinModifier> declaredModifiers) {
 		String modifiers = declaredModifiers.stream().filter((entry) -> !entry.equals(KotlinModifier.PUBLIC)).sorted()
@@ -334,6 +339,9 @@ public class KotlinSourceCodeWriter implements SourceCodeWriter<KotlinSourceCode
 			if (Enum.class.isAssignableFrom(attribute.getType())) {
 				imports.addAll(attribute.getValues().stream().map((value) -> value.substring(0, value.lastIndexOf(".")))
 						.collect(Collectors.toList()));
+			}
+			if (attribute.getType().isAnnotation()) {
+				imports.add(attribute.getType().getCanonicalName());
 			}
 		});
 		return imports;

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/groovy/GroovySourceCodeWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/groovy/GroovySourceCodeWriterTests.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import io.spring.initializr.generator.condition.ConditionalOnLanguage;
 import io.spring.initializr.generator.io.IndentingWriterFactory;
 import io.spring.initializr.generator.language.Annotation;
 import io.spring.initializr.generator.language.Language;
@@ -255,6 +256,17 @@ class GroovySourceCodeWriterTests {
 		assertThat(lines).containsExactly("package com.example", "", "import com.example.One",
 				"import java.time.temporal.ChronoUnit", "import org.springframework.test.TestApplication", "",
 				"@TestApplication(target = One, unit = ChronoUnit.NANOS)", "class Test {", "", "}");
+	}
+
+	@Test
+	void annotationWithNestedAnnotationAttribute() throws IOException {
+		Annotation nested = Annotation.name("io.spring.initializr.generator.condition.ConditionalOnLanguage", (builder) ->
+				builder.attribute("value", String.class, "groovy"));
+		List<String> lines = writeClassAnnotation(Annotation.name("org.springframework.test.TestApplication",
+				(builder) -> builder.attribute("nested", ConditionalOnLanguage.class, nested)));
+		assertThat(lines).containsExactly("package com.example", "", "import io.spring.initializr.generator.condition.ConditionalOnLanguage",
+				"import org.springframework.test.TestApplication", "",
+				"@TestApplication(nested = @ConditionalOnLanguage(\"groovy\"))", "class Test {", "", "}");
 	}
 
 	private List<String> writeClassAnnotation(Annotation annotation) throws IOException {

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/groovy/GroovySourceCodeWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/groovy/GroovySourceCodeWriterTests.java
@@ -260,11 +260,12 @@ class GroovySourceCodeWriterTests {
 
 	@Test
 	void annotationWithNestedAnnotationAttribute() throws IOException {
-		Annotation nested = Annotation.name("io.spring.initializr.generator.condition.ConditionalOnLanguage", (builder) ->
-				builder.attribute("value", String.class, "groovy"));
+		Annotation nested = Annotation.name("io.spring.initializr.generator.condition.ConditionalOnLanguage",
+				(builder) -> builder.attribute("value", String.class, "groovy"));
 		List<String> lines = writeClassAnnotation(Annotation.name("org.springframework.test.TestApplication",
 				(builder) -> builder.attribute("nested", ConditionalOnLanguage.class, nested)));
-		assertThat(lines).containsExactly("package com.example", "", "import io.spring.initializr.generator.condition.ConditionalOnLanguage",
+		assertThat(lines).containsExactly("package com.example", "",
+				"import io.spring.initializr.generator.condition.ConditionalOnLanguage",
 				"import org.springframework.test.TestApplication", "",
 				"@TestApplication(nested = @ConditionalOnLanguage(\"groovy\"))", "class Test {", "", "}");
 	}

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriterTests.java
@@ -16,16 +16,6 @@
 
 package io.spring.initializr.generator.language.java;
 
-import io.spring.initializr.generator.condition.ConditionalOnLanguage;
-import io.spring.initializr.generator.io.IndentingWriterFactory;
-import io.spring.initializr.generator.language.Annotation;
-import io.spring.initializr.generator.language.Language;
-import io.spring.initializr.generator.language.Parameter;
-import io.spring.initializr.generator.language.SourceStructure;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.springframework.util.StreamUtils;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Modifier;
@@ -36,6 +26,17 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+
+import io.spring.initializr.generator.condition.ConditionalOnLanguage;
+import io.spring.initializr.generator.io.IndentingWriterFactory;
+import io.spring.initializr.generator.language.Annotation;
+import io.spring.initializr.generator.language.Language;
+import io.spring.initializr.generator.language.Parameter;
+import io.spring.initializr.generator.language.SourceStructure;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.springframework.util.StreamUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -261,11 +262,12 @@ class JavaSourceCodeWriterTests {
 
 	@Test
 	void annotationWithNestedAnnotationAttribute() throws IOException {
-		Annotation nested = Annotation.name("io.spring.initializr.generator.condition.ConditionalOnLanguage", (builder) ->
-				builder.attribute("value", String.class, "java"));
+		Annotation nested = Annotation.name("io.spring.initializr.generator.condition.ConditionalOnLanguage",
+				(builder) -> builder.attribute("value", String.class, "java"));
 		List<String> lines = writeClassAnnotation(Annotation.name("org.springframework.test.TestApplication",
 				(builder) -> builder.attribute("nested", ConditionalOnLanguage.class, nested)));
-		assertThat(lines).containsExactly("package com.example;", "", "import io.spring.initializr.generator.condition.ConditionalOnLanguage;",
+		assertThat(lines).containsExactly("package com.example;", "",
+				"import io.spring.initializr.generator.condition.ConditionalOnLanguage;",
 				"import org.springframework.test.TestApplication;", "",
 				"@TestApplication(nested = @ConditionalOnLanguage(\"java\"))", "class Test {", "", "}");
 	}
@@ -307,6 +309,9 @@ class JavaSourceCodeWriterTests {
 	}
 
 	private @interface Nested {
+
 		String value();
+
 	}
+
 }

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriterTests.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import io.spring.initializr.generator.condition.ConditionalOnLanguage;
 import io.spring.initializr.generator.io.IndentingWriterFactory;
 import io.spring.initializr.generator.language.Annotation;
 import io.spring.initializr.generator.language.Language;
@@ -314,6 +315,17 @@ class KotlinSourceCodeWriterTests {
 		assertThat(lines).containsExactly("package com.example", "", "import com.example.One",
 				"import java.time.temporal.ChronoUnit", "import org.springframework.test.TestApplication", "",
 				"@TestApplication(target = One::class, unit = ChronoUnit.NANOS)", "class Test");
+	}
+
+	@Test
+	void annotationWithNestedAnnotationAttribute() throws IOException {
+		Annotation nested = Annotation.name("io.spring.initializr.generator.condition.ConditionalOnLanguage", (builder) ->
+				builder.attribute("value", String.class, "kotlin"));
+		List<String> lines = writeClassAnnotation(Annotation.name("org.springframework.test.TestApplication",
+				(builder) -> builder.attribute("nested", ConditionalOnLanguage.class, nested)));
+		assertThat(lines).containsExactly("package com.example", "", "import io.spring.initializr.generator.condition.ConditionalOnLanguage",
+				"import org.springframework.test.TestApplication", "",
+				"@TestApplication(nested = @ConditionalOnLanguage(\"kotlin\"))", "class Test");
 	}
 
 	private List<String> writeClassAnnotation(Annotation annotation) throws IOException {

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriterTests.java
@@ -319,11 +319,12 @@ class KotlinSourceCodeWriterTests {
 
 	@Test
 	void annotationWithNestedAnnotationAttribute() throws IOException {
-		Annotation nested = Annotation.name("io.spring.initializr.generator.condition.ConditionalOnLanguage", (builder) ->
-				builder.attribute("value", String.class, "kotlin"));
+		Annotation nested = Annotation.name("io.spring.initializr.generator.condition.ConditionalOnLanguage",
+				(builder) -> builder.attribute("value", String.class, "kotlin"));
 		List<String> lines = writeClassAnnotation(Annotation.name("org.springframework.test.TestApplication",
 				(builder) -> builder.attribute("nested", ConditionalOnLanguage.class, nested)));
-		assertThat(lines).containsExactly("package com.example", "", "import io.spring.initializr.generator.condition.ConditionalOnLanguage",
+		assertThat(lines).containsExactly("package com.example", "",
+				"import io.spring.initializr.generator.condition.ConditionalOnLanguage",
 				"import org.springframework.test.TestApplication", "",
 				"@TestApplication(nested = @ConditionalOnLanguage(\"kotlin\"))", "class Test");
 	}


### PR DESCRIPTION
fix #1053

implementation notes:

1. the builder enforces annotation has only nested annotations or no nested annotations.
  The implementation is based on this prerequisite.

2. Writer keeps all nested annotations on the same line;
  we could force a new line per attribute (+indentation)

3. new `formatAnnotation` method creates internally a StringWriter. We could use the calling `IndentingWriter` but would need to pass it down `formatAnnotationAttribute` for callback

4. declaring the type and the full name of the annotation makes a duplicate.
  I think it would be best to remove the type. Downside of this is that - when providing an array of annotations - the user has to ensure to always pass the same type (else compilation issue)

5. nothing prevents a user from creating an infinite loop by nesting an annotation to itself

If you have an idea of a different approach regarding the change on `Annotation.Attribute` I'm all ears; I'm not fond of having 2 mixed models (class+value and nested) but I think that a interface with 2 implementations would add more complexity.
