### PR TITLE
Main and Test application types should only be annotated if they haven't been done already

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/SourceCodeProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/SourceCodeProjectGenerationConfiguration.java
@@ -38,14 +38,21 @@ public class SourceCodeProjectGenerationConfiguration {
 
 	@Bean
 	public MainApplicationTypeCustomizer<TypeDeclaration> springBootApplicationAnnotator() {
-		return (typeDeclaration) -> typeDeclaration
-				.annotate(Annotation.name("org.springframework.boot.autoconfigure.SpringBootApplication"));
+		return (typeDeclaration) -> annotateIfNotAlreadyAnnotated(typeDeclaration,
+				"org.springframework.boot.autoconfigure.SpringBootApplication");
 	}
 
 	@Bean
 	public TestApplicationTypeCustomizer<TypeDeclaration> junitJupiterSpringBootTestTypeCustomizer() {
-		return (typeDeclaration) -> typeDeclaration
-				.annotate(Annotation.name("org.springframework.boot.test.context.SpringBootTest"));
+		return (typeDeclaration) -> annotateIfNotAlreadyAnnotated(typeDeclaration,
+				"org.springframework.boot.test.context.SpringBootTest");
+	}
+
+	private void annotateIfNotAlreadyAnnotated(TypeDeclaration typeDeclaration, String annotationName) {
+		if (typeDeclaration.getAnnotations().stream()
+				.noneMatch((annotation) -> annotationName.equals(annotation.getName()))) {
+			typeDeclaration.annotate(Annotation.name(annotationName));
+		}
 	}
 
 	/**


### PR DESCRIPTION
With this commit custom `MainApplicationTypeCustomizer` and `TestApplicationTypeCustomizer` are able to provide custom
`@SpringBootApplication` and `@SpringBootTest` annotations in their own generated projects.

Fixes #1264