### PR TITLE
(🎁) Utilize `maven` helper function in kotlin build files

### DIFF
--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-build.gradle.kts.gen
@@ -10,8 +10,8 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
 	mavenCentral()
-	maven { url = uri("https://example.com/foo") }
-	maven { url = uri("https://example.com/bar") }
+	maven("https://example.com/foo")
+	maven("https://example.com/bar")
 }
 
 dependencies {

--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.kts.gen
@@ -10,7 +10,7 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
 	mavenCentral()
-	maven { url = uri("https://repo.spring.io/milestone") }
+	maven("https://repo.spring.io/milestone")
 }
 
 dependencies {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriter.java
@@ -118,7 +118,7 @@ public class KotlinDslGradleBuildWriter extends GradleBuildWriter {
 		if (MavenRepository.MAVEN_CENTRAL.equals(repository)) {
 			return "mavenCentral()";
 		}
-		return "maven { url = uri(\"" + repository.getUrl() + "\") }";
+		return "maven(\"" + repository.getUrl() + "\")";
 	}
 
 	@Override

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriterTests.java
@@ -153,7 +153,7 @@ class KotlinDslGradleBuildWriterTests extends GradleBuildWriterTests {
 		build.repositories().add(MavenRepository.withIdAndUrl("spring-milestones", "https://repo.spring.io/milestone"));
 		assertThat(write(build)).contains("""
 				repositories {
-					maven { url = uri("https://repo.spring.io/milestone") }
+					maven("https://repo.spring.io/milestone")
 				}""");
 	}
 
@@ -164,7 +164,7 @@ class KotlinDslGradleBuildWriterTests extends GradleBuildWriterTests {
 				MavenRepository.withIdAndUrl("spring-snapshots", "https://repo.spring.io/snapshot").onlySnapshots());
 		assertThat(write(build)).contains("""
 				repositories {
-					maven { url = uri("https://repo.spring.io/snapshot") }
+					maven("https://repo.spring.io/snapshot")
 				}""");
 	}
 

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleSettingsWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleSettingsWriterTests.java
@@ -61,7 +61,7 @@ class KotlinDslGradleSettingsWriterTests {
 		assertThat(generateSettings(build)).contains("""
 				pluginManagement {
 					repositories {
-						maven { url = uri("https://repo.spring.io/milestone") }
+						maven("https://repo.spring.io/milestone")
 						gradlePluginPortal()
 					}
 				}""");
@@ -76,7 +76,7 @@ class KotlinDslGradleSettingsWriterTests {
 		assertThat(generateSettings(build)).contains("""
 				pluginManagement {
 					repositories {
-						maven { url = uri("https://repo.spring.io/snapshot") }
+						maven("https://repo.spring.io/snapshot")
 						gradlePluginPortal()
 					}
 				}""");


### PR DESCRIPTION
Gradle provides a helper function for declaring `maven` repositories with a nice shorthand.

```kts
repositories {
    maven { url = uri("https://repo.spring.io/milestone") }  # old
    maven("https://repo.spring.io/milestone")  # new
}
