### PR TITLE
Polish reference guide

### DIFF
--- a/initializr-docs/src/main/asciidoc/configuration-guide.adoc
+++ b/initializr-docs/src/main/asciidoc/configuration-guide.adoc
@@ -790,7 +790,7 @@ The following `rel` value are currently officially supported:
 
 * `guide`: the link points to a guide describing how to use the related dependency. It
 can be a tutorial, a how-to or typically a guide available on https://spring.io/guides
-* reference: the link points to a section of a developer guide typically or any page that
+* `reference`: the link points to a section of a developer guide typically or any page that
 documents how to use the dependency
 
 The url can be templated if its actual value can change according to the environment. An

--- a/initializr-docs/src/main/asciidoc/configuration-guide.adoc
+++ b/initializr-docs/src/main/asciidoc/configuration-guide.adoc
@@ -110,7 +110,7 @@ all contributors found in `META-INF/spring.factories` and also registers an addi
 `ProjectContributor` programmatically.
 
 `ProjectContributor` is the highest level interface one can implement to contribute assets
-to a a project. The `SampleContributor` registered above generates a `test.txt` file at
+to a a project. The `SampleContributor` registered above generates a `hello.txt` file at
 the root of the project structure, as shown below:
 
 [source,java,indent=0,subs="verbatim,quotes,attributes"]


### PR DESCRIPTION
To make it less confusing, the file name in the description and in the code sample were different.