### PR TITLE
Vary Kotlin standard library artifact ID depending on the version of Kotlin

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinDependenciesConfigurer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinDependenciesConfigurer.java
@@ -31,8 +31,6 @@ class KotlinDependenciesConfigurer implements BuildCustomizer<Build> {
 
 	@Override
 	public void customize(Build build) {
-		build.dependencies().add("kotlin-stdlib", Dependency
-				.withCoordinates("org.jetbrains.kotlin", "kotlin-stdlib-jdk8").scope(DependencyScope.COMPILE));
 		build.dependencies().add("kotlin-reflect",
 				Dependency.withCoordinates("org.jetbrains.kotlin", "kotlin-reflect").scope(DependencyScope.COMPILE));
 	}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenBuildCustomizer.java
@@ -52,8 +52,13 @@ class KotlinMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
 			});
 			kotlinMavenPlugin.dependency("org.jetbrains.kotlin", "kotlin-maven-allopen", "${kotlin.version}");
 		});
-		build.dependencies().add("kotlin-stdlib", Dependency
-				.withCoordinates("org.jetbrains.kotlin", "kotlin-stdlib-jdk8").scope(DependencyScope.COMPILE));
+		String[] version = this.settings.getVersion().split("\\.");
+		String artifactId = (Integer.parseInt(version[0]) >= 2
+				|| Integer.parseInt(version[0]) == 1 && Integer.parseInt(version[1]) >= 8) ? "kotlin-stdlib"
+						: "kotlin-stdlib-jdk8";
+		build.dependencies().add("kotlin-stdlib",
+				Dependency.withCoordinates("org.jetbrains.kotlin", artifactId).scope(DependencyScope.COMPILE));
+
 	}
 
 }

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenBuildCustomizer.java
@@ -16,6 +16,8 @@
 
 package io.spring.initializr.generator.spring.code.kotlin;
 
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.DependencyScope;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 
@@ -50,6 +52,8 @@ class KotlinMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
 			});
 			kotlinMavenPlugin.dependency("org.jetbrains.kotlin", "kotlin-maven-allopen", "${kotlin.version}");
 		});
+		build.dependencies().add("kotlin-stdlib", Dependency
+				.withCoordinates("org.jetbrains.kotlin", "kotlin-stdlib-jdk8").scope(DependencyScope.COMPILE));
 	}
 
 }

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinDependenciesConfigurerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinDependenciesConfigurerTests.java
@@ -17,7 +17,6 @@
 package io.spring.initializr.generator.spring.code.kotlin;
 
 import io.spring.initializr.generator.buildsystem.Dependency;
-import io.spring.initializr.generator.buildsystem.DependencyScope;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
 import org.junit.jupiter.api.Test;
@@ -35,12 +34,7 @@ class KotlinDependenciesConfigurerTests {
 	void configuresDependenciesForGradleBuild() {
 		GradleBuild build = new GradleBuild();
 		new KotlinDependenciesConfigurer().customize(build);
-		assertThat(build.dependencies().ids()).containsOnly("kotlin-stdlib", "kotlin-reflect");
-		Dependency kotlinStdlib = build.dependencies().get("kotlin-stdlib");
-		assertThat(kotlinStdlib.getGroupId()).isEqualTo("org.jetbrains.kotlin");
-		assertThat(kotlinStdlib.getArtifactId()).isEqualTo("kotlin-stdlib-jdk8");
-		assertThat(kotlinStdlib.getVersion()).isNull();
-		assertThat(kotlinStdlib.getScope()).isEqualTo(DependencyScope.COMPILE);
+		assertThat(build.dependencies().ids()).containsOnly("kotlin-reflect");
 		Dependency kotlinReflect = build.dependencies().get("kotlin-reflect");
 		assertThat(kotlinReflect.getGroupId()).isEqualTo("org.jetbrains.kotlin");
 		assertThat(kotlinReflect.getArtifactId()).isEqualTo("kotlin-reflect");
@@ -51,12 +45,7 @@ class KotlinDependenciesConfigurerTests {
 	void configuresDependenciesForMavenBuild() {
 		MavenBuild build = new MavenBuild();
 		new KotlinDependenciesConfigurer().customize(build);
-		assertThat(build.dependencies().ids()).containsOnly("kotlin-stdlib", "kotlin-reflect");
-		Dependency kotlinStdlib = build.dependencies().get("kotlin-stdlib");
-		assertThat(kotlinStdlib.getGroupId()).isEqualTo("org.jetbrains.kotlin");
-		assertThat(kotlinStdlib.getArtifactId()).isEqualTo("kotlin-stdlib-jdk8");
-		assertThat(kotlinStdlib.getVersion()).isNull();
-		assertThat(kotlinStdlib.getScope()).isEqualTo(DependencyScope.COMPILE);
+		assertThat(build.dependencies().ids()).containsOnly("kotlin-reflect");
 		Dependency kotlinReflect = build.dependencies().get("kotlin-reflect");
 		assertThat(kotlinReflect.getGroupId()).isEqualTo("org.jetbrains.kotlin");
 		assertThat(kotlinReflect.getArtifactId()).isEqualTo("kotlin-reflect");

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenBuildCustomizerTests.java
@@ -19,6 +19,7 @@ package io.spring.initializr.generator.spring.code.kotlin;
 import java.util.Arrays;
 import java.util.List;
 
+import io.spring.initializr.generator.buildsystem.DependencyScope;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
 import io.spring.initializr.generator.buildsystem.maven.MavenPlugin.Configuration;
 import io.spring.initializr.generator.buildsystem.maven.MavenPlugin.Dependency;
@@ -96,6 +97,18 @@ class KotlinMavenBuildCustomizerTests {
 			assertThat(args.getValue()).asList().element(1).hasFieldOrPropertyWithValue("name", "arg")
 					.hasFieldOrPropertyWithValue("value", "-Dtwo=2");
 		});
+	}
+
+	@Test
+	void kotlinMavenKotlinStdlibIsConfigured() {
+		MavenBuild build = new MavenBuild();
+		new KotlinMavenBuildCustomizer(new TestKotlinProjectSettings()).customize(build);
+		assertThat(build.dependencies().ids()).containsOnly("kotlin-stdlib");
+		io.spring.initializr.generator.buildsystem.Dependency kotlinStdlib = build.dependencies().get("kotlin-stdlib");
+		assertThat(kotlinStdlib.getGroupId()).isEqualTo("org.jetbrains.kotlin");
+		assertThat(kotlinStdlib.getArtifactId()).isEqualTo("kotlin-stdlib-jdk8");
+		assertThat(kotlinStdlib.getVersion()).isNull();
+		assertThat(kotlinStdlib.getScope()).isEqualTo(DependencyScope.COMPILE);
 	}
 
 	private static class TestKotlinProjectSettings extends SimpleKotlinProjectSettings {

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinMavenBuildCustomizerTests.java
@@ -106,7 +106,19 @@ class KotlinMavenBuildCustomizerTests {
 		assertThat(build.dependencies().ids()).containsOnly("kotlin-stdlib");
 		io.spring.initializr.generator.buildsystem.Dependency kotlinStdlib = build.dependencies().get("kotlin-stdlib");
 		assertThat(kotlinStdlib.getGroupId()).isEqualTo("org.jetbrains.kotlin");
-		assertThat(kotlinStdlib.getArtifactId()).isEqualTo("kotlin-stdlib-jdk8");
+		assertThat(kotlinStdlib.getArtifactId()).isEqualTo("kotlin-stdlib");
+		assertThat(kotlinStdlib.getVersion()).isNull();
+		assertThat(kotlinStdlib.getScope()).isEqualTo(DependencyScope.COMPILE);
+	}
+
+	@Test
+	void kotlinMavenKotlinStdlibIsConfiguredWithOldKotlin() {
+		MavenBuild build = new MavenBuild();
+		new KotlinMavenBuildCustomizer(new TestKotlinProjectSettingsOldKotlin()).customize(build);
+		assertThat(build.dependencies().ids()).containsOnly("kotlin-stdlib");
+		io.spring.initializr.generator.buildsystem.Dependency kotlinStdlib = build.dependencies().get("kotlin-stdlib");
+		assertThat(kotlinStdlib.getGroupId()).isEqualTo("org.jetbrains.kotlin");
+		assertThat(kotlinStdlib.getArtifactId()).isEqualTo("kotlin-stdlib-jvm8");
 		assertThat(kotlinStdlib.getVersion()).isNull();
 		assertThat(kotlinStdlib.getScope()).isEqualTo(DependencyScope.COMPILE);
 	}
@@ -114,6 +126,19 @@ class KotlinMavenBuildCustomizerTests {
 	private static class TestKotlinProjectSettings extends SimpleKotlinProjectSettings {
 
 		TestKotlinProjectSettings() {
+			super("1.8.10");
+		}
+
+		@Override
+		public List<String> getCompilerArgs() {
+			return Arrays.asList("-Done=1", "-Dtwo=2");
+		}
+
+	}
+
+	private static class TestKotlinProjectSettingsOldKotlin extends SimpleKotlinProjectSettings {
+
+		TestKotlinProjectSettingsOldKotlin() {
 			super("1.3.20");
 		}
 

--- a/initializr-generator-spring/src/test/resources/project/gradle/kotlin-java11-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/kotlin-java11-build.gradle.gen
@@ -18,7 +18,6 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
-	implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/initializr-generator-spring/src/test/resources/project/gradle/kotlin-java11-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/kotlin-java11-build.gradle.kts.gen
@@ -18,7 +18,6 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/initializr-generator-spring/src/test/resources/project/kotlin/standard/build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/standard/build.gradle.gen
@@ -18,7 +18,6 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
-	implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/initializr-generator-spring/src/test/resources/project/kotlin/standard/build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/standard/build.gradle.kts.gen
@@ -18,7 +18,6 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/initializr-generator-spring/src/test/resources/project/kotlin/standard/war-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/standard/war-build.gradle.gen
@@ -19,7 +19,6 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
-	implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/initializr-generator-spring/src/test/resources/project/kotlin/standard/war-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/standard/war-build.gradle.kts.gen
@@ -19,7 +19,6 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 	providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 }


### PR DESCRIPTION
- Resolves: https://github.com/spring-io/start.spring.io/issues/1120

⚠ This change is currently based on #1376 because the two changes heavily conflict, so that one will need to be merged first.