### PR TITLE
Allow more dependencies to benefit from developmentOnly/optional

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/dependency/DevelopmentOnlyDependencyGradleBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/dependency/DevelopmentOnlyDependencyGradleBuildCustomizer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.dependency;
+
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.buildsystem.gradle.GradleDependency;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+
+/**
+ * Gradle {@link BuildCustomizer} that sets the "developmentOnly" configuration for a
+ * dependency.
+ *
+ * @author Stephane Nicoll
+ * @author Moritz Halbritter
+ */
+public class DevelopmentOnlyDependencyGradleBuildCustomizer implements BuildCustomizer<GradleBuild> {
+
+	private final String dependencyId;
+
+	/**
+	 * Create a new instance with the identifier for the dependency.
+	 * @param dependencyId the id of the dependency
+	 */
+	public DevelopmentOnlyDependencyGradleBuildCustomizer(String dependencyId) {
+		this.dependencyId = dependencyId;
+	}
+
+	@Override
+	public void customize(GradleBuild build) {
+		Dependency dependency = build.dependencies().get(this.dependencyId);
+		if (dependency != null) {
+			build.dependencies()
+				.add(this.dependencyId, GradleDependency.from(dependency).configuration("developmentOnly"));
+		}
+	}
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/dependency/OptionalDependencyMavenBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/dependency/OptionalDependencyMavenBuildCustomizer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.dependency;
+
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
+import io.spring.initializr.generator.buildsystem.maven.MavenDependency;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+
+/**
+ * Maven {@link BuildCustomizer} that sets the "optional" flag for a dependency.
+ *
+ * @author Stephane Nicoll
+ * @author Moritz Halbritter
+ */
+public class OptionalDependencyMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
+
+	private final String dependencyId;
+
+	/**
+	 * Create a new instance with the identifier for the dependency.
+	 * @param dependencyId the id of the dependency
+	 */
+	public OptionalDependencyMavenBuildCustomizer(String dependencyId) {
+		this.dependencyId = dependencyId;
+	}
+
+	@Override
+	public void customize(MavenBuild build) {
+		Dependency dependency = build.dependencies().get(this.dependencyId);
+		if (dependency != null) {
+			build.dependencies().add(this.dependencyId, MavenDependency.from(dependency).optional(true));
+		}
+	}
+
+}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/dependency/devtools/DevToolsGradleBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/dependency/devtools/DevToolsGradleBuildCustomizer.java
@@ -20,6 +20,7 @@ import io.spring.initializr.generator.buildsystem.Dependency;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
 import io.spring.initializr.generator.buildsystem.gradle.GradleDependency;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
+import io.spring.initializr.generator.spring.dependency.DevelopmentOnlyDependencyGradleBuildCustomizer;
 import io.spring.initializr.generator.version.Version;
 import io.spring.initializr.generator.version.VersionParser;
 import io.spring.initializr.generator.version.VersionRange;
@@ -29,7 +30,9 @@ import io.spring.initializr.generator.version.VersionRange;
  * when devtools is selected.
  *
  * @author Stephane Nicoll
+ * @deprecated in favor of {@link DevelopmentOnlyDependencyGradleBuildCustomizer}
  */
+@Deprecated
 public class DevToolsGradleBuildCustomizer implements BuildCustomizer<GradleBuild> {
 
 	private static final VersionRange SPRING_BOOT_2_3_0_RC1_OR_LATER = VersionParser.DEFAULT.parseRange("2.3.0.RC1");

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/dependency/devtools/DevToolsMavenBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/dependency/devtools/DevToolsMavenBuildCustomizer.java
@@ -20,12 +20,15 @@ import io.spring.initializr.generator.buildsystem.Dependency;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
 import io.spring.initializr.generator.buildsystem.maven.MavenDependency;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
+import io.spring.initializr.generator.spring.dependency.OptionalDependencyMavenBuildCustomizer;
 
 /**
  * Maven {@link BuildCustomizer} that sets the "optional" flag when devtools is selected.
  *
  * @author Stephane Nicoll
+ * @deprecated in favor of {@link OptionalDependencyMavenBuildCustomizer}
  */
+@Deprecated
 public class DevToolsMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
 
 	private final String devtoolsDependencyId;

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/dependency/package-info.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/dependency/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Customizations for dependencies.
+ */
+package io.spring.initializr.generator.spring.dependency;

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/dependency/DevelopmentOnlyDependencyGradleBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/dependency/DevelopmentOnlyDependencyGradleBuildCustomizerTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.dependency;
+
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.buildsystem.gradle.GradleDependency;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DevelopmentOnlyDependencyGradleBuildCustomizer}.
+ *
+ * @author Stephane Nicoll
+ * @author Moritz Halbritter
+ */
+class DevelopmentOnlyDependencyGradleBuildCustomizerTests {
+
+	private static final Dependency WEB_DEPENDENCY = Dependency
+		.withCoordinates("org.springframework.boot", "spring-boot-starter-web")
+		.build();
+
+	private static final Dependency DEVTOOLS_DEPENDENCY = Dependency
+		.withCoordinates("org.springframework.boot", "spring-boot-devtools")
+		.build();
+
+	@Test
+	void shouldAddDevelopmentOnlyConfiguration() {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("devtools", DEVTOOLS_DEPENDENCY);
+		new DevelopmentOnlyDependencyGradleBuildCustomizer("devtools").customize(build);
+		Dependency devtools = build.dependencies().get("devtools");
+		assertThat(devtools).isInstanceOf(GradleDependency.class);
+		assertThat(((GradleDependency) devtools).getConfiguration()).isEqualTo("developmentOnly");
+	}
+
+	@Test
+	void shouldNotFailOnDuplicateDependencies() {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("devtools", DEVTOOLS_DEPENDENCY);
+		build.dependencies().add("devtools", DEVTOOLS_DEPENDENCY);
+		build.dependencies().add("web", WEB_DEPENDENCY);
+		new DevelopmentOnlyDependencyGradleBuildCustomizer("devtools").customize(build);
+		Dependency devtools = build.dependencies().get("devtools");
+		assertThat(devtools).isInstanceOf(GradleDependency.class);
+		assertThat(((GradleDependency) devtools).getConfiguration()).isEqualTo("developmentOnly");
+	}
+
+	@Test
+	void shouldIgnoreOtherDependencies() {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("devtools", DEVTOOLS_DEPENDENCY);
+		build.dependencies().add("web", WEB_DEPENDENCY);
+		new DevelopmentOnlyDependencyGradleBuildCustomizer("devtools").customize(build);
+		Dependency devtools = build.dependencies().get("devtools");
+		assertThat(devtools).isInstanceOf(GradleDependency.class);
+		assertThat(((GradleDependency) devtools).getConfiguration()).isEqualTo("developmentOnly");
+		Dependency web = build.dependencies().get("web");
+		assertThat(web).isNotInstanceOf(GradleDependency.class);
+	}
+
+	@Test
+	void shouldNotChangeDependencies() {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("web", WEB_DEPENDENCY);
+		new DevelopmentOnlyDependencyGradleBuildCustomizer("devtools").customize(build);
+		assertThat(build.dependencies().ids()).containsOnly("web");
+	}
+
+}

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/dependency/OptionalDependencyMavenBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/dependency/OptionalDependencyMavenBuildCustomizerTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.dependency;
+
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
+import io.spring.initializr.generator.buildsystem.maven.MavenDependency;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link OptionalDependencyMavenBuildCustomizer}.
+ *
+ * @author Stephane Nicoll
+ * @author Moritz Halbritter
+ */
+class OptionalDependencyMavenBuildCustomizerTests {
+
+	private static final Dependency WEB_DEPENDENCY = Dependency
+		.withCoordinates("org.springframework.boot", "spring-boot-starter-web")
+		.build();
+
+	private static final Dependency DEVTOOLS_DEPENDENCY = Dependency
+		.withCoordinates("org.springframework.boot", "spring-boot-devtools")
+		.build();
+
+	@Test
+	void shouldAddOptionalScope() {
+		MavenBuild build = new MavenBuild();
+		build.dependencies().add("devtools", DEVTOOLS_DEPENDENCY);
+		new OptionalDependencyMavenBuildCustomizer("devtools").customize(build);
+		Dependency devtools = build.dependencies().get("devtools");
+		assertThat(devtools).isInstanceOf(MavenDependency.class);
+		assertThat(((MavenDependency) devtools).isOptional()).isTrue();
+	}
+
+	@Test
+	void shouldNotFailOnDuplicateDependencies() {
+		MavenBuild build = new MavenBuild();
+		build.dependencies().add("devtools", DEVTOOLS_DEPENDENCY);
+		build.dependencies().add("devtools", DEVTOOLS_DEPENDENCY);
+		new OptionalDependencyMavenBuildCustomizer("devtools").customize(build);
+		Dependency devtools = build.dependencies().get("devtools");
+		assertThat(devtools).isInstanceOf(MavenDependency.class);
+		assertThat(((MavenDependency) devtools).isOptional()).isTrue();
+	}
+
+	@Test
+	void shouldIgnoreOtherDependencies() {
+		MavenBuild build = new MavenBuild();
+		build.dependencies().add("devtools", DEVTOOLS_DEPENDENCY);
+		build.dependencies().add("web", WEB_DEPENDENCY);
+		new OptionalDependencyMavenBuildCustomizer("devtools").customize(build);
+		Dependency devtools = build.dependencies().get("devtools");
+		assertThat(devtools).isInstanceOf(MavenDependency.class);
+		assertThat(((MavenDependency) devtools).isOptional()).isTrue();
+		Dependency web = build.dependencies().get("web");
+		assertThat(web).isNotInstanceOf(MavenDependency.class);
+	}
+
+	@Test
+	void shouldNotChangeDependencies() {
+		MavenBuild build = new MavenBuild();
+		build.dependencies().add("web", WEB_DEPENDENCY);
+		new OptionalDependencyMavenBuildCustomizer("devtools").customize(build);
+		assertThat(build.dependencies().ids()).containsOnly("web");
+	}
+
+}


### PR DESCRIPTION
Adds `DockerComposeGradleBuildCustomizer` and `DockerComposeMavenBuildCustomizer`, which sets `developmentOnly` or `<optional>true</optional>` for the `spring-boot-docker-compose` dependency.