### PR TITLE
Ensure Gradle tasks are configured lazily

### DIFF
--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfigurationTests.java
@@ -129,7 +129,7 @@ class GradleProjectGenerationConfigurationTests {
 				"    testImplementation 'org.springframework.boot:spring-boot-starter-test'",
 				"}",
 				"",
-				"test {",
+				"tasks.named('test') {",
 				"    useJUnitPlatform()",
 				"}"); // @formatter:on
 	}
@@ -150,7 +150,8 @@ class GradleProjectGenerationConfigurationTests {
 		description.setPlatformVersion(Version.parse("2.2.4.RELEASE"));
 		description.setLanguage(new JavaLanguage());
 		ProjectStructure project = this.projectTester.generate(description);
-		assertThat(project).textFile("build.gradle").lines().containsSequence("test {", "    useJUnitPlatform()", "}");
+		assertThat(project).textFile("build.gradle").lines().containsSequence("tasks.named('test') {",
+				"    useJUnitPlatform()", "}");
 	}
 
 	@Test

--- a/initializr-generator-spring/src/test/resources/project/gradle/annotation-processor-dependency-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/annotation-processor-dependency-build.gradle.gen
@@ -25,6 +25,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initializr-generator-spring/src/test/resources/project/gradle/bom-ordering-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/bom-ordering-build.gradle.gen
@@ -25,6 +25,6 @@ dependencyManagement {
 	}
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initializr-generator-spring/src/test/resources/project/gradle/bom-property-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/bom-property-build.gradle.gen
@@ -27,6 +27,6 @@ dependencyManagement {
 	}
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initializr-generator-spring/src/test/resources/project/gradle/compile-only-dependency-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/compile-only-dependency-build.gradle.gen
@@ -19,6 +19,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initializr-generator-spring/src/test/resources/project/gradle/kotlin-java11-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/kotlin-java11-build.gradle.gen
@@ -29,6 +29,6 @@ tasks.withType(KotlinCompile) {
 	}
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-build.gradle.gen
@@ -20,6 +20,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.gen
@@ -18,6 +18,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initializr-generator-spring/src/test/resources/project/gradle/version-override-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/version-override-build.gradle.gen
@@ -22,6 +22,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initializr-generator-spring/src/test/resources/project/groovy/standard/build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/groovy/standard/build.gradle.gen
@@ -18,6 +18,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initializr-generator-spring/src/test/resources/project/groovy/standard/war-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/groovy/standard/war-build.gradle.gen
@@ -20,6 +20,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initializr-generator-spring/src/test/resources/project/java/standard/build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/java/standard/build.gradle.gen
@@ -17,6 +17,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initializr-generator-spring/src/test/resources/project/java/standard/war-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/java/standard/war-build.gradle.gen
@@ -19,6 +19,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initializr-generator-spring/src/test/resources/project/kotlin/standard/build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/standard/build.gradle.gen
@@ -29,6 +29,6 @@ tasks.withType(KotlinCompile) {
 	}
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initializr-generator-spring/src/test/resources/project/kotlin/standard/war-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/standard/war-build.gradle.gen
@@ -31,6 +31,6 @@ tasks.withType(KotlinCompile) {
 	}
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2020 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -190,7 +190,7 @@ public class GroovyDslGradleBuildWriter extends GradleBuildWriter {
 		});
 		tasks.values().filter((candidate) -> candidate.getType() == null).forEach((task) -> {
 			writer.println();
-			writer.println(task.getName() + " {");
+			writer.println("tasks.named('" + task.getName() + "') {");
 			writer.indented(() -> writeTaskCustomization(writer, task));
 			writer.println("}");
 		});

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
@@ -170,7 +170,8 @@ class GroovyDslGradleBuildWriterTests {
 			task.invoke("dependsOn", "test");
 		});
 		List<String> lines = generateBuild(build);
-		assertThat(lines).containsSequence("asciidoctor {", "    inputs.dir snippetsDir", "    dependsOn test", "}");
+		assertThat(lines).containsSequence("tasks.named('asciidoctor') {", "    inputs.dir snippetsDir",
+				"    dependsOn test", "}");
 	}
 
 	@Test
@@ -178,7 +179,7 @@ class GroovyDslGradleBuildWriterTests {
 		GradleBuild build = new GradleBuild();
 		build.tasks().customize("test", (task) -> task.invoke("myMethod"));
 		List<String> lines = generateBuild(build);
-		assertThat(lines).containsSequence("test {", "    myMethod()", "}");
+		assertThat(lines).containsSequence("tasks.named('test') {", "    myMethod()", "}");
 	}
 
 	@Test
@@ -189,7 +190,7 @@ class GroovyDslGradleBuildWriterTests {
 			task.attribute("kotlinOptions.jvmTarget", "'1.8'");
 		});
 		List<String> lines = generateBuild(build);
-		assertThat(lines).containsSequence("compileKotlin {",
+		assertThat(lines).containsSequence("tasks.named('compileKotlin') {",
 				"    kotlinOptions.freeCompilerArgs = ['-Xjsr305=strict']", "    kotlinOptions.jvmTarget = '1.8'", "}");
 	}
 
@@ -202,7 +203,7 @@ class GroovyDslGradleBuildWriterTests {
 					kotlinOptions.attribute("jvmTarget", "'1.8'");
 				}));
 		List<String> lines = generateBuild(build);
-		assertThat(lines).containsSequence("compileKotlin {", "    kotlinOptions {",
+		assertThat(lines).containsSequence("tasks.named('compileKotlin') {", "    kotlinOptions {",
 				"        freeCompilerArgs = ['-Xjsr305=strict']", "        jvmTarget = '1.8'", "    }", "}");
 	}
 


### PR DESCRIPTION
At present, generated Gradle build scripts that use Groovy DSL configure tasks eagerly. This is both suboptimal and actually not aligned with the generated build scripts that use Kotlin DSL, which configures tasks lazily.

This commit updates `GroovyDslGradleBuildWriter` to ensure tasks are configured lazily.

See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html for more details on the task configuration avoidance topic.