### PR TITLE
Add support for Maven extensions

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuild.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuild.java
@@ -26,6 +26,7 @@ import io.spring.initializr.generator.buildsystem.maven.MavenBuildSettings.Build
  *
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author Niklas Herder
  */
 public class MavenBuild extends Build {
 
@@ -36,6 +37,8 @@ public class MavenBuild extends Build {
 	private final MavenResourceContainer testResources = new MavenResourceContainer();
 
 	private final MavenPluginContainer plugins = new MavenPluginContainer();
+
+	private final MavenExtensionsContainer extensions = new MavenExtensionsContainer();
 
 	private final MavenDistributionManagement.Builder distributionManagement = new MavenDistributionManagement.Builder();
 
@@ -103,6 +106,15 @@ public class MavenBuild extends Build {
 	 */
 	public MavenPluginContainer plugins() {
 		return this.plugins;
+	}
+
+	/**
+	 * Return the {@linkplain MavenExtensionsContainer extensions container} to use to
+	 * configure extensions.
+	 * @return the {@link MavenExtensionsContainer}
+	 */
+	public MavenExtensionsContainer extensions() {
+		return this.extensions;
 	}
 
 	/**

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
@@ -59,6 +59,7 @@ import org.springframework.util.StringUtils;
  * @author Olga Maciaszek-Sharma
  * @author Jafer Khan Shamshad
  * @author Joachim Pasquali
+ * @author Niklas Herder
  */
 public class MavenBuildWriter {
 
@@ -315,7 +316,8 @@ public class MavenBuildWriter {
 		MavenBuildSettings settings = build.getSettings();
 		if (settings.getDefaultGoal() == null && settings.getFinalName() == null
 				&& settings.getSourceDirectory() == null && settings.getTestSourceDirectory() == null
-				&& build.resources().isEmpty() && build.testResources().isEmpty() && build.plugins().isEmpty()) {
+				&& build.resources().isEmpty() && build.testResources().isEmpty() && build.plugins().isEmpty()
+				&& build.extensions().isEmpty()) {
 			return;
 		}
 		writer.println();
@@ -326,6 +328,7 @@ public class MavenBuildWriter {
 			writeSingleElement(writer, "testSourceDirectory", settings.getTestSourceDirectory());
 			writeResources(writer, build.resources(), build.testResources());
 			writeCollectionElement(writer, "plugins", build.plugins().values(), this::writePlugin);
+			writeCollectionElement(writer, "extensions", build.extensions().values(), this::writeExtension);
 		});
 	}
 
@@ -493,6 +496,14 @@ public class MavenBuildWriter {
 				}
 			});
 		}
+	}
+
+	private void writeExtension(IndentingWriter writer, MavenExtension extension) {
+		writeElement(writer, "extension", () -> {
+			writeSingleElement(writer, "groupId", extension.getGroupId());
+			writeSingleElement(writer, "artifactId", extension.getArtifactId());
+			writeSingleElement(writer, "version", extension.getVersion());
+		});
 	}
 
 	private void writeProfiles(IndentingWriter writer, MavenBuild build) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenExtension.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenExtension.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.buildsystem.maven;
+
+/**
+ * An extension entry in a @{@link MavenBuild}.
+ *
+ * @author Niklas Herder
+ */
+public class MavenExtension {
+
+	private final String groupId;
+
+	private final String artifactId;
+
+	private String version;
+
+	protected MavenExtension(Builder builder) {
+		this.groupId = builder.groupId;
+		this.artifactId = builder.artifactId;
+		this.version = builder.version;
+	}
+
+	public String getGroupId() {
+		return this.groupId;
+	}
+
+	public String getArtifactId() {
+		return this.artifactId;
+	}
+
+	public String getVersion() {
+		return this.version;
+	}
+
+	public static class Builder {
+
+		private final String groupId;
+
+		private final String artifactId;
+
+		private String version;
+
+		protected Builder(String groupId, String artifactId) {
+			this.groupId = groupId;
+			this.artifactId = artifactId;
+		}
+
+		public Builder version(String version) {
+			this.version = version;
+			return this;
+		}
+
+		public MavenExtension build() {
+			return new MavenExtension(this);
+		}
+
+	}
+
+}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenExtensionsContainer.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenExtensionsContainer.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.buildsystem.maven;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+public class MavenExtensionsContainer {
+
+	private final Map<String, MavenExtension.Builder> extensions = new LinkedHashMap<>();
+
+	/**
+	 * Specify if this container is empty.
+	 * @return {@code true} if no {@link MavenExtension} is added
+	 */
+	public boolean isEmpty() {
+		return this.extensions.isEmpty();
+	}
+
+	/**
+	 * Specify if this container has a extension with the specified {@code groupId} and
+	 * {@code artifactId}.
+	 * @param groupId the groupId of the extension
+	 * @param artifactId the artifactId of the extension
+	 * @return {@code true} if an item with the specified {@code groupId} and
+	 * {@code artifactId} exists
+	 */
+	public boolean has(String groupId, String artifactId) {
+		return this.extensions.containsKey(extensionKey(groupId, artifactId));
+	}
+
+	/**
+	 * Returns a {@link Stream} of registered {@link MavenExtension}s.
+	 * @return a stream of {@link MavenExtension}s
+	 */
+	public Stream<MavenExtension> values() {
+		return this.extensions.values().stream().map(MavenExtension.Builder::build);
+	}
+
+	/**
+	 * Add a {@link MavenExtension} with the specified {@code groupId} and
+	 * {@code artifactId}. Does nothing if the extension has already been added.
+	 * @param groupId the groupId of the extension
+	 * @param artifactId the artifactId of the extension
+	 * @see #add(String, String, Consumer)
+	 */
+	public void add(String groupId, String artifactId) {
+		addExtension(groupId, artifactId);
+	}
+
+	/**
+	 * Add a {@link MavenExtension} with the specified {@code groupId} and
+	 * {@code artifactId} and {@link Consumer} to customize the extension. If the
+	 * extension has already been added, the consumer can be used to further tune the
+	 * existing extension configuration.
+	 * @param groupId the groupId of the extension
+	 * @param artifactId the artifactId of the extension
+	 * @param extension a {@link Consumer} to customize the {@link MavenExtension}
+	 */
+	public void add(String groupId, String artifactId, Consumer<MavenExtension.Builder> extension) {
+		extension.accept(addExtension(groupId, artifactId));
+	}
+
+	private MavenExtension.Builder addExtension(String groupId, String artifactId) {
+		return this.extensions.computeIfAbsent(extensionKey(groupId, artifactId),
+				(extensionId) -> new MavenExtension.Builder(groupId, artifactId));
+	}
+
+	/**
+	 * Remove the extension with the specified {@code groupId} and {@code artifactId}.
+	 * @param groupId the groupId of the extension to remove
+	 * @param artifactId the artifactId of the extension to remove
+	 * @return {@code true} if such a extension was registered, {@code false} otherwise
+	 */
+	public boolean remove(String groupId, String artifactId) {
+		return this.extensions.remove(extensionKey(groupId, artifactId)) != null;
+	}
+
+	private String extensionKey(String groupId, String artifactId) {
+		return String.format("%s:%s", groupId, artifactId);
+	}
+
+}

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriterTests.java
@@ -823,6 +823,23 @@ class MavenBuildWriterTests {
 	}
 
 	@Test
+	void pomWithoutExtensions() {
+		MavenBuild build = new MavenBuild();
+		generatePom(build, (pom) -> assertThat(pom).nodeAtPath("/project/build/extensions").isNull());
+	}
+
+	@Test
+	void pomWithExtension() {
+		MavenBuild build = new MavenBuild();
+		build.extensions().add("com.example", "testExtension", (builder) -> builder.version("1.6.1"));
+		generatePom(build, (pom) -> {
+			assertThat(pom).textAtPath("/project/build/extensions/extension/groupId").isEqualTo("com.example");
+			assertThat(pom).textAtPath("/project/build/extensions/extension/artifactId").isEqualTo("testExtension");
+			assertThat(pom).textAtPath("/project/build/extensions/extension/version").isEqualTo("1.6.1");
+		});
+	}
+
+	@Test
 	void pomWithDistributionManagementRepository() {
 		MavenBuild build = new MavenBuild();
 		build.distributionManagement().repository((repository) -> repository.id("released-repo").name("released repo")


### PR DESCRIPTION
This adds support for adding extension entries to the Maven pom. This is useful to be able to use plugins that are dependant on OS version, for example, by extending with the os-maven plugin.