### PR TITLE
InitializrMetadataV2JsonMapper hardocdes type attribute for TypeCapability

### DIFF
--- a/initializr-web/src/main/java/io/spring/initializr/web/mapper/InitializrMetadataV2JsonMapper.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/mapper/InitializrMetadataV2JsonMapper.java
@@ -126,7 +126,7 @@ public class InitializrMetadataV2JsonMapper implements InitializrMetadataJsonMap
 
 	protected void type(ObjectNode parent, TypeCapability capability) {
 		ObjectNode type = nodeFactory.objectNode();
-		type.put("type", "action");
+		type.put("type", capability.getType().getName());
 		Type defaultType = capability.getDefault();
 		if (defaultType != null) {
 			type.put("default", defaultType.getId());


### PR DESCRIPTION
Using type from capability.getType().getName() for field 'type'