### PR TITLE
Eclipse's output directory for Gradle-based projects is not defined in .gitignore

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/scm/git/GitProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/scm/git/GitProjectGenerationConfiguration.java
@@ -62,7 +62,7 @@ public class GitProjectGenerationConfiguration {
 			gitIgnore.getGeneral().add(".gradle", "build/", "!gradle/wrapper/gradle-wrapper.jar",
 					"!**/src/main/**/build/", "!**/src/test/**/build/");
 			gitIgnore.getIntellijIdea().add("out/", "!**/src/main/**/out/", "!**/src/test/**/out/");
-			gitIgnore.getSts().add("bin/");
+			gitIgnore.getSts().add("bin/", "!**/src/main/**/bin/", "!**/src/test/**/bin/");
 		};
 	}
 

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/scm/git/GitProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/scm/git/GitProjectGenerationConfiguration.java
@@ -59,9 +59,10 @@ public class GitProjectGenerationConfiguration {
 	@ConditionalOnBuildSystem(GradleBuildSystem.ID)
 	public GitIgnoreCustomizer gradleGitIgnoreCustomizer() {
 		return (gitIgnore) -> {
-			gitIgnore.getGeneral().add(".gradle", "build/", "bin/", "!gradle/wrapper/gradle-wrapper.jar",
+			gitIgnore.getGeneral().add(".gradle", "build/", "!gradle/wrapper/gradle-wrapper.jar",
 					"!**/src/main/**/build/", "!**/src/test/**/build/");
 			gitIgnore.getIntellijIdea().add("out/", "!**/src/main/**/out/", "!**/src/test/**/out/");
+			gitIgnore.getSts().add("bin/");
 		};
 	}
 

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/scm/git/GitProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/scm/git/GitProjectGenerationConfiguration.java
@@ -59,7 +59,7 @@ public class GitProjectGenerationConfiguration {
 	@ConditionalOnBuildSystem(GradleBuildSystem.ID)
 	public GitIgnoreCustomizer gradleGitIgnoreCustomizer() {
 		return (gitIgnore) -> {
-			gitIgnore.getGeneral().add(".gradle", "build/", "!gradle/wrapper/gradle-wrapper.jar",
+			gitIgnore.getGeneral().add(".gradle", "build/", "bin/", "!gradle/wrapper/gradle-wrapper.jar",
 					"!**/src/main/**/build/", "!**/src/test/**/build/");
 			gitIgnore.getIntellijIdea().add("out/", "!**/src/main/**/out/", "!**/src/test/**/out/");
 		};

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/scm/git/GitProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/scm/git/GitProjectGenerationConfigurationTests.java
@@ -69,7 +69,7 @@ class GitProjectGenerationConfigurationTests {
 		description.setPlatformVersion(Version.parse("2.1.0.RELEASE"));
 		assertThat(generateGitIgnore(description))
 				.contains(".gradle", "build/", "!gradle/wrapper/gradle-wrapper.jar", "out/", "!**/src/main/**/build/",
-						"!**/src/test/**/build/", "!**/src/main/**/out/", "!**/src/test/**/out/")
+						"!**/src/test/**/build/", "!**/src/main/**/out/", "!**/src/test/**/out/", "bin/")
 				.doesNotContain("/target/", "!.mvn/wrapper/maven-wrapper.jar");
 	}
 

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/scm/git/GitProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/scm/git/GitProjectGenerationConfigurationTests.java
@@ -69,7 +69,8 @@ class GitProjectGenerationConfigurationTests {
 		description.setPlatformVersion(Version.parse("2.1.0.RELEASE"));
 		assertThat(generateGitIgnore(description))
 				.contains(".gradle", "build/", "!gradle/wrapper/gradle-wrapper.jar", "out/", "!**/src/main/**/build/",
-						"!**/src/test/**/build/", "!**/src/main/**/out/", "!**/src/test/**/out/", "bin/")
+						"!**/src/test/**/build/", "!**/src/main/**/out/", "!**/src/test/**/out/", "bin/",
+						"!**/src/main/**/bin/", "!**/src/test/**/bin/")
 				.doesNotContain("/target/", "!.mvn/wrapper/maven-wrapper.jar");
 	}
 


### PR DESCRIPTION
After running ``./gradlew build`` on a newly generated gradle project from the initializer, a ``bin/`` directory will be created containing the ``.class`` files which were generated while building. This directory should not be uploaded to git, but it wasn't included in the ``.gitignore`` file generated for gradle projects.

With this PR, it should no longer be needed to add ``bin/`` to the ``.gitignore`` file manually.