### PR TITLE
Support for multi module gradle builds

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleBuildProjectContributor.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleBuildProjectContributor.java
@@ -54,7 +54,11 @@ public class GradleBuildProjectContributor implements BuildWriter, ProjectContri
 
 	@Override
 	public void contribute(Path projectRoot) throws IOException {
-		Path buildGradle = Files.createFile(projectRoot.resolve(this.buildFileName));
+		Path buildGradle = projectRoot.resolve(this.buildFileName);
+		if (!Files.exists(buildGradle)) {
+			Files.createDirectories(buildGradle.getParent());
+			Files.createFile(buildGradle);
+		}
 		writeBuild(Files.newBufferedWriter(buildGradle));
 	}
 

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfiguration.java
@@ -111,15 +111,28 @@ public class GradleProjectGenerationConfiguration {
 	@Bean
 	@ConditionalOnBuildSystem(id = GradleBuildSystem.ID, dialect = GradleBuildSystem.DIALECT_GROOVY)
 	public GradleBuildProjectContributor gradleBuildProjectContributor(GroovyDslGradleBuildWriter buildWriter,
-			GradleBuild build) {
-		return new GradleBuildProjectContributor(buildWriter, build, this.indentingWriterFactory, "build.gradle");
+			GradleBuild build, ProjectDescription description) {
+		String buildFileName = gradleBuildFilePath(description, "build.gradle");
+		return new GradleBuildProjectContributor(buildWriter, build, this.indentingWriterFactory, buildFileName);
 	}
 
 	@Bean
 	@ConditionalOnBuildSystem(id = GradleBuildSystem.ID, dialect = GradleBuildSystem.DIALECT_KOTLIN)
 	public GradleBuildProjectContributor gradleKtsBuildProjectContributor(KotlinDslGradleBuildWriter buildWriter,
-			GradleBuild build) {
-		return new GradleBuildProjectContributor(buildWriter, build, this.indentingWriterFactory, "build.gradle.kts");
+			GradleBuild build, ProjectDescription description) {
+		String buildFileName = gradleBuildFilePath(description, "build.gradle.kts");
+		return new GradleBuildProjectContributor(buildWriter, build, this.indentingWriterFactory, buildFileName);
+	}
+
+	private String gradleBuildFilePath(ProjectDescription description, String buildFileName) {
+		String module = description.getBuildSystem().getApplicationModuleName();
+		return (module != null) ? module + "/" + buildFileName : buildFileName;
+	}
+
+	@Bean
+	@ConditionalOnBuildSystem(id = GradleBuildSystem.ID, multiModule = "true")
+	BuildCustomizer<GradleBuild> addSubmodulesToGradleBuild(ProjectDescription description) {
+		return (build) -> build.settings().submodule(description.getBuildSystem().getApplicationModuleName());
 	}
 
 	/**

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/configuration/ApplicationConfigurationProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/configuration/ApplicationConfigurationProjectGenerationConfiguration.java
@@ -17,6 +17,7 @@
 package io.spring.initializr.generator.spring.configuration;
 
 import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
 import io.spring.initializr.metadata.InitializrMetadata;
 
@@ -31,13 +32,20 @@ import org.springframework.context.annotation.Bean;
 public class ApplicationConfigurationProjectGenerationConfiguration {
 
 	@Bean
-	public ApplicationPropertiesContributor applicationPropertiesContributor() {
-		return new ApplicationPropertiesContributor();
+	public ApplicationPropertiesContributor applicationPropertiesContributor(
+			ResourcesPathProvider resourcesPathProvider) {
+		return new ApplicationPropertiesContributor(resourcesPathProvider);
 	}
 
 	@Bean
-	public WebFoldersContributor webFoldersContributor(Build build, InitializrMetadata metadata) {
-		return new WebFoldersContributor(build, metadata);
+	public WebFoldersContributor webFoldersContributor(Build build, InitializrMetadata metadata,
+			ResourcesPathProvider resourcesPathProvider) {
+		return new WebFoldersContributor(build, metadata, resourcesPathProvider);
+	}
+
+	@Bean
+	public ResourcesPathProvider resourcesPathProvider(ProjectDescription description) {
+		return ResourcesPathProvider.forProject(description);
 	}
 
 }

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/configuration/ApplicationPropertiesContributor.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/configuration/ApplicationPropertiesContributor.java
@@ -26,12 +26,22 @@ import io.spring.initializr.generator.project.contributor.SingleResourceProjectC
  */
 public class ApplicationPropertiesContributor extends SingleResourceProjectContributor {
 
+	private static final String defaultResourcePattern = "classpath:configuration/application.properties";
+
 	public ApplicationPropertiesContributor() {
-		this("classpath:configuration/application.properties");
+		this(ResourcesPathProvider.DEFAULT, defaultResourcePattern);
 	}
 
 	public ApplicationPropertiesContributor(String resourcePattern) {
-		super("src/main/resources/application.properties", resourcePattern);
+		this(ResourcesPathProvider.DEFAULT, resourcePattern);
+	}
+
+	public ApplicationPropertiesContributor(ResourcesPathProvider resourcesPathProvider) {
+		this(resourcesPathProvider, defaultResourcePattern);
+	}
+
+	public ApplicationPropertiesContributor(ResourcesPathProvider resourcesPathProvider, String resourcePattern) {
+		super((root) -> resourcesPathProvider.get(root).resolve("application.properties"), resourcePattern);
 	}
 
 }

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/configuration/ResourcesPathProvider.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/configuration/ResourcesPathProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.configuration;
+
+import java.nio.file.Path;
+
+import io.spring.initializr.generator.project.ProjectDescription;
+
+@FunctionalInterface
+interface ResourcesPathProvider {
+
+	ResourcesPathProvider DEFAULT = (root) -> root.resolve("src/main/resources");
+
+	static ResourcesPathProvider forProject(ProjectDescription description) {
+		return (root) -> description.getBuildSystem().getMainSource(root, description.getLanguage())
+				.getResourcesDirectory();
+	}
+
+	Path get(Path projectRoot);
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/configuration/WebFoldersContributor.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/configuration/WebFoldersContributor.java
@@ -39,16 +39,25 @@ public class WebFoldersContributor implements ProjectContributor {
 
 	private final BuildMetadataResolver buildMetadataResolver;
 
+	private final ResourcesPathProvider resourcesPathProvider;
+
 	public WebFoldersContributor(Build build, InitializrMetadata metadata) {
+		this(build, metadata, ResourcesPathProvider.DEFAULT);
+	}
+
+	public WebFoldersContributor(Build build, InitializrMetadata metadata,
+			ResourcesPathProvider resourcesPathProvider) {
 		this.build = build;
 		this.buildMetadataResolver = new BuildMetadataResolver(metadata);
+		this.resourcesPathProvider = resourcesPathProvider;
 	}
 
 	@Override
 	public void contribute(Path projectRoot) throws IOException {
 		if (this.buildMetadataResolver.hasFacet(this.build, "web")) {
-			Files.createDirectories(projectRoot.resolve("src/main/resources/templates"));
-			Files.createDirectories(projectRoot.resolve("src/main/resources/static"));
+			Path resources = this.resourcesPathProvider.get(projectRoot);
+			Files.createDirectories(resources.resolve("templates"));
+			Files.createDirectories(resources.resolve("static"));
 		}
 	}
 

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleBuildProjectContributorTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleBuildProjectContributorTests.java
@@ -51,6 +51,16 @@ class GradleBuildProjectContributorTests {
 	}
 
 	@Test
+	void groovyDslGradleBuildIsContributedInMultiProjectStructure(@TempDir Path projectDir) throws IOException {
+		String path = "sub/build.gradle";
+		GradleBuild build = new GradleBuild();
+		new GradleBuildProjectContributor(new GroovyDslGradleBuildWriter(), build,
+				IndentingWriterFactory.withDefaultSettings(), path).contribute(projectDir);
+		Path buildGradle = projectDir.resolve(path);
+		assertThat(buildGradle).isRegularFile();
+	}
+
+	@Test
 	void groovyDslGradleBuildIsContributedToProject() throws IOException {
 		GradleBuild build = new GradleBuild();
 		build.settings().group("com.example").version("1.0.0-SNAPSHOT");

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfigurationTests.java
@@ -134,6 +134,23 @@ class GradleProjectGenerationConfigurationTests {
 				"}"); // @formatter:on
 	}
 
+	static Stream<Arguments> gradleBuildSystemDialects() {
+		return Stream.of(Arguments.arguments(GradleBuildSystem.DIALECT_GROOVY, "build.gradle"),
+				Arguments.arguments(GradleBuildSystem.DIALECT_KOTLIN, "build.gradle.kts"));
+	}
+
+	@ParameterizedTest(name = "Dialect {0}")
+	@MethodSource("gradleBuildSystemDialects")
+	void buildScriptIsContributedWhenGeneratingMultiModuleGradleProject(String dialect, String buildFileName) {
+		MutableProjectDescription description = new MutableProjectDescription();
+		description.setPlatformVersion(Version.parse("2.4.0"));
+		description.setLanguage(new JavaLanguage("11"));
+		ProjectStructure project = this.projectTester
+				.withDescriptionCustomizer((d) -> d.setBuildSystem(new GradleBuildSystem(dialect, "service")))
+				.generate(description);
+		assertThat(project).containsFiles("service/" + buildFileName);
+	}
+
 	@Test
 	void warPluginIsAppliedWhenBuildingProjectThatUsesWarPackaging() {
 		MutableProjectDescription description = new MutableProjectDescription();

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/configuration/ApplicationConfigurationProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/configuration/ApplicationConfigurationProjectGenerationConfigurationTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.configuration;
+
+import java.nio.file.Path;
+
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
+import io.spring.initializr.generator.language.java.JavaLanguage;
+import io.spring.initializr.generator.project.MutableProjectDescription;
+import io.spring.initializr.generator.spring.build.gradle.GradleProjectGenerationConfiguration;
+import io.spring.initializr.generator.test.InitializrMetadataTestBuilder;
+import io.spring.initializr.generator.test.project.ProjectAssetTester;
+import io.spring.initializr.generator.test.project.ProjectStructure;
+import io.spring.initializr.generator.version.Version;
+import io.spring.initializr.metadata.InitializrMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ApplicationConfigurationProjectGenerationConfiguration}
+ *
+ * @author Linda Navarette
+ */
+class ApplicationConfigurationProjectGenerationConfigurationTests {
+
+	private ProjectAssetTester projectTester;
+
+	@BeforeEach
+	void setup(@TempDir Path directory) {
+		this.projectTester = new ProjectAssetTester().withIndentingWriterFactory()
+				.withConfiguration(ApplicationConfigurationProjectGenerationConfiguration.class,
+						GradleProjectGenerationConfiguration.class)
+				.withDirectory(directory)
+				.withBean(InitializrMetadata.class, () -> InitializrMetadataTestBuilder.withDefaults().build());
+	}
+
+	@Test
+	void applicationConfigurationResourcesAreIncludedInSingleModuleBuild() {
+		MutableProjectDescription description = new MutableProjectDescription();
+		description.setPlatformVersion(Version.parse("2.4.0"));
+		description.setLanguage(new JavaLanguage());
+		description.setBuildSystem(new GradleBuildSystem());
+		ProjectStructure project = this.projectTester.generate(description);
+		assertThat(project).containsFiles("src/main/resources/application.properties");
+	}
+
+	@Test
+	void applicationConfigurationResourcesAreIncludedInMultiModuleBuild() {
+		MutableProjectDescription description = new MutableProjectDescription();
+		description.setPlatformVersion(Version.parse("2.4.0"));
+		description.setLanguage(new JavaLanguage());
+		description.setBuildSystem(new GradleBuildSystem(GradleBuildSystem.DIALECT_GROOVY, "foo"));
+		ProjectStructure project = this.projectTester.generate(description);
+		assertThat(project).containsFiles("foo/src/main/resources/application.properties");
+	}
+
+}

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/configuration/ApplicationPropertiesContributorTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/configuration/ApplicationPropertiesContributorTests.java
@@ -44,4 +44,11 @@ class ApplicationPropertiesContributorTests {
 				.isEmpty();
 	}
 
+	@Test
+	void applicationConfigurationWithCustomResourcesDirectory() throws IOException {
+		Path projectDir = Files.createTempDirectory(this.directory, "project-");
+		new ApplicationPropertiesContributor((root) -> root.resolve("foo")).contribute(projectDir);
+		assertThat(new ProjectStructure(projectDir)).textFile("foo/application.properties").lines().isEmpty();
+	}
+
 }

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/configuration/WebFoldersContributorTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/configuration/WebFoldersContributorTests.java
@@ -81,7 +81,8 @@ class WebFoldersContributorTests {
 	}
 
 	private Path contribute(Build build, InitializrMetadata metadata) throws IOException {
-		new WebFoldersContributor(build, metadata).contribute(this.projectDir);
+		new WebFoldersContributor(build, metadata, (dir) -> dir.resolve("src/main/resources"))
+				.contribute(this.projectDir);
 		return this.projectDir;
 	}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/BuildSettings.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/BuildSettings.java
@@ -16,6 +16,9 @@
 
 package io.spring.initializr.generator.buildsystem;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * General build settings.
  *
@@ -29,10 +32,13 @@ public class BuildSettings {
 
 	private final String version;
 
+	private final List<String> submodules;
+
 	protected BuildSettings(Builder<?> builder) {
 		this.group = builder.group;
 		this.artifact = builder.artifact;
 		this.version = builder.version;
+		this.submodules = builder.submodules;
 	}
 
 	/**
@@ -60,6 +66,14 @@ public class BuildSettings {
 	}
 
 	/**
+	 * Return the submodules of the project.
+	 * @return the submodules or {@code null}
+	 */
+	public List<String> getSubmodules() {
+		return this.submodules;
+	}
+
+	/**
 	 * Builder for build settings.
 	 *
 	 * @param <B> builder type
@@ -71,6 +85,8 @@ public class BuildSettings {
 		private String artifact;
 
 		private String version = "0.0.1-SNAPSHOT";
+
+		private final List<String> submodules = new ArrayList<>();
 
 		protected Builder() {
 		}
@@ -102,6 +118,16 @@ public class BuildSettings {
 		 */
 		public B version(String version) {
 			this.version = version;
+			return self();
+		}
+
+		/**
+		 * Adds a submodule to the project.
+		 * @param moduleName the name of the submodule
+		 * @return this for method chaining
+		 */
+		public B submodule(String moduleName) {
+			this.submodules.add(moduleName);
 			return self();
 		}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/BuildSystem.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/BuildSystem.java
@@ -47,13 +47,40 @@ public interface BuildSystem {
 	}
 
 	/**
+	 * Whether the build is a multi module build.
+	 * @return {@code true} if multi module build
+	 */
+	default boolean isMultiModuleBuild() {
+		return getApplicationModuleName() != null;
+	}
+
+	/**
+	 * Name of the application module; or {@code null} if a single module build.
+	 * @return name of the application module
+	 */
+	default String getApplicationModuleName() {
+		return null;
+	}
+
+	/**
+	 * Path of the application module; this may differ from the project root if the
+	 * application is multi-module.
+	 * @param projectRoot the root of the project structure
+	 * @return path for the application project
+	 */
+	default Path getApplicationModuleRoot(Path projectRoot) {
+		String sub = getApplicationModuleName();
+		return (sub != null) ? projectRoot.resolve(sub) : projectRoot;
+	}
+
+	/**
 	 * Returns a {@link SourceStructure} for main sources.
 	 * @param projectRoot the root of the project structure
 	 * @param language the language of the project
 	 * @return a {@link SourceStructure} for main assets
 	 */
 	default SourceStructure getMainSource(Path projectRoot, Language language) {
-		return new SourceStructure(projectRoot.resolve("src/main/"), language);
+		return new SourceStructure(getApplicationModuleRoot(projectRoot).resolve("src/main/"), language);
 	}
 
 	/**
@@ -63,7 +90,7 @@ public interface BuildSystem {
 	 * @return a {@link SourceStructure} for test assets
 	 */
 	default SourceStructure getTestSource(Path projectRoot, Language language) {
-		return new SourceStructure(projectRoot.resolve("src/test/"), language);
+		return new SourceStructure(getApplicationModuleRoot(projectRoot).resolve("src/test/"), language);
 	}
 
 	static BuildSystem forId(String id) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildSystem.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildSystem.java
@@ -42,12 +42,19 @@ public final class GradleBuildSystem implements BuildSystem {
 
 	private final String dialect;
 
+	private final String applicationModuleName;
+
 	public GradleBuildSystem() {
 		this(DIALECT_GROOVY);
 	}
 
 	public GradleBuildSystem(String dialect) {
+		this(dialect, null);
+	}
+
+	public GradleBuildSystem(String dialect, String applicationModuleName) {
 		this.dialect = dialect;
+		this.applicationModuleName = applicationModuleName;
 	}
 
 	@Override
@@ -58,6 +65,11 @@ public final class GradleBuildSystem implements BuildSystem {
 	@Override
 	public String dialect() {
 		return this.dialect;
+	}
+
+	@Override
+	public String getApplicationModuleName() {
+		return this.applicationModuleName;
 	}
 
 	@Override

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleSettingsWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleSettingsWriter.java
@@ -40,6 +40,7 @@ public abstract class GradleSettingsWriter {
 	public final void writeTo(IndentingWriter writer, GradleBuild build) {
 		writePluginManagement(writer, build);
 		writer.println("rootProject.name = " + wrapWithQuotes(build.getSettings().getArtifact()));
+		build.getSettings().getSubmodules().forEach((s) -> writer.println("include(" + wrapWithQuotes(s) + ")"));
 	}
 
 	private void writePluginManagement(IndentingWriter writer, GradleBuild build) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/condition/ConditionalOnBuildSystem.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/condition/ConditionalOnBuildSystem.java
@@ -60,4 +60,12 @@ public @interface ConditionalOnBuildSystem {
 	 */
 	String dialect() default "";
 
+	/**
+	 * Whether the {@link BuildSystem} is configured for multi module builds. Use
+	 * {@code true} to indicate multi module, and {@code false} to indicate single module.
+	 * When not specified, either will be matched.
+	 * @return whether the build is multi module
+	 */
+	String multiModule() default "";
+
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/condition/OnBuildSystemCondition.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/condition/OnBuildSystemCondition.java
@@ -39,14 +39,15 @@ class OnBuildSystemCondition extends ProjectGenerationCondition {
 				.getAllAnnotationAttributes(ConditionalOnBuildSystem.class.getName());
 		String buildSystemId = (String) attributes.getFirst("value");
 		String dialect = (String) attributes.getFirst("dialect");
+		String multiModule = (String) attributes.getFirst("multiModule");
 		BuildSystem buildSystem = description.getBuildSystem();
-		if (buildSystem.id().equals(buildSystemId)) {
-			if (StringUtils.hasText(dialect)) {
-				return dialect.equals(buildSystem.dialect());
-			}
-			return true;
-		}
-		return false;
+		boolean dialectMatches = matches(dialect, buildSystem.dialect());
+		boolean multiModuleMatches = matches(multiModule, String.valueOf(buildSystem.isMultiModuleBuild()));
+		return buildSystem.id().equals(buildSystemId) && dialectMatches && multiModuleMatches;
+	}
+
+	private boolean matches(String target, String actual) {
+		return !StringUtils.hasText(target) || target.equals(actual);
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/project/contributor/SingleResourceProjectContributor.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/project/contributor/SingleResourceProjectContributor.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.function.Function;
 
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
@@ -36,7 +37,7 @@ public class SingleResourceProjectContributor implements ProjectContributor {
 
 	private final PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
 
-	private final String relativePath;
+	private final Function<Path, Path> pathProvider;
 
 	private final String resourcePattern;
 
@@ -49,13 +50,17 @@ public class SingleResourceProjectContributor implements ProjectContributor {
 	 * @see PathMatchingResourcePatternResolver#getResource(String)
 	 */
 	public SingleResourceProjectContributor(String relativePath, String resourcePattern) {
-		this.relativePath = relativePath;
+		this((root) -> root.resolve(relativePath), resourcePattern);
+	}
+
+	public SingleResourceProjectContributor(Function<Path, Path> pathProvider, String resourcePattern) {
+		this.pathProvider = pathProvider;
 		this.resourcePattern = resourcePattern;
 	}
 
 	@Override
 	public void contribute(Path projectRoot) throws IOException {
-		Path output = projectRoot.resolve(this.relativePath);
+		Path output = this.pathProvider.apply(projectRoot);
 		if (!Files.exists(output)) {
 			Files.createDirectories(output.getParent());
 			Files.createFile(output);

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/BuildSystemTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/BuildSystemTests.java
@@ -67,6 +67,33 @@ class BuildSystemTests {
 	}
 
 	@Test
+	void gradleMultiModuleApplicationRoot(@TempDir Path directory) {
+		Path applicationModuleRoot = new GradleBuildSystem(GradleBuildSystem.DIALECT_GROOVY, "my-project")
+				.getApplicationModuleRoot(directory);
+		assertThat(applicationModuleRoot).isEqualTo(directory.resolve("my-project"));
+	}
+
+	@Test
+	void gradleMultiModuleMainSource(@TempDir Path directory) {
+		SourceStructure mainCodeStructure = new GradleBuildSystem(GradleBuildSystem.DIALECT_GROOVY, "my-project")
+				.getMainSource(directory, new JavaLanguage());
+		assertThat(mainCodeStructure.getRootDirectory()).isEqualTo(directory.resolve("my-project/src/main"));
+		assertThat(mainCodeStructure.getSourcesDirectory()).isEqualTo(directory.resolve("my-project/src/main/java"));
+		assertThat(mainCodeStructure.getResourcesDirectory())
+				.isEqualTo(directory.resolve("my-project/src/main/resources"));
+	}
+
+	@Test
+	void gradleMultiModuleTestSource(@TempDir Path directory) {
+		SourceStructure mainCodeStructure = new GradleBuildSystem(GradleBuildSystem.DIALECT_GROOVY, "my-project")
+				.getTestSource(directory, new JavaLanguage());
+		assertThat(mainCodeStructure.getRootDirectory()).isEqualTo(directory.resolve("my-project/src/test"));
+		assertThat(mainCodeStructure.getSourcesDirectory()).isEqualTo(directory.resolve("my-project/src/test/java"));
+		assertThat(mainCodeStructure.getResourcesDirectory())
+				.isEqualTo(directory.resolve("my-project/src/test/resources"));
+	}
+
+	@Test
 	void unknownBuildSystem() {
 		assertThatIllegalStateException().isThrownBy(() -> BuildSystem.forId("unknown"))
 				.withMessageContaining("Unrecognized build system id 'unknown'");

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleSettingsWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleSettingsWriterTests.java
@@ -109,6 +109,14 @@ class GroovyDslGradleSettingsWriterTests {
 		assertThat(lines).containsSequence("rootProject.name = 'my-application'");
 	}
 
+	@Test
+	void submoduleShouldBeIncluded() {
+		GradleBuild build = new GradleBuild();
+		build.settings().artifact("my-application").submodule("submodule");
+		List<String> lines = generateSettings(build);
+		assertThat(lines).containsSequence("include('submodule')");
+	}
+
 	private List<String> generateSettings(GradleBuild build) {
 		GradleSettingsWriter writer = new GroovyDslGradleSettingsWriter();
 		StringWriter out = new StringWriter();

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleSettingsWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleSettingsWriterTests.java
@@ -108,6 +108,14 @@ class KotlinDslGradleSettingsWriterTests {
 		assertThat(lines).containsSequence("rootProject.name = \"my-application\"");
 	}
 
+	@Test
+	void submoduleShouldBeIncluded() {
+		GradleBuild build = new GradleBuild();
+		build.settings().artifact("my-application").submodule("submodule");
+		List<String> lines = generateSettings(build);
+		assertThat(lines).containsSequence("include(\"submodule\")");
+	}
+
 	private List<String> generateSettings(GradleBuild build) {
 		GradleSettingsWriter writer = new KotlinDslGradleSettingsWriter();
 		StringWriter out = new StringWriter();

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/condition/ConditionalOnBuildSystemTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/condition/ConditionalOnBuildSystemTests.java
@@ -59,6 +59,14 @@ class ConditionalOnBuildSystemTests {
 				"gradleKotlin");
 	}
 
+	@Test
+	void conditionalOnGradleWithMultiModuleMatchesWhenGradleBuildSystemUsesMultiModuleConfiguration() {
+		MutableProjectDescription description = new MutableProjectDescription();
+		description.setBuildSystem(new GradleBuildSystem(GradleBuildSystem.DIALECT_GROOVY, "test"));
+		assertThat(candidatesFor(description, BuildSystemTestConfiguration.class)).containsOnlyKeys("gradle",
+				"multiModuleGradleAnyDialect");
+	}
+
 	private Map<String, String> candidatesFor(MutableProjectDescription description, Class<?>... extraConfigurations) {
 		try (ProjectGenerationContext context = new ProjectGenerationContext()) {
 			context.registerBean(ProjectDescription.class, () -> description);
@@ -93,6 +101,12 @@ class ConditionalOnBuildSystemTests {
 		@ConditionalOnBuildSystem(id = "gradle", dialect = "kotlin")
 		String gradleKotlin() {
 			return "testGradleKotlinDialect";
+		}
+
+		@Bean
+		@ConditionalOnBuildSystem(id = "gradle", multiModule = "true")
+		String multiModuleGradleAnyDialect() {
+			return "multiModuleGradleAnyDialect";
 		}
 
 	}


### PR DESCRIPTION
This change _partially_ resolves #663 

High level overview of the changes: 
 - The `BuildSystem` already had methods for getting main/test source roots. I have updated a few of the standard `ProjectContributor`s to use that so that I could extend the `BuildSystem` to be the source of truth for whether it's a single or multi module build. 
 - I extend the `BuildSystem` to support configuration of a module (other than root module) to hold the application, and it now provides a `getApplicationModuleRoot` so that `ProjectContributor`s can grab that if they want to put files in the application module - regardless of whether it's a single or multi project build. 
 - I didn't update any of the factories to support this automatically, I took a direction similar to how the kotlin dialect was implemented, which requires a `ProjectDescriptionCustomizer` to inject the `BuildSystem` implementation
 - I only implemented the changes for the gradle build system as I have more familiarity there. I'm happy to do the work to add the same for maven. 


I'd like feedback on:
- if `BuildSystem` was the "correct" thing to extend to add this functionality or if there may be a better place. It seemed clean enough but in a few places I needed to introduce it as a dependency for another class. 
- from a testing POV, what would you want to see to be confident these changes are working as expected?
- from a feature completeness POV - is the approach of requiring a `ProjectDescriptionCustomizer` acceptable? 