### PR TITLE
Try to expose the usage of a Spring Boot version through a resolver

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/BuildProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/BuildProjectGenerationConfiguration.java
@@ -21,11 +21,13 @@ import io.spring.initializr.generator.buildsystem.Dependency;
 import io.spring.initializr.generator.buildsystem.Dependency.Exclusion;
 import io.spring.initializr.generator.buildsystem.DependencyScope;
 import io.spring.initializr.generator.condition.ConditionalOnPackaging;
-import io.spring.initializr.generator.condition.ConditionalOnPlatformVersion;
 import io.spring.initializr.generator.packaging.war.WarPackaging;
 import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
 import io.spring.initializr.generator.spring.build.maven.DefaultMavenBuildCustomizer;
+import io.spring.initializr.generator.spring.version.ConditionalOnSpringBootVersion;
+import io.spring.initializr.generator.spring.version.SpringBootProjectSettings;
+import io.spring.initializr.generator.spring.version.SpringBootVersionResolver;
 import io.spring.initializr.metadata.InitializrMetadata;
 
 import org.springframework.context.annotation.Bean;
@@ -40,7 +42,7 @@ import org.springframework.context.annotation.Bean;
 public class BuildProjectGenerationConfiguration {
 
 	@Bean
-	@ConditionalOnPlatformVersion("[2.2.0.M5,2.4.0-SNAPSHOT)")
+	@ConditionalOnSpringBootVersion("[2.2.0.M5,2.4.0-SNAPSHOT)")
 	public BuildCustomizer<Build> junit5TestStarterContributor() {
 		return (build) -> build.dependencies().add("test",
 				Dependency.withCoordinates("org.springframework.boot", "spring-boot-starter-test")
@@ -49,7 +51,7 @@ public class BuildProjectGenerationConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnPlatformVersion("2.4.0-M1")
+	@ConditionalOnSpringBootVersion("2.4.0-M1")
 	public BuildCustomizer<Build> junitJupiterTestStarterContributor() {
 		return (build) -> build.dependencies().add("test",
 				Dependency.withCoordinates("org.springframework.boot", "spring-boot-starter-test")
@@ -63,8 +65,8 @@ public class BuildProjectGenerationConfiguration {
 
 	@Bean
 	public DefaultMavenBuildCustomizer initializrMetadataMavenBuildCustomizer(ProjectDescription description,
-			InitializrMetadata metadata) {
-		return new DefaultMavenBuildCustomizer(description, metadata);
+			InitializrMetadata metadata, SpringBootProjectSettings settings) {
+		return new DefaultMavenBuildCustomizer(description, metadata, settings);
 	}
 
 	@Bean
@@ -85,8 +87,10 @@ public class BuildProjectGenerationConfiguration {
 	}
 
 	@Bean
-	public SpringBootVersionRepositoriesBuildCustomizer repositoriesBuilderCustomizer(ProjectDescription description) {
-		return new SpringBootVersionRepositoriesBuildCustomizer(description.getPlatformVersion());
+	public SpringBootVersionRepositoriesBuildCustomizer repositoriesBuilderCustomizer(ProjectDescription description,
+			SpringBootVersionResolver bootVersionResolver) {
+		return new SpringBootVersionRepositoriesBuildCustomizer(
+				bootVersionResolver.resolveSpringBootVersion(description));
 	}
 
 }

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfiguration.java
@@ -29,7 +29,6 @@ import io.spring.initializr.generator.buildsystem.gradle.KotlinDslGradleSettings
 import io.spring.initializr.generator.condition.ConditionalOnBuildSystem;
 import io.spring.initializr.generator.condition.ConditionalOnLanguage;
 import io.spring.initializr.generator.condition.ConditionalOnPackaging;
-import io.spring.initializr.generator.condition.ConditionalOnPlatformVersion;
 import io.spring.initializr.generator.io.IndentingWriterFactory;
 import io.spring.initializr.generator.language.java.JavaLanguage;
 import io.spring.initializr.generator.packaging.war.WarPackaging;
@@ -37,6 +36,8 @@ import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 import io.spring.initializr.generator.spring.util.LambdaSafe;
+import io.spring.initializr.generator.spring.version.ConditionalOnSpringBootVersion;
+import io.spring.initializr.generator.spring.version.SpringBootProjectSettings;
 import io.spring.initializr.metadata.InitializrMetadata;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -103,9 +104,11 @@ public class GradleProjectGenerationConfiguration {
 	@Bean
 	@ConditionalOnGradleVersion({ "6", "7" })
 	BuildCustomizer<GradleBuild> springBootPluginContributor(ProjectDescription description,
-			ObjectProvider<DependencyManagementPluginVersionResolver> versionResolver, InitializrMetadata metadata) {
-		return new SpringBootPluginBuildCustomizer(description, versionResolver
-				.getIfAvailable(() -> new InitializrDependencyManagementPluginVersionResolver(metadata)));
+			ObjectProvider<DependencyManagementPluginVersionResolver> versionResolver, InitializrMetadata metadata,
+			SpringBootProjectSettings settings) {
+		return new SpringBootPluginBuildCustomizer(description,
+				versionResolver.getIfAvailable(() -> new InitializrDependencyManagementPluginVersionResolver(metadata)),
+				settings);
 	}
 
 	@Bean
@@ -171,7 +174,7 @@ public class GradleProjectGenerationConfiguration {
 		}
 
 		@Bean
-		@ConditionalOnPlatformVersion("2.2.0.M3")
+		@ConditionalOnSpringBootVersion("2.2.0.M3")
 		BuildCustomizer<GradleBuild> testTaskContributor() {
 			return new BuildCustomizer<GradleBuild>() {
 				@Override
@@ -214,7 +217,7 @@ public class GradleProjectGenerationConfiguration {
 		}
 
 		@Bean
-		@ConditionalOnPlatformVersion("2.2.0.M3")
+		@ConditionalOnSpringBootVersion("2.2.0.M3")
 		BuildCustomizer<GradleBuild> testTaskContributor() {
 			return new BuildCustomizer<GradleBuild>() {
 				@Override

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/OnGradleVersionCondition.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/OnGradleVersionCondition.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 
 import io.spring.initializr.generator.condition.ProjectGenerationCondition;
 import io.spring.initializr.generator.project.ProjectDescription;
+import io.spring.initializr.generator.spring.util.SpringBootVersionCondition;
+import io.spring.initializr.generator.spring.version.SpringBootProjectSettings;
 import io.spring.initializr.generator.version.Version;
 import io.spring.initializr.generator.version.VersionParser;
 import io.spring.initializr.generator.version.VersionRange;
@@ -34,7 +36,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  */
-public class OnGradleVersionCondition extends ProjectGenerationCondition {
+public class OnGradleVersionCondition extends SpringBootVersionCondition {
 
 	private static final VersionRange GRADLE_6_VERSION_RANGE = VersionParser.DEFAULT
 			.parseRange("[2.2.2.RELEASE,2.5.0-RC1)");
@@ -42,9 +44,9 @@ public class OnGradleVersionCondition extends ProjectGenerationCondition {
 	private static final VersionRange GRADLE_7_VERSION_RANGE = VersionParser.DEFAULT.parseRange("2.5.0-RC1");
 
 	@Override
-	protected boolean matches(ProjectDescription description, ConditionContext context,
-			AnnotatedTypeMetadata metadata) {
-		String gradleGeneration = determineGradleGeneration(description.getPlatformVersion());
+	protected boolean matches(ProjectDescription description, ConditionContext context, AnnotatedTypeMetadata metadata,
+			SpringBootProjectSettings settings) {
+		String gradleGeneration = determineGradleGeneration(Version.safeParse(settings.getVersion()));
 		if (gradleGeneration == null) {
 			return false;
 		}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/SpringBootPluginBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/SpringBootPluginBuildCustomizer.java
@@ -19,6 +19,7 @@ package io.spring.initializr.generator.spring.build.gradle;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
 import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
+import io.spring.initializr.generator.spring.version.SpringBootProjectSettings;
 
 /**
  * A {@link BuildCustomizer} to configure the Spring Boot plugin and dependency management
@@ -38,16 +39,23 @@ public final class SpringBootPluginBuildCustomizer implements BuildCustomizer<Gr
 
 	private final DependencyManagementPluginVersionResolver versionResolver;
 
+	private final SpringBootProjectSettings settings;
+
 	public SpringBootPluginBuildCustomizer(ProjectDescription description,
 			DependencyManagementPluginVersionResolver versionResolver) {
+		this(description, versionResolver, () -> description.getPlatformVersion().toString());
+	}
+
+	public SpringBootPluginBuildCustomizer(ProjectDescription description,
+			DependencyManagementPluginVersionResolver versionResolver, SpringBootProjectSettings settings) {
 		this.description = description;
 		this.versionResolver = versionResolver;
+		this.settings = settings;
 	}
 
 	@Override
 	public void customize(GradleBuild build) {
-		build.plugins().add("org.springframework.boot",
-				(plugin) -> plugin.setVersion(this.description.getPlatformVersion().toString()));
+		build.plugins().add("org.springframework.boot", (plugin) -> plugin.setVersion(this.settings.getVersion()));
 		build.plugins().add("io.spring.dependency-management", (plugin) -> plugin
 				.setVersion(this.versionResolver.resolveDependencyManagementPluginVersion(this.description)));
 	}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/maven/DefaultMavenBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/maven/DefaultMavenBuildCustomizer.java
@@ -20,6 +20,7 @@ import io.spring.initializr.generator.buildsystem.BillOfMaterials;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
 import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
+import io.spring.initializr.generator.spring.version.SpringBootProjectSettings;
 import io.spring.initializr.generator.version.VersionProperty;
 import io.spring.initializr.metadata.InitializrConfiguration.Env.Maven;
 import io.spring.initializr.metadata.InitializrConfiguration.Env.Maven.ParentPom;
@@ -37,9 +38,17 @@ public class DefaultMavenBuildCustomizer implements BuildCustomizer<MavenBuild> 
 
 	private final InitializrMetadata metadata;
 
+	private final SpringBootProjectSettings settings;
+
 	public DefaultMavenBuildCustomizer(ProjectDescription description, InitializrMetadata metadata) {
+		this(description, metadata, () -> description.getPlatformVersion().toString());
+	}
+
+	public DefaultMavenBuildCustomizer(ProjectDescription description, InitializrMetadata metadata,
+			SpringBootProjectSettings settings) {
 		this.description = description;
 		this.metadata = metadata;
+		this.settings = settings;
 	}
 
 	@Override
@@ -49,7 +58,7 @@ public class DefaultMavenBuildCustomizer implements BuildCustomizer<MavenBuild> 
 		build.plugins().add("org.springframework.boot", "spring-boot-maven-plugin");
 
 		Maven maven = this.metadata.getConfiguration().getEnv().getMaven();
-		String springBootVersion = this.description.getPlatformVersion().toString();
+		String springBootVersion = this.settings.getVersion();
 		ParentPom parentPom = maven.resolveParentPom(springBootVersion);
 		if (parentPom.isIncludeSpringBootBom()) {
 			String versionProperty = "spring-boot.version";

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/SourceCodeProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/SourceCodeProjectGenerationConfiguration.java
@@ -17,12 +17,12 @@
 package io.spring.initializr.generator.spring.code;
 
 import io.spring.initializr.generator.condition.ConditionalOnPackaging;
-import io.spring.initializr.generator.condition.ConditionalOnPlatformVersion;
 import io.spring.initializr.generator.language.Annotation;
 import io.spring.initializr.generator.language.TypeDeclaration;
 import io.spring.initializr.generator.packaging.war.WarPackaging;
 import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
+import io.spring.initializr.generator.spring.version.ConditionalOnSpringBootVersion;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
@@ -62,7 +62,7 @@ public class SourceCodeProjectGenerationConfiguration {
 		}
 
 		@Bean
-		@ConditionalOnPlatformVersion("2.0.0.M1")
+		@ConditionalOnSpringBootVersion("2.0.0.M1")
 		ServletInitializerContributor boot20ServletInitializerContributor(
 				ObjectProvider<ServletInitializerCustomizer<?>> servletInitializerCustomizers) {
 			return new ServletInitializerContributor(this.description.getPackageName(),

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/groovy/GroovyProjectGenerationDefaultContributorsConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/groovy/GroovyProjectGenerationDefaultContributorsConfiguration.java
@@ -36,6 +36,7 @@ import io.spring.initializr.generator.spring.build.BuildCustomizer;
 import io.spring.initializr.generator.spring.code.MainApplicationTypeCustomizer;
 import io.spring.initializr.generator.spring.code.ServletInitializerCustomizer;
 import io.spring.initializr.generator.spring.code.TestApplicationTypeCustomizer;
+import io.spring.initializr.generator.spring.version.SpringBootVersionResolver;
 import io.spring.initializr.generator.version.VersionParser;
 import io.spring.initializr.generator.version.VersionRange;
 
@@ -73,8 +74,10 @@ class GroovyProjectGenerationDefaultContributorsConfiguration {
 	}
 
 	@Bean
-	BuildCustomizer<Build> groovyDependenciesConfigurer(ProjectDescription description) {
-		return new GroovyDependenciesConfigurer(GROOVY4.match(description.getPlatformVersion()));
+	BuildCustomizer<Build> groovyDependenciesConfigurer(ProjectDescription description,
+			SpringBootVersionResolver bootVersionResolver) {
+		return new GroovyDependenciesConfigurer(
+				GROOVY4.match(bootVersionResolver.resolveSpringBootVersion(description)));
 	}
 
 	/**

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/InitializrMetadataKotlinVersionResolver.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/InitializrMetadataKotlinVersionResolver.java
@@ -17,6 +17,8 @@
 package io.spring.initializr.generator.spring.code.kotlin;
 
 import io.spring.initializr.generator.project.ProjectDescription;
+import io.spring.initializr.generator.spring.version.InitializrMetadataSpringBootVersionResolver;
+import io.spring.initializr.generator.spring.version.SpringBootVersionResolver;
 import io.spring.initializr.metadata.InitializrMetadata;
 
 /**
@@ -29,14 +31,22 @@ public class InitializrMetadataKotlinVersionResolver implements KotlinVersionRes
 
 	private final InitializrMetadata metadata;
 
+	private final SpringBootVersionResolver bootVersionResolver;
+
 	public InitializrMetadataKotlinVersionResolver(InitializrMetadata metadata) {
+		this(metadata, new InitializrMetadataSpringBootVersionResolver(metadata));
+	}
+
+	public InitializrMetadataKotlinVersionResolver(InitializrMetadata metadata,
+			SpringBootVersionResolver bootVersionResolver) {
 		this.metadata = metadata;
+		this.bootVersionResolver = bootVersionResolver;
 	}
 
 	@Override
 	public String resolveKotlinVersion(ProjectDescription description) {
 		return this.metadata.getConfiguration().getEnv().getKotlin()
-				.resolveKotlinVersion(description.getPlatformVersion());
+				.resolveKotlinVersion(this.bootVersionResolver.resolveSpringBootVersion(description));
 	}
 
 }

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinProjectGenerationConfiguration.java
@@ -32,6 +32,7 @@ import io.spring.initializr.generator.spring.code.MainSourceCodeProjectContribut
 import io.spring.initializr.generator.spring.code.TestApplicationTypeCustomizer;
 import io.spring.initializr.generator.spring.code.TestSourceCodeCustomizer;
 import io.spring.initializr.generator.spring.code.TestSourceCodeProjectContributor;
+import io.spring.initializr.generator.spring.version.SpringBootVersionResolver;
 import io.spring.initializr.metadata.InitializrMetadata;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -81,9 +82,9 @@ public class KotlinProjectGenerationConfiguration {
 
 	@Bean
 	public KotlinProjectSettings kotlinProjectSettings(ObjectProvider<KotlinVersionResolver> kotlinVersionResolver,
-			InitializrMetadata metadata) {
+			InitializrMetadata metadata, SpringBootVersionResolver bootVersionResolver) {
 		String kotlinVersion = kotlinVersionResolver
-				.getIfAvailable(() -> new InitializrMetadataKotlinVersionResolver(metadata))
+				.getIfAvailable(() -> new InitializrMetadataKotlinVersionResolver(metadata, bootVersionResolver))
 				.resolveKotlinVersion(this.description);
 		return new SimpleKotlinProjectSettings(kotlinVersion, this.description.getLanguage().jvmVersion());
 	}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinProjectGenerationDefaultContributorsConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinProjectGenerationDefaultContributorsConfiguration.java
@@ -21,7 +21,6 @@ import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
 import io.spring.initializr.generator.condition.ConditionalOnBuildSystem;
 import io.spring.initializr.generator.condition.ConditionalOnPackaging;
-import io.spring.initializr.generator.condition.ConditionalOnPlatformVersion;
 import io.spring.initializr.generator.language.Annotation;
 import io.spring.initializr.generator.language.Parameter;
 import io.spring.initializr.generator.language.kotlin.KotlinCompilationUnit;
@@ -38,6 +37,7 @@ import io.spring.initializr.generator.spring.build.BuildCustomizer;
 import io.spring.initializr.generator.spring.code.MainCompilationUnitCustomizer;
 import io.spring.initializr.generator.spring.code.ServletInitializerCustomizer;
 import io.spring.initializr.generator.spring.code.TestApplicationTypeCustomizer;
+import io.spring.initializr.generator.spring.version.ConditionalOnSpringBootVersion;
 import io.spring.initializr.metadata.InitializrMetadata;
 
 import org.springframework.context.annotation.Bean;
@@ -84,7 +84,7 @@ class KotlinProjectGenerationDefaultContributorsConfiguration {
 	 * Configuration for Kotlin projects using Spring Boot 2.0 and later.
 	 */
 	@Configuration
-	@ConditionalOnPlatformVersion("2.0.0.M1")
+	@ConditionalOnSpringBootVersion("2.0.0.M1")
 	static class SpringBoot2AndLaterKotlinProjectGenerationConfiguration {
 
 		@Bean

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/documentation/HelpDocumentProjectGenerationDefaultContributorsConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/documentation/HelpDocumentProjectGenerationDefaultContributorsConfiguration.java
@@ -18,6 +18,7 @@ package io.spring.initializr.generator.spring.documentation;
 
 import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.spring.scm.git.GitIgnoreCustomizer;
+import io.spring.initializr.generator.spring.version.SpringBootProjectSettings;
 import io.spring.initializr.metadata.InitializrMetadata;
 
 import org.springframework.context.annotation.Bean;
@@ -33,8 +34,9 @@ public class HelpDocumentProjectGenerationDefaultContributorsConfiguration {
 
 	@Bean
 	public RequestedDependenciesHelpDocumentCustomizer dependenciesHelpDocumentCustomizer(
-			ProjectDescription description, InitializrMetadata metadata) {
-		return new RequestedDependenciesHelpDocumentCustomizer(description, metadata);
+			ProjectDescription description, InitializrMetadata metadata,
+			SpringBootProjectSettings springBootProjectSettings) {
+		return new RequestedDependenciesHelpDocumentCustomizer(description, metadata, springBootProjectSettings);
 	}
 
 	@Bean

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/documentation/RequestedDependenciesHelpDocumentCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/documentation/RequestedDependenciesHelpDocumentCustomizer.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 
 import io.spring.initializr.generator.io.text.BulletedSection;
 import io.spring.initializr.generator.project.ProjectDescription;
+import io.spring.initializr.generator.spring.version.SpringBootProjectSettings;
 import io.spring.initializr.metadata.Dependency;
 import io.spring.initializr.metadata.InitializrMetadata;
 import io.spring.initializr.metadata.Link;
@@ -44,11 +45,24 @@ public class RequestedDependenciesHelpDocumentCustomizer implements HelpDocument
 
 	private final String platformVersion;
 
+	private final String bootVersion;
+
 	public RequestedDependenciesHelpDocumentCustomizer(ProjectDescription description, InitializrMetadata metadata) {
+		this(description, metadata, (String) null);
+	}
+
+	public RequestedDependenciesHelpDocumentCustomizer(ProjectDescription description, InitializrMetadata metadata,
+			SpringBootProjectSettings settings) {
+		this(description, metadata, settings.getVersion());
+	}
+
+	private RequestedDependenciesHelpDocumentCustomizer(ProjectDescription description, InitializrMetadata metadata,
+			String bootVersion) {
 		this.description = description;
 		this.metadata = metadata;
 		this.platformVersion = (description.getPlatformVersion() != null) ? description.getPlatformVersion().toString()
 				: metadata.getBootVersions().getDefault().getId();
+		this.bootVersion = (bootVersion != null) ? bootVersion : this.platformVersion;
 	}
 
 	@Override
@@ -86,7 +100,8 @@ public class RequestedDependenciesHelpDocumentCustomizer implements HelpDocument
 				String description = (link.getDescription() != null) ? link.getDescription()
 						: defaultDescription.apply(links);
 				if (description != null) {
-					String url = link.getHref().replace("{bootVersion}", this.platformVersion);
+					String url = link.getHref().replace("{bootVersion}", this.bootVersion);
+					url = url.replace("{platformVersion}", this.platformVersion);
 					section.get().addItem(new GettingStartedSection.Link(url, description));
 				}
 			}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/util/SpringBootVersionCondition.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/util/SpringBootVersionCondition.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.util;
+
+import io.spring.initializr.generator.condition.ProjectGenerationCondition;
+import io.spring.initializr.generator.project.ProjectDescription;
+import io.spring.initializr.generator.spring.version.SpringBootProjectSettings;
+
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public abstract class SpringBootVersionCondition extends ProjectGenerationCondition {
+
+	@Override
+	protected boolean matches(ProjectDescription description, ConditionContext context,
+			AnnotatedTypeMetadata metadata) {
+		SpringBootProjectSettings settings = context.getBeanFactory().getBean(SpringBootProjectSettings.class);
+		return matches(description, context, metadata, settings);
+	}
+
+	protected abstract boolean matches(ProjectDescription description, ConditionContext context,
+			AnnotatedTypeMetadata metadata, SpringBootProjectSettings settings);
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/ConditionalOnSpringBootVersion.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/ConditionalOnSpringBootVersion.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.version;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.spring.initializr.generator.version.VersionRange;
+
+import org.springframework.context.annotation.Conditional;
+
+/**
+ * Condition that matches when a generated project is using a matching version of Spring
+ * Boot.
+ *
+ * @author Filip Hrisafov
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Documented
+@Conditional(OnSpringBootVersionCondition.class)
+public @interface ConditionalOnSpringBootVersion {
+
+	/**
+	 * The {@linkplain VersionRange version ranges} to check. The condition matches when
+	 * at least one range matches the Spring Boot version.
+	 * @return the version ranges to check
+	 */
+	String[] value();
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/InitializrMetadataSpringBootVersionResolver.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/InitializrMetadataSpringBootVersionResolver.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.version;
+
+import io.spring.initializr.generator.project.ProjectDescription;
+import io.spring.initializr.generator.version.Version;
+import io.spring.initializr.metadata.InitializrMetadata;
+
+/**
+ * {@link SpringBootVersionResolver} that resolves the version from
+ * {@link InitializrMetadata} when not provided in the project description.
+ *
+ * @author Filip Hrisafov
+ */
+public class InitializrMetadataSpringBootVersionResolver implements SpringBootVersionResolver {
+
+	private final InitializrMetadata metadata;
+
+	public InitializrMetadataSpringBootVersionResolver(InitializrMetadata metadata) {
+		this.metadata = metadata;
+	}
+
+	@Override
+	public Version resolveSpringBootVersion(ProjectDescription projectDescription) {
+		return (projectDescription.getPlatformVersion() != null) ? projectDescription.getPlatformVersion()
+				: Version.parse(this.metadata.getBootVersions().getDefault().getId());
+	}
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/OnSpringBootVersionCondition.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/OnSpringBootVersionCondition.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.version;
+
+import java.util.Arrays;
+
+import io.spring.initializr.generator.project.ProjectDescription;
+import io.spring.initializr.generator.spring.util.SpringBootVersionCondition;
+import io.spring.initializr.generator.version.Version;
+import io.spring.initializr.generator.version.VersionParser;
+
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * {@link SpringBootVersionCondition} implementation for
+ * {@link ConditionalOnSpringBootVersion}.
+ *
+ * @author Filip Hrisafov
+ */
+class OnSpringBootVersionCondition extends SpringBootVersionCondition {
+
+	@Override
+	protected boolean matches(ProjectDescription description, ConditionContext context, AnnotatedTypeMetadata metadata,
+			SpringBootProjectSettings settings) {
+		Version springBootVersion = Version.safeParse(settings.getVersion());
+		if (springBootVersion == null) {
+			return false;
+		}
+		return Arrays
+				.stream((String[]) metadata.getAnnotationAttributes(ConditionalOnSpringBootVersion.class.getName())
+						.get("value"))
+				.anyMatch((range) -> VersionParser.DEFAULT.parseRange(range).match(springBootVersion));
+
+	}
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/SimpleSpringBootProjectSettings.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/SimpleSpringBootProjectSettings.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.version;
+
+/**
+ * Common settings for Spring Boot projects.
+ *
+ * @author Filip Hrisafov
+ */
+public class SimpleSpringBootProjectSettings implements SpringBootProjectSettings {
+
+	private final String version;
+
+	public SimpleSpringBootProjectSettings(String version) {
+		this.version = version;
+	}
+
+	@Override
+	public String getVersion() {
+		return this.version;
+	}
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/SpringBootProjectSettings.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/SpringBootProjectSettings.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.version;
+
+/**
+ * Common Settings for Spring Boot projects.
+ *
+ * @author Filip Hrisafov
+ */
+public interface SpringBootProjectSettings {
+
+	/**
+	 * Return the version of Spring Boot to use.
+	 * @return the spring Boot version
+	 */
+	String getVersion();
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/SpringBootVersionResolver.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/SpringBootVersionResolver.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.version;
+
+import io.spring.initializr.generator.project.ProjectDescription;
+import io.spring.initializr.generator.version.Version;
+
+/**
+ * Strategy for resolving a Spring Boot version from a platform version.
+ *
+ * @author Filip Hrisafov
+ */
+@FunctionalInterface
+public interface SpringBootVersionResolver {
+
+	/**
+	 * Resolve the Spring Boot version based on a project description.
+	 * @param description the project description
+	 * @return the resolved Spring Boot version
+	 */
+	Version resolveSpringBootVersion(ProjectDescription description);
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/VersionProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/VersionProjectGenerationConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.version;
+
+import io.spring.initializr.generator.project.ProjectDescription;
+import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
+import io.spring.initializr.metadata.InitializrMetadata;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Configuration for Spring Boot version contribution to a project.
+ *
+ * @author Filip Hrisafov
+ */
+@ProjectGenerationConfiguration
+public class VersionProjectGenerationConfiguration {
+
+	@Bean
+	public SpringBootProjectSettings springBootProjectSettings(
+			ObjectProvider<SpringBootVersionResolver> springBootVersionResolver, ProjectDescription description,
+			InitializrMetadata metadata) {
+		String bootVersion = springBootVersionResolver
+				.getIfAvailable(() -> new InitializrMetadataSpringBootVersionResolver(metadata))
+				.resolveSpringBootVersion(description).toString();
+		return new SimpleSpringBootProjectSettings(bootVersion);
+	}
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/package-info.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/version/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Spring Boot version resolver.
+ */
+package io.spring.initializr.generator.spring.version;

--- a/initializr-generator-spring/src/main/resources/META-INF/spring.factories
+++ b/initializr-generator-spring/src/main/resources/META-INF/spring.factories
@@ -8,4 +8,5 @@ io.spring.initializr.generator.spring.code.java.JavaProjectGenerationConfigurati
 io.spring.initializr.generator.spring.code.kotlin.KotlinProjectGenerationConfiguration,\
 io.spring.initializr.generator.spring.configuration.ApplicationConfigurationProjectGenerationConfiguration,\
 io.spring.initializr.generator.spring.documentation.HelpDocumentProjectGenerationConfiguration,\
-io.spring.initializr.generator.spring.scm.git.GitProjectGenerationConfiguration
+io.spring.initializr.generator.spring.scm.git.GitProjectGenerationConfiguration,\
+io.spring.initializr.generator.spring.version.VersionProjectGenerationConfiguration

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/ProjectGeneratorIntegrationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/ProjectGeneratorIntegrationTests.java
@@ -23,6 +23,7 @@ import io.spring.initializr.generator.language.java.JavaLanguage;
 import io.spring.initializr.generator.project.MutableProjectDescription;
 import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
 import io.spring.initializr.generator.project.ProjectGenerator;
+import io.spring.initializr.generator.spring.version.VersionProjectGenerationConfiguration;
 import io.spring.initializr.generator.test.InitializrMetadataTestBuilder;
 import io.spring.initializr.generator.test.project.ProjectGeneratorTester;
 import io.spring.initializr.generator.test.project.ProjectStructure;
@@ -47,6 +48,7 @@ class ProjectGeneratorIntegrationTests {
 	@BeforeEach
 	void setup(@TempDir Path directory) {
 		this.projectTester = new ProjectGeneratorTester().withDirectory(directory).withIndentingWriterFactory()
+				.withConfiguration(VersionProjectGenerationConfiguration.class)
 				.withBean(InitializrMetadata.class, () -> InitializrMetadataTestBuilder.withDefaults().build());
 	}
 

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/ConditionalOnGradleVersionTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/ConditionalOnGradleVersionTests.java
@@ -17,6 +17,7 @@
 package io.spring.initializr.generator.spring.build.gradle;
 
 import io.spring.initializr.generator.project.MutableProjectDescription;
+import io.spring.initializr.generator.spring.version.VersionProjectGenerationConfiguration;
 import io.spring.initializr.generator.test.project.ProjectAssetTester;
 import io.spring.initializr.generator.version.Version;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ConditionalOnGradleVersionTests {
 
 	private final ProjectAssetTester projectTester = new ProjectAssetTester()
-			.withConfiguration(GradleVersionTestConfiguration.class);
+			.withConfiguration(VersionProjectGenerationConfiguration.class, GradleVersionTestConfiguration.class);
 
 	@Test
 	void outcomeWithSpringBoot23() {

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleKtsProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleKtsProjectGenerationConfigurationTests.java
@@ -28,6 +28,7 @@ import io.spring.initializr.generator.language.java.JavaLanguage;
 import io.spring.initializr.generator.packaging.war.WarPackaging;
 import io.spring.initializr.generator.project.MutableProjectDescription;
 import io.spring.initializr.generator.spring.build.BuildProjectGenerationConfiguration;
+import io.spring.initializr.generator.spring.version.VersionProjectGenerationConfiguration;
 import io.spring.initializr.generator.test.InitializrMetadataTestBuilder;
 import io.spring.initializr.generator.test.project.ProjectAssetTester;
 import io.spring.initializr.generator.test.project.ProjectStructure;
@@ -58,6 +59,7 @@ class GradleKtsProjectGenerationConfigurationTests {
 	void setup(@TempDir Path directory) {
 		this.projectTester = new ProjectAssetTester().withIndentingWriterFactory()
 				.withConfiguration(BuildProjectGenerationConfiguration.class,
+						VersionProjectGenerationConfiguration.class,
 						GradleProjectGenerationConfiguration.class)
 				.withDirectory(directory)
 				.withBean(InitializrMetadata.class, () -> InitializrMetadataTestBuilder.withDefaults().build())

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfigurationTests.java
@@ -28,6 +28,7 @@ import io.spring.initializr.generator.language.java.JavaLanguage;
 import io.spring.initializr.generator.packaging.war.WarPackaging;
 import io.spring.initializr.generator.project.MutableProjectDescription;
 import io.spring.initializr.generator.spring.build.BuildProjectGenerationConfiguration;
+import io.spring.initializr.generator.spring.version.VersionProjectGenerationConfiguration;
 import io.spring.initializr.generator.test.InitializrMetadataTestBuilder;
 import io.spring.initializr.generator.test.project.ProjectAssetTester;
 import io.spring.initializr.generator.test.project.ProjectStructure;
@@ -58,6 +59,7 @@ class GradleProjectGenerationConfigurationTests {
 	void setup(@TempDir Path directory) {
 		this.projectTester = new ProjectAssetTester().withIndentingWriterFactory()
 				.withConfiguration(BuildProjectGenerationConfiguration.class,
+						VersionProjectGenerationConfiguration.class,
 						GradleProjectGenerationConfiguration.class)
 				.withDirectory(directory)
 				.withBean(InitializrMetadata.class, () -> InitializrMetadataTestBuilder.withDefaults().build())

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/maven/MavenProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/maven/MavenProjectGenerationConfigurationTests.java
@@ -24,6 +24,7 @@ import io.spring.initializr.generator.language.java.JavaLanguage;
 import io.spring.initializr.generator.packaging.war.WarPackaging;
 import io.spring.initializr.generator.project.MutableProjectDescription;
 import io.spring.initializr.generator.spring.build.BuildProjectGenerationConfiguration;
+import io.spring.initializr.generator.spring.version.VersionProjectGenerationConfiguration;
 import io.spring.initializr.generator.test.InitializrMetadataTestBuilder;
 import io.spring.initializr.generator.test.project.ProjectAssetTester;
 import io.spring.initializr.generator.test.project.ProjectStructure;
@@ -47,7 +48,7 @@ class MavenProjectGenerationConfigurationTests {
 	@BeforeEach
 	void setup(@TempDir Path directory) {
 		this.projectTester = new ProjectAssetTester().withIndentingWriterFactory()
-				.withConfiguration(BuildProjectGenerationConfiguration.class, MavenProjectGenerationConfiguration.class)
+				.withConfiguration(BuildProjectGenerationConfiguration.class, MavenProjectGenerationConfiguration.class, VersionProjectGenerationConfiguration.class)
 				.withBean(InitializrMetadata.class, () -> InitializrMetadataTestBuilder.withDefaults().build())
 				.withDirectory(directory).withDescriptionCustomizer((description) -> {
 					description.setBuildSystem(new MavenBuildSystem());

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/SourceCodeProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/SourceCodeProjectGenerationConfigurationTests.java
@@ -21,6 +21,7 @@ import io.spring.initializr.generator.language.SourceCode;
 import io.spring.initializr.generator.language.TypeDeclaration;
 import io.spring.initializr.generator.packaging.Packaging;
 import io.spring.initializr.generator.project.MutableProjectDescription;
+import io.spring.initializr.generator.spring.version.VersionProjectGenerationConfiguration;
 import io.spring.initializr.generator.test.project.ProjectAssetTester;
 import io.spring.initializr.generator.version.Version;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ import static org.mockito.Mockito.verify;
 class SourceCodeProjectGenerationConfigurationTests {
 
 	private final ProjectAssetTester projectTester = new ProjectAssetTester()
-			.withConfiguration(SourceCodeProjectGenerationConfiguration.class);
+			.withConfiguration(SourceCodeProjectGenerationConfiguration.class, VersionProjectGenerationConfiguration.class);
 
 	@Test
 	@SuppressWarnings("unchecked")

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/groovy/GroovyProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/groovy/GroovyProjectGenerationConfigurationTests.java
@@ -23,6 +23,7 @@ import io.spring.initializr.generator.language.groovy.GroovyLanguage;
 import io.spring.initializr.generator.packaging.war.WarPackaging;
 import io.spring.initializr.generator.project.MutableProjectDescription;
 import io.spring.initializr.generator.spring.code.SourceCodeProjectGenerationConfiguration;
+import io.spring.initializr.generator.spring.version.VersionProjectGenerationConfiguration;
 import io.spring.initializr.generator.test.project.ProjectAssetTester;
 import io.spring.initializr.generator.test.project.ProjectStructure;
 import io.spring.initializr.generator.version.Version;
@@ -45,6 +46,7 @@ class GroovyProjectGenerationConfigurationTests {
 	void setup(@TempDir Path directory) {
 		this.projectTester = new ProjectAssetTester().withIndentingWriterFactory()
 				.withConfiguration(SourceCodeProjectGenerationConfiguration.class,
+						VersionProjectGenerationConfiguration.class,
 						GroovyProjectGenerationConfiguration.class)
 				.withDirectory(directory).withDescriptionCustomizer((description) -> {
 					description.setLanguage(new GroovyLanguage());

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/java/JavaProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/java/JavaProjectGenerationConfigurationTests.java
@@ -23,6 +23,7 @@ import io.spring.initializr.generator.language.java.JavaLanguage;
 import io.spring.initializr.generator.packaging.war.WarPackaging;
 import io.spring.initializr.generator.project.MutableProjectDescription;
 import io.spring.initializr.generator.spring.code.SourceCodeProjectGenerationConfiguration;
+import io.spring.initializr.generator.spring.version.VersionProjectGenerationConfiguration;
 import io.spring.initializr.generator.test.project.ProjectAssetTester;
 import io.spring.initializr.generator.test.project.ProjectStructure;
 import io.spring.initializr.generator.version.Version;
@@ -44,7 +45,8 @@ class JavaProjectGenerationConfigurationTests {
 	@BeforeEach
 	void setup(@TempDir Path directory) {
 		this.projectTester = new ProjectAssetTester().withIndentingWriterFactory()
-				.withConfiguration(SourceCodeProjectGenerationConfiguration.class,
+				.withConfiguration(VersionProjectGenerationConfiguration.class,
+						SourceCodeProjectGenerationConfiguration.class,
 						JavaProjectGenerationConfiguration.class)
 				.withDirectory(directory).withDescriptionCustomizer((description) -> {
 					description.setLanguage(new JavaLanguage());

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinProjectGenerationConfigurationTests.java
@@ -27,6 +27,7 @@ import io.spring.initializr.generator.project.MutableProjectDescription;
 import io.spring.initializr.generator.spring.build.BuildProjectGenerationConfiguration;
 import io.spring.initializr.generator.spring.build.maven.MavenProjectGenerationConfiguration;
 import io.spring.initializr.generator.spring.code.SourceCodeProjectGenerationConfiguration;
+import io.spring.initializr.generator.spring.version.VersionProjectGenerationConfiguration;
 import io.spring.initializr.generator.test.InitializrMetadataTestBuilder;
 import io.spring.initializr.generator.test.project.ProjectAssetTester;
 import io.spring.initializr.generator.test.project.ProjectStructure;
@@ -52,6 +53,7 @@ class KotlinProjectGenerationConfigurationTests {
 		this.projectTester = new ProjectAssetTester().withIndentingWriterFactory()
 				.withConfiguration(SourceCodeProjectGenerationConfiguration.class,
 						KotlinProjectGenerationConfiguration.class, BuildProjectGenerationConfiguration.class,
+						VersionProjectGenerationConfiguration.class,
 						MavenProjectGenerationConfiguration.class)
 				.withDirectory(directory).withBean(InitializrMetadata.class, () -> {
 					io.spring.initializr.metadata.Dependency dependency = io.spring.initializr.metadata.Dependency

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/documentation/HelpDocumentProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/documentation/HelpDocumentProjectGenerationConfigurationTests.java
@@ -21,6 +21,9 @@ import java.nio.file.Path;
 import io.spring.initializr.generator.io.template.MustacheTemplateRenderer;
 import io.spring.initializr.generator.project.MutableProjectDescription;
 import io.spring.initializr.generator.spring.scm.git.GitIgnoreCustomizer;
+import io.spring.initializr.generator.spring.version.SimpleSpringBootProjectSettings;
+import io.spring.initializr.generator.spring.version.SpringBootProjectSettings;
+import io.spring.initializr.generator.spring.version.VersionProjectGenerationConfiguration;
 import io.spring.initializr.generator.test.InitializrMetadataTestBuilder;
 import io.spring.initializr.generator.test.project.ProjectAssetTester;
 import io.spring.initializr.generator.test.project.ProjectStructure;
@@ -48,7 +51,7 @@ class HelpDocumentProjectGenerationConfigurationTests {
 	@BeforeEach
 	void setup(@TempDir Path directory) {
 		this.projectTester = new ProjectAssetTester()
-				.withConfiguration(HelpDocumentProjectGenerationConfiguration.class)
+				.withConfiguration(HelpDocumentProjectGenerationConfiguration.class, VersionProjectGenerationConfiguration.class)
 				.withBean(MustacheTemplateRenderer.class, () -> new MustacheTemplateRenderer("classpath:/templates"))
 				.withBean(InitializrMetadata.class, () -> this.metadataBuilder.build()).withDirectory(directory);
 	}


### PR DESCRIPTION
We recently started using the Spring initializr for creating our own initializr for our own projects. Our projects are highly based on Spring Boot and our approach of generating is to define the platform version to be our version, but we still want to have a project generated that will use the Spring Boot starters.

Currently there are some problems when a non Spring Boot version is used as a platform version:

* The help files contains wrong links to resources, because `{bootVersion}` is not really the Spring Boot version, but rather our platform version
* The parent contains wrong version and so on

We would like to keep using `initializr-generator-spring` and benefit from the opinionated approach of generating Spring Boot projects. 

This PR is a work in progress and before I go ahead and fix the tests I would like to first get your opinion about it. Will something like this be accepted? If yes I will spend more time on this to try to iron out the details.