### PR TITLE
Extend Java source code generator

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaMethodDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaMethodDeclaration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import io.spring.initializr.generator.language.Parameter;
  * Declaration of a method written in Java.
  *
  * @author Andy Wilkinson
+ * @author Guillaume Gerbaud
  */
 public final class JavaMethodDeclaration implements Annotatable {
 
@@ -38,16 +39,19 @@ public final class JavaMethodDeclaration implements Annotatable {
 
 	private final String returnType;
 
+	private final List<String> throwables;
+
 	private final int modifiers;
 
 	private final List<Parameter> parameters;
 
 	private final List<JavaStatement> statements;
 
-	private JavaMethodDeclaration(String name, String returnType, int modifiers, List<Parameter> parameters,
-			List<JavaStatement> statements) {
+	private JavaMethodDeclaration(String name, String returnType, List<String> throwables, int modifiers,
+			List<Parameter> parameters, List<JavaStatement> statements) {
 		this.name = name;
 		this.returnType = returnType;
+		this.throwables = throwables;
 		this.modifiers = modifiers;
 		this.parameters = parameters;
 		this.statements = statements;
@@ -63,6 +67,10 @@ public final class JavaMethodDeclaration implements Annotatable {
 
 	String getReturnType() {
 		return this.returnType;
+	}
+
+	public List<String> getThrowables() {
+		return this.throwables;
 	}
 
 	List<Parameter> getParameters() {
@@ -98,6 +106,8 @@ public final class JavaMethodDeclaration implements Annotatable {
 
 		private String returnType = "void";
 
+		private List<String> throwables = new ArrayList<>();
+
 		private int modifiers;
 
 		private Builder(String name) {
@@ -114,14 +124,19 @@ public final class JavaMethodDeclaration implements Annotatable {
 			return this;
 		}
 
+		public Builder throwing(String... throwables) {
+			this.throwables = Arrays.asList(throwables);
+			return this;
+		}
+
 		public Builder parameters(Parameter... parameters) {
 			this.parameters = Arrays.asList(parameters);
 			return this;
 		}
 
 		public JavaMethodDeclaration body(JavaStatement... statements) {
-			return new JavaMethodDeclaration(this.name, this.returnType, this.modifiers, this.parameters,
-					Arrays.asList(statements));
+			return new JavaMethodDeclaration(this.name, this.returnType, this.throwables, this.modifiers,
+					this.parameters, Arrays.asList(statements));
 		}
 
 	}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaMethodInvocation.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaMethodInvocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,22 +23,27 @@ import java.util.List;
  * An invocation of a method.
  *
  * @author Andy Wilkinson
+ * @author Guillaume Gerbaud
  */
 public class JavaMethodInvocation extends JavaExpression {
 
-	private final String target;
+	private final JavaExpression target;
 
 	private final String name;
 
 	private final List<String> arguments;
 
-	public JavaMethodInvocation(String target, String name, String... arguments) {
+	public JavaMethodInvocation(JavaExpression target, String name, String... arguments) {
 		this.target = target;
 		this.name = name;
 		this.arguments = Arrays.asList(arguments);
 	}
 
-	public String getTarget() {
+	public JavaMethodInvocation(String target, String name, String... arguments) {
+		this(new JavaStringExpression(target), name, arguments);
+	}
+
+	public JavaExpression getTarget() {
 		return this.target;
 	}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaStringExpression.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaStringExpression.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.language.java;
+
+/**
+ * A java expression that can be represented as a String.
+ *
+ * @author Guillaume Gerbaud
+ */
+public class JavaStringExpression extends JavaExpression {
+
+	private final String value;
+
+	public JavaStringExpression(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return this.value;
+	}
+
+}

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriterTests.java
@@ -119,6 +119,38 @@ class JavaSourceCodeWriterTests {
 	}
 
 	@Test
+	void methodThrowingException() throws IOException {
+		JavaSourceCode sourceCode = new JavaSourceCode();
+		JavaCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		JavaTypeDeclaration test = compilationUnit.createTypeDeclaration("Test");
+		test.addMethodDeclaration(JavaMethodDeclaration.method("format").returning("java.lang.String")
+				.throwing("java.util.IllegalFormatException").modifiers(Modifier.PUBLIC)
+				.parameters(new Parameter("java.lang.String", "value"), new Parameter("java.lang.String", "format"),
+						new Parameter("java.lang.Object[]", "args"))
+				.body(new JavaReturnStatement(new JavaMethodInvocation("value", "format", "format", "args"))));
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.java");
+		assertThat(lines).containsExactly("package com.example;", "", "import java.util.IllegalFormatException;", "",
+				"class Test {", "",
+				"    public String format(String value, String format, Object[] args) throws IllegalFormatException {",
+				"        return value.format(format, args);", "    }", "", "}");
+	}
+
+	@Test
+	void methodWithChainedInvocation() throws IOException {
+		JavaSourceCode sourceCode = new JavaSourceCode();
+		JavaCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		JavaTypeDeclaration test = compilationUnit.createTypeDeclaration("Test");
+		test.addMethodDeclaration(
+				JavaMethodDeclaration.method("trim").returning("java.lang.String").modifiers(Modifier.PUBLIC)
+						.parameters(new Parameter("java.lang.String", "value")).body(new JavaReturnStatement(
+								new JavaMethodInvocation(new JavaMethodInvocation("value", "trim"), "toUpperCase"))));
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.java");
+		assertThat(lines).containsExactly("package com.example;", "", "class Test {", "",
+				"    public String trim(String value) {", "        return value.trim().toUpperCase();", "    }", "",
+				"}");
+	}
+
+	@Test
 	void field() throws IOException {
 		JavaSourceCode sourceCode = new JavaSourceCode();
 		JavaCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");


### PR DESCRIPTION
Methods can throw Exception
```java
JavaMethodDeclaration
    .method("format")
    .returning("java.lang.String")
    .throwing("java.util.IllegalFormatException")
// ... String format(...) throws IllegalFormatException
```
MethodInvocation is done on a JavaExpression. This allow to chain MethodInvocation (see #1043 )
```java
new JavaReturnStatement(
    new JavaMethodInvocation(
        new JavaMethodInvocation("value", "trim"), 
        "toUpperCase"
))
// return value.trim().toUpperCase();
```
