### PR TITLE
Handling Unicode in Project Generation

### DIFF
--- a/initializr-web/src/main/java/io/spring/initializr/web/project/ProjectRequest.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/project/ProjectRequest.java
@@ -66,7 +66,7 @@ public class ProjectRequest {
 	}
 
 	public String getName() {
-		return this.name;
+		return cleanInputValue(this.name);
 	}
 
 	public void setName(String name) {
@@ -90,7 +90,7 @@ public class ProjectRequest {
 	}
 
 	public String getGroupId() {
-		return this.groupId;
+		return cleanInputValue(this.groupId);
 	}
 
 	public void setGroupId(String groupId) {
@@ -98,7 +98,7 @@ public class ProjectRequest {
 	}
 
 	public String getArtifactId() {
-		return this.artifactId;
+		return cleanInputValue(this.artifactId);
 	}
 
 	public void setArtifactId(String artifactId) {
@@ -147,7 +147,7 @@ public class ProjectRequest {
 
 	public String getPackageName() {
 		if (StringUtils.hasText(this.packageName)) {
-			return this.packageName;
+			return cleanInputValue(this.packageName);
 		}
 		if (StringUtils.hasText(this.groupId) && StringUtils.hasText(this.artifactId)) {
 			return getGroupId() + "." + getArtifactId();
@@ -173,6 +173,13 @@ public class ProjectRequest {
 
 	public void setBaseDir(String baseDir) {
 		this.baseDir = baseDir;
+	}
+
+	private String cleanInputValue(String inputString) {
+		if (StringUtils.hasText(inputString)) {
+			return org.apache.commons.lang3.StringUtils.stripAccents(inputString);
+		}
+		return inputString;
 	}
 
 }

--- a/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectGenerationControllerArchiveIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectGenerationControllerArchiveIntegrationTests.java
@@ -36,4 +36,10 @@ public class ProjectGenerationControllerArchiveIntegrationTests extends Abstract
 		assertDefaultProject(project.resolveModule("demo trial"));
 	}
 
+	@Test
+	void projectNameWithAccentRemoved() {
+		ProjectStructure project = downloadZip("/starter.zip?artifactId=demo&baseDir=demo trial&name=Demö");
+		assertDefaultProject(project.resolveModule("demo trial"));
+	}
+
 }


### PR DESCRIPTION
Fix for Bug : https://github.com/spring-io/initializr/issues/1328

There can we two approach to handle this scenario 
1- Have Validation on request and give error to caller.
2- We don't give error But clean input request to safe value -like to stripAccents 
   Demö  to be used as Demo
   köykkä  to be used as koykka

we can add more cleaning options
