### PR TITLE
Add support for writing credentials in Gradle's build file

### DIFF
--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-build.gradle.gen
@@ -10,8 +10,12 @@ sourceCompatibility = '1.8'
 
 repositories {
 	mavenCentral()
-	maven { url 'https://example.com/foo' }
-	maven { url 'https://example.com/bar' }
+	maven {
+		url 'https://example.com/foo'
+	}
+	maven {
+		url 'https://example.com/bar'
+	}
 }
 
 dependencies {

--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-build.gradle.kts.gen
@@ -10,8 +10,12 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
 	mavenCentral()
-	maven { url = uri("https://example.com/foo") }
-	maven { url = uri("https://example.com/bar") }
+	maven {
+		url = uri("https://example.com/foo")
+	}
+	maven {
+		url = uri("https://example.com/bar")
+	}
 }
 
 dependencies {

--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.gen
@@ -10,7 +10,9 @@ sourceCompatibility = '1.8'
 
 repositories {
 	mavenCentral()
-	maven { url 'https://repo.spring.io/milestone' }
+	maven {
+		url 'https://repo.spring.io/milestone'
+	}
 }
 
 dependencies {

--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.kts.gen
@@ -10,7 +10,9 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
 	mavenCentral()
-	maven { url = uri("https://repo.spring.io/milestone") }
+	maven {
+		url = uri("https://repo.spring.io/milestone")
+	}
 }
 
 dependencies {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/MavenRepository.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/MavenRepository.java
@@ -20,6 +20,7 @@ package io.spring.initializr.generator.buildsystem;
  * A Maven repository.
  *
  * @author Andy Wilkinson
+ * @author Jafer Khan Shamshad
  */
 public class MavenRepository {
 
@@ -37,11 +38,14 @@ public class MavenRepository {
 
 	private final boolean snapshotsEnabled;
 
+	private final MavenRepositoryCredentials credentials;
+
 	protected MavenRepository(Builder builder) {
 		this.id = builder.id;
 		this.name = builder.name;
 		this.url = builder.url;
 		this.snapshotsEnabled = builder.snapshotsEnabled;
+		this.credentials = builder.credentials;
 	}
 
 	/**
@@ -87,6 +91,14 @@ public class MavenRepository {
 		return this.snapshotsEnabled;
 	}
 
+	/**
+	 * Return the credentials required for accessing the repository.
+	 * @return the repository credentials
+	 */
+	public MavenRepositoryCredentials getCredentials() {
+		return this.credentials;
+	}
+
 	public static class Builder {
 
 		private String id;
@@ -96,6 +108,8 @@ public class MavenRepository {
 		private String url;
 
 		private boolean snapshotsEnabled;
+
+		private MavenRepositoryCredentials credentials;
 
 		public Builder(String id, String url) {
 			this.id = id;
@@ -140,6 +154,16 @@ public class MavenRepository {
 		 */
 		public Builder snapshotsEnabled(boolean snapshotsEnabled) {
 			this.snapshotsEnabled = snapshotsEnabled;
+			return this;
+		}
+
+		/**
+		 * Set the credentials required for accessing the repository.
+		 * @param credentials the credentials
+		 * @return this for method chaining
+		 */
+		public Builder credentials(MavenRepositoryCredentials credentials) {
+			this.credentials = credentials;
 			return this;
 		}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/MavenRepositoryCredentials.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/MavenRepositoryCredentials.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.buildsystem;
+
+/**
+ * Represents credentials for a {@link MavenRepository maven repository}.
+ *
+ * @author Jafer Khan Shamshad
+ */
+public class MavenRepositoryCredentials {
+
+	private final String username;
+
+	private final String password;
+
+	public MavenRepositoryCredentials(String username, String password) {
+		this.username = username;
+		this.password = password;
+	}
+
+	/**
+	 * Return the username required to access the repository.
+	 * @return the username
+	 */
+	public String getUsername() {
+		return this.username;
+	}
+
+	/**
+	 * Return the password required to access the repository.
+	 * @return the password
+	 */
+	public String getPassword() {
+		return this.password;
+	}
+
+}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
@@ -46,6 +46,7 @@ import io.spring.initializr.generator.version.VersionProperty;
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  * @author Jean-Baptiste Nizet
+ * @author Jafer Khan Shamshad
  * @see GroovyDslGradleBuildWriter
  * @see KotlinDslGradleBuildWriter
  */
@@ -96,11 +97,15 @@ public abstract class GradleBuildWriter {
 	protected abstract void writeConfigurations(IndentingWriter writer, GradleConfigurationContainer configurations);
 
 	protected final void writeRepositories(IndentingWriter writer, GradleBuild build) {
-		writeNestedCollection(writer, "repositories", build.repositories().items().collect(Collectors.toList()),
-				this::repositoryAsString);
+		List<MavenRepository> repositories = build.repositories().items().collect(Collectors.toList());
+		if (!repositories.isEmpty()) {
+			writer.println("repositories {");
+			writer.indented(() -> repositories.forEach((repository) -> writeRepository(writer, repository)));
+			writer.println("}");
+		}
 	}
 
-	protected abstract String repositoryAsString(MavenRepository repository);
+	protected abstract void writeRepository(IndentingWriter writer, MavenRepository repository);
 
 	private void writeProperties(IndentingWriter writer, PropertyContainer properties) {
 		if (properties.isEmpty()) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriter.java
@@ -25,6 +25,7 @@ import io.spring.initializr.generator.buildsystem.BillOfMaterials;
 import io.spring.initializr.generator.buildsystem.Dependency;
 import io.spring.initializr.generator.buildsystem.Dependency.Exclusion;
 import io.spring.initializr.generator.buildsystem.MavenRepository;
+import io.spring.initializr.generator.buildsystem.MavenRepositoryCredentials;
 import io.spring.initializr.generator.io.IndentingWriter;
 import io.spring.initializr.generator.version.VersionProperty;
 import io.spring.initializr.generator.version.VersionReference;
@@ -33,6 +34,7 @@ import io.spring.initializr.generator.version.VersionReference;
  * A {@link GradleBuild} writer for {@code build.gradle}.
  *
  * @author Jean-Baptiste Nizet
+ * @author Jafer Khan Shamshad
  */
 public class GroovyDslGradleBuildWriter extends GradleBuildWriter {
 
@@ -92,11 +94,27 @@ public class GroovyDslGradleBuildWriter extends GradleBuildWriter {
 	}
 
 	@Override
-	protected String repositoryAsString(MavenRepository repository) {
+	protected void writeRepository(IndentingWriter writer, MavenRepository repository) {
 		if (MavenRepository.MAVEN_CENTRAL.equals(repository)) {
-			return "mavenCentral()";
+			writer.println("mavenCentral()");
+			return;
 		}
-		return "maven { url '" + repository.getUrl() + "' }";
+
+		writer.println("maven {");
+		writer.indented(() -> {
+			writer.println("url '" + repository.getUrl() + "'");
+
+			MavenRepositoryCredentials credentials = repository.getCredentials();
+			if (credentials != null) {
+				writer.println("credentials {");
+				writer.indented(() -> {
+					writer.println("username '" + credentials.getUsername() + "'");
+					writer.println("password '" + credentials.getPassword() + "'");
+				});
+				writer.println("}");
+			}
+		});
+		writer.println("}");
 	}
 
 	@Override

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleSettingsWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleSettingsWriter.java
@@ -20,6 +20,7 @@ package io.spring.initializr.generator.buildsystem.gradle;
  * A {@link GradleBuild} writer for {@code settings.gradle}.
  *
  * @author Jean-Baptiste Nizet
+ * @author Jafer Khan Shamshad
  */
 public class GroovyDslGradleSettingsWriter extends GradleSettingsWriter {
 
@@ -29,8 +30,8 @@ public class GroovyDslGradleSettingsWriter extends GradleSettingsWriter {
 	}
 
 	@Override
-	protected String urlAssignment(String url) {
-		return "url " + wrapWithQuotes(url);
+	protected String propertyAssignment(String name, String value) {
+		return name + " " + wrapWithQuotes(value);
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriter.java
@@ -27,6 +27,7 @@ import io.spring.initializr.generator.buildsystem.BillOfMaterials;
 import io.spring.initializr.generator.buildsystem.Dependency;
 import io.spring.initializr.generator.buildsystem.Dependency.Exclusion;
 import io.spring.initializr.generator.buildsystem.MavenRepository;
+import io.spring.initializr.generator.buildsystem.MavenRepositoryCredentials;
 import io.spring.initializr.generator.io.IndentingWriter;
 import io.spring.initializr.generator.version.VersionProperty;
 import io.spring.initializr.generator.version.VersionReference;
@@ -35,6 +36,7 @@ import io.spring.initializr.generator.version.VersionReference;
  * A {@link GradleBuild} writer for {@code build.gradle.kts}.
  *
  * @author Jean-Baptiste Nizet
+ * @author Jafer Khan Shamshad
  */
 public class KotlinDslGradleBuildWriter extends GradleBuildWriter {
 
@@ -109,11 +111,27 @@ public class KotlinDslGradleBuildWriter extends GradleBuildWriter {
 	}
 
 	@Override
-	protected String repositoryAsString(MavenRepository repository) {
+	protected void writeRepository(IndentingWriter writer, MavenRepository repository) {
 		if (MavenRepository.MAVEN_CENTRAL.equals(repository)) {
-			return "mavenCentral()";
+			writer.println("mavenCentral()");
+			return;
 		}
-		return "maven { url = uri(\"" + repository.getUrl() + "\") }";
+
+		writer.println("maven {");
+		writer.indented(() -> {
+			writer.println("url = uri(\"" + repository.getUrl() + "\")");
+
+			MavenRepositoryCredentials credentials = repository.getCredentials();
+			if (credentials != null) {
+				writer.println("credentials {");
+				writer.indented(() -> {
+					writer.println("username = \"" + credentials.getUsername() + "\"");
+					writer.println("password = \"" + credentials.getPassword() + "\"");
+				});
+				writer.println("}");
+			}
+		});
+		writer.println("}");
 	}
 
 	@Override

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleSettingsWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleSettingsWriter.java
@@ -20,6 +20,7 @@ package io.spring.initializr.generator.buildsystem.gradle;
  * A {@link GradleBuild} writer for {@code settings.gradle.kts}.
  *
  * @author Jean-Baptiste Nizet
+ * @author Jafer Khan Shamshad
  */
 public class KotlinDslGradleSettingsWriter extends GradleSettingsWriter {
 
@@ -29,8 +30,12 @@ public class KotlinDslGradleSettingsWriter extends GradleSettingsWriter {
 	}
 
 	@Override
-	protected String urlAssignment(String url) {
-		return "url = uri(\"" + url + "\")";
+	protected String propertyAssignment(String name, String value) {
+		if (name.equalsIgnoreCase("url")) {
+			return name + " = uri(" + wrapWithQuotes(value) + ")";
+		}
+
+		return name + " = " + wrapWithQuotes(value);
 	}
 
 }

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
@@ -25,6 +25,7 @@ import io.spring.initializr.generator.buildsystem.Dependency;
 import io.spring.initializr.generator.buildsystem.Dependency.Exclusion;
 import io.spring.initializr.generator.buildsystem.DependencyScope;
 import io.spring.initializr.generator.buildsystem.MavenRepository;
+import io.spring.initializr.generator.buildsystem.MavenRepositoryCredentials;
 import io.spring.initializr.generator.io.IndentingWriter;
 import io.spring.initializr.generator.version.VersionProperty;
 import io.spring.initializr.generator.version.VersionReference;
@@ -38,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andy Wilkinson
  * @author Jean-Baptiste Nizet
  * @author Stephane Nicoll
+ * @author Jafer Khan Shamshad
  */
 class GroovyDslGradleBuildWriterTests {
 
@@ -116,8 +118,19 @@ class GroovyDslGradleBuildWriterTests {
 		GradleBuild build = new GradleBuild();
 		build.repositories().add(MavenRepository.withIdAndUrl("spring-milestones", "https://repo.spring.io/milestone"));
 		List<String> lines = generateBuild(build);
-		assertThat(lines).containsSequence("repositories {", "    maven { url 'https://repo.spring.io/milestone' }",
-				"}");
+		assertThat(lines).containsSequence("repositories {", "    maven {",
+				"        url 'https://repo.spring.io/milestone'", "    }", "}");
+	}
+
+	@Test
+	void gradleBuildWithRepositoryCredentials() {
+		GradleBuild build = new GradleBuild();
+		build.repositories().add(MavenRepository.withIdAndUrl("foo-repository", "https://example.com/foo")
+				.credentials(new MavenRepositoryCredentials("foo", "bar")));
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("repositories {", "    maven {", "        url 'https://example.com/foo'",
+				"        credentials {", "            username 'foo'", "            password 'bar'", "        }",
+				"    }", "}");
 	}
 
 	@Test
@@ -126,8 +139,8 @@ class GroovyDslGradleBuildWriterTests {
 		build.repositories().add(MavenRepository.withIdAndUrl("spring-snapshots", "https://repo.spring.io/snapshot")
 				.snapshotsEnabled(true));
 		List<String> lines = generateBuild(build);
-		assertThat(lines).containsSequence("repositories {", "    maven { url 'https://repo.spring.io/snapshot' }",
-				"}");
+		assertThat(lines).containsSequence("repositories {", "    maven {",
+				"        url 'https://repo.spring.io/snapshot'", "    }", "}");
 	}
 
 	@Test

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleSettingsWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleSettingsWriterTests.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.spring.initializr.generator.buildsystem.MavenRepository;
+import io.spring.initializr.generator.buildsystem.MavenRepositoryCredentials;
 import io.spring.initializr.generator.io.IndentingWriter;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Andy Wilkinson
  * @author Jean-Baptiste Nizet
+ * @author Jafer Khan Shamshad
  */
 class GroovyDslGradleSettingsWriterTests {
 
@@ -56,12 +58,28 @@ class GroovyDslGradleSettingsWriterTests {
 		build.pluginRepositories().add(MavenRepository
 				.withIdAndUrl("spring-milestones", "https://repo.spring.io/milestone").name("Spring Milestones"));
 		List<String> lines = generateSettings(build);
-		assertThat(lines).containsSequence("pluginManagement {", "    repositories {",
-				"        maven { url 'https://repo.spring.io/milestone' }", "        gradlePluginPortal()", "    }",
-				"    resolutionStrategy {", "        eachPlugin {",
+		assertThat(lines).containsSequence("pluginManagement {", "    repositories {", "        maven {",
+				"            url 'https://repo.spring.io/milestone'", "        }", "        gradlePluginPortal()",
+				"    }", "    resolutionStrategy {", "        eachPlugin {",
 				"            if (requested.id.id == 'org.springframework.boot') {",
 				"                useModule(\"org.springframework.boot:spring-boot-gradle-plugin:${requested.version}\")",
 				"            }", "        }", "    }", "}");
+	}
+
+	@Test
+	void gradleBuildWithPluginRepositoryCredentials() {
+		GradleBuild build = new GradleBuild();
+		build.pluginRepositories().add(MavenRepository.withIdAndUrl("foo-repository", "https://example.com/foo")
+				.credentials(new MavenRepositoryCredentials("foo", "bar")));
+		List<String> lines = generateSettings(build);
+		assertThat(lines).containsSequence("pluginManagement {", "    repositories {", "        maven {",
+				"            url 'https://example.com/foo'", "            credentials {",
+				"                username 'foo'", "                password 'bar'", "            }", "        }",
+				"        gradlePluginPortal()", "    }", "    resolutionStrategy {", "        eachPlugin {",
+				"            if (requested.id.id == 'org.springframework.boot') {",
+				"                useModule(\"org.springframework.boot:spring-boot-gradle-plugin:${requested.version}\")",
+				"            }", "        }", "    }", "}");
+
 	}
 
 	@Test
@@ -71,9 +89,9 @@ class GroovyDslGradleSettingsWriterTests {
 				.add(MavenRepository.withIdAndUrl("spring-snapshots", "https://repo.spring.io/snapshot")
 						.name("Spring Snapshots").snapshotsEnabled(true));
 		List<String> lines = generateSettings(build);
-		assertThat(lines).containsSequence("pluginManagement {", "    repositories {",
-				"        maven { url 'https://repo.spring.io/snapshot' }", "        gradlePluginPortal()", "    }",
-				"    resolutionStrategy {", "        eachPlugin {",
+		assertThat(lines).containsSequence("pluginManagement {", "    repositories {", "        maven {",
+				"            url 'https://repo.spring.io/snapshot'", "        }", "        gradlePluginPortal()",
+				"    }", "    resolutionStrategy {", "        eachPlugin {",
 				"            if (requested.id.id == 'org.springframework.boot') {",
 				"                useModule(\"org.springframework.boot:spring-boot-gradle-plugin:${requested.version}\")",
 				"            }", "        }", "    }", "}");

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriterTests.java
@@ -25,6 +25,7 @@ import io.spring.initializr.generator.buildsystem.Dependency;
 import io.spring.initializr.generator.buildsystem.Dependency.Exclusion;
 import io.spring.initializr.generator.buildsystem.DependencyScope;
 import io.spring.initializr.generator.buildsystem.MavenRepository;
+import io.spring.initializr.generator.buildsystem.MavenRepositoryCredentials;
 import io.spring.initializr.generator.io.IndentingWriter;
 import io.spring.initializr.generator.version.VersionProperty;
 import io.spring.initializr.generator.version.VersionReference;
@@ -37,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * Tests for {@link KotlinDslGradleBuildWriter}
  *
  * @author Jean-Baptiste Nizet
+ * @author Jafer Khan Shamshad
  */
 class KotlinDslGradleBuildWriterTests {
 
@@ -127,8 +129,19 @@ class KotlinDslGradleBuildWriterTests {
 		GradleBuild build = new GradleBuild();
 		build.repositories().add(MavenRepository.withIdAndUrl("spring-milestones", "https://repo.spring.io/milestone"));
 		List<String> lines = generateBuild(build);
-		assertThat(lines).containsSequence("repositories {",
-				"    maven { url = uri(\"https://repo.spring.io/milestone\") }", "}");
+		assertThat(lines).containsSequence("repositories {", "    maven {",
+				"        url = uri(\"https://repo.spring.io/milestone\")", "    }", "}");
+	}
+
+	@Test
+	void gradleBuildWithRepositoryCredentials() {
+		GradleBuild build = new GradleBuild();
+		build.repositories().add(MavenRepository.withIdAndUrl("foo-repository", "https://example.com/foo")
+				.credentials(new MavenRepositoryCredentials("foo", "bar")));
+		List<String> lines = generateBuild(build);
+		assertThat(lines).containsSequence("repositories {", "    maven {",
+				"        url = uri(\"https://example.com/foo\")", "        credentials {",
+				"            username = \"foo\"", "            password = \"bar\"", "        }", "    }", "}");
 	}
 
 	@Test
@@ -137,8 +150,8 @@ class KotlinDslGradleBuildWriterTests {
 		build.repositories().add(MavenRepository.withIdAndUrl("spring-snapshots", "https://repo.spring.io/snapshot")
 				.snapshotsEnabled(true));
 		List<String> lines = generateBuild(build);
-		assertThat(lines).containsSequence("repositories {",
-				"    maven { url = uri(\"https://repo.spring.io/snapshot\") }", "}");
+		assertThat(lines).containsSequence("repositories {", "    maven {",
+				"        url = uri(\"https://repo.spring.io/snapshot\")", "    }", "}");
 	}
 
 	@Test

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleSettingsWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleSettingsWriterTests.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.spring.initializr.generator.buildsystem.MavenRepository;
+import io.spring.initializr.generator.buildsystem.MavenRepositoryCredentials;
 import io.spring.initializr.generator.io.IndentingWriter;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link KotlinDslGradleSettingsWriter}.
  *
  * @author Jean-Baptiste Nizet
+ * @author Jafer Khan Shamshad
  */
 class KotlinDslGradleSettingsWriterTests {
 
@@ -55,10 +57,25 @@ class KotlinDslGradleSettingsWriterTests {
 		build.pluginRepositories().add(MavenRepository
 				.withIdAndUrl("spring-milestones", "https://repo.spring.io/milestone").name("Spring Milestones"));
 		List<String> lines = generateSettings(build);
-		assertThat(lines).containsSequence("pluginManagement {", "    repositories {",
-				"        maven { url = uri(\"https://repo.spring.io/milestone\") }", "        gradlePluginPortal()",
-				"    }", "    resolutionStrategy {", "        eachPlugin {",
+		assertThat(lines).containsSequence("pluginManagement {", "    repositories {", "        maven {",
+				"            url = uri(\"https://repo.spring.io/milestone\")", "        }",
+				"        gradlePluginPortal()", "    }", "    resolutionStrategy {", "        eachPlugin {",
 				"            if (requested.id.id == \"org.springframework.boot\") {",
+				"                useModule(\"org.springframework.boot:spring-boot-gradle-plugin:${requested.version}\")",
+				"            }", "        }", "    }", "}");
+	}
+
+	@Test
+	void gradleBuildWithPluginRepositoryCredentials() {
+		GradleBuild build = new GradleBuild();
+		build.pluginRepositories().add(MavenRepository.withIdAndUrl("foo-repository", "https://example.com/foo")
+				.name("foo-repo").credentials(new MavenRepositoryCredentials("foo", "bar")));
+		List<String> lines = generateSettings(build);
+		assertThat(lines).containsSequence("pluginManagement {", "    repositories {", "        maven {",
+				"            url = uri(\"https://example.com/foo\")", "            credentials {",
+				"                username = \"foo\"", "                password = \"bar\"", "            }",
+				"        }", "        gradlePluginPortal()", "    }", "    resolutionStrategy {",
+				"        eachPlugin {", "            if (requested.id.id == \"org.springframework.boot\") {",
 				"                useModule(\"org.springframework.boot:spring-boot-gradle-plugin:${requested.version}\")",
 				"            }", "        }", "    }", "}");
 	}
@@ -70,9 +87,9 @@ class KotlinDslGradleSettingsWriterTests {
 				.add(MavenRepository.withIdAndUrl("spring-snapshots", "https://repo.spring.io/snapshot")
 						.name("Spring Snapshots").snapshotsEnabled(true));
 		List<String> lines = generateSettings(build);
-		assertThat(lines).containsSequence("pluginManagement {", "    repositories {",
-				"        maven { url = uri(\"https://repo.spring.io/snapshot\") }", "        gradlePluginPortal()",
-				"    }", "    resolutionStrategy {", "        eachPlugin {",
+		assertThat(lines).containsSequence("pluginManagement {", "    repositories {", "        maven {",
+				"            url = uri(\"https://repo.spring.io/snapshot\")", "        }",
+				"        gradlePluginPortal()", "    }", "    resolutionStrategy {", "        eachPlugin {",
 				"            if (requested.id.id == \"org.springframework.boot\") {",
 				"                useModule(\"org.springframework.boot:spring-boot-gradle-plugin:${requested.version}\")",
 				"            }", "        }", "    }", "}");


### PR DESCRIPTION
Hello people,

This pull request enhances the existing Gradle's build file writer in order to support writing credentials (if provided) for custom repositories. It has been submitted as a response to issue #997

I've also written some test cases to cover my feature.

I would highly appreciate someone's feedback on my pull request and make improvements accordingly.

Thanks,
Jafer