### PR TITLE
ProjectGenerationInvoker is not thread safe

### DIFF
--- a/initializr-web/src/main/java/io/spring/initializr/web/project/ProjectGenerationInvoker.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/project/ProjectGenerationInvoker.java
@@ -20,9 +20,9 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import io.spring.initializr.generator.buildsystem.BuildItemResolver;
 import io.spring.initializr.generator.buildsystem.BuildWriter;
@@ -56,7 +56,7 @@ public class ProjectGenerationInvoker<R extends ProjectRequest> {
 
 	private final ProjectRequestToDescriptionConverter<R> requestConverter;
 
-	private transient Map<Path, List<Path>> temporaryFiles = new LinkedHashMap<>();
+	private transient Map<Path, List<Path>> temporaryFiles = new ConcurrentHashMap<>();
 
 	public ProjectGenerationInvoker(ApplicationContext parentApplicationContext,
 			ProjectRequestToDescriptionConverter<R> requestConverter) {
@@ -143,7 +143,14 @@ public class ProjectGenerationInvoker<R extends ProjectRequest> {
 	}
 
 	private void addTempFile(Path group, Path file) {
-		this.temporaryFiles.computeIfAbsent(group, (key) -> new ArrayList<>()).add(file);
+		this.temporaryFiles.compute(group, (path, paths) -> {
+			List<Path> newPaths = paths;
+			if (newPaths == null) {
+				newPaths = new ArrayList<>();
+			}
+			newPaths.add(file);
+			return newPaths;
+		});
 	}
 
 	/**


### PR DESCRIPTION
This pull request fixes #1124 . `ConcurrentHashMap` is used instead of `LinkedHashMap` as the key insertion order property of this implementation was not used anywhere anyway.