### PR TITLE
Add BuildAssert support for Gradle with the Kotlin DSL

### DIFF
--- a/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/GroovyDslGradleBuildAssert.java
+++ b/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/GroovyDslGradleBuildAssert.java
@@ -85,21 +85,4 @@ public class GroovyDslGradleBuildAssert extends AbstractTextAssert<GroovyDslGrad
 		return contains(String.format("%s = '%s'", name, value));
 	}
 
-	/**
-	 * Assert {@code build.gradle} contains only the specified properties.
-	 * @param values the property value pairs
-	 * @return this for method chaining.
-	 */
-	public GroovyDslGradleBuildAssert containsOnlyExtProperties(String... values) {
-		StringBuilder builder = new StringBuilder(String.format("ext {%n"));
-		if (values.length % 2 == 1) {
-			throw new IllegalArgumentException("Size must be even, it is a set of property=value pairs");
-		}
-		for (int i = 0; i < values.length; i += 2) {
-			builder.append(String.format("\tset('%s', \"%s\")%n", values[i], values[i + 1]));
-		}
-		builder.append("}");
-		return contains(builder.toString());
-	}
-
 }

--- a/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/KotlinDslGradleBuildAssert.java
+++ b/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/KotlinDslGradleBuildAssert.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.test.buildsystem.gradle;
+
+import java.nio.file.Path;
+
+import io.spring.initializr.generator.test.io.AbstractTextAssert;
+import io.spring.initializr.generator.test.io.TextTestUtils;
+
+/**
+ * Simple assertions for a kotlin build using the kotlin DSL.
+ *
+ * @author Prithvi singh
+ */
+public class KotlinDslGradleBuildAssert extends AbstractTextAssert<KotlinDslGradleBuildAssert> {
+
+	public KotlinDslGradleBuildAssert(String content) {
+		super(content, KotlinDslGradleBuildAssert.class);
+	}
+
+	public KotlinDslGradleBuildAssert(Path buildGradleFile) {
+		this(TextTestUtils.readContent(buildGradleFile));
+	}
+
+	/**
+	 * Assert {@code build.gradle.kts} defines a plugin with the specified id and version.
+	 * @param id the id of the plugin
+	 * @param version the version of the plugin
+	 * @return {@code this} assertion object
+	 */
+	public KotlinDslGradleBuildAssert hasPlugin(String id, String version) {
+		return contains(String.format("id('%s') version '%s'", id, version));
+	}
+
+	/**
+	 * Assert {@code build.gradle.kts} defines a plugin with the specified id.
+	 * @param id the id of the plugin
+	 * @return {@code this} assertion object
+	 */
+	public KotlinDslGradleBuildAssert hasPlugin(String id) {
+		return contains(String.format("id('%s')", id));
+	}
+
+	/**
+	 * Assert {@code build.gradle.kts} uses the specified {@code version}.
+	 * @param version the version of the build
+	 * @return {@code this} assertion object
+	 */
+	public KotlinDslGradleBuildAssert hasVersion(String version) {
+		return hasProperty("version", version);
+	}
+
+	/**
+	 * Assert {@code build.gradle.kts} uses a source compatibility for the specified java
+	 * version.
+	 * @param javaVersion the java version
+	 * @return {@code this} assertion object
+	 */
+	public KotlinDslGradleBuildAssert hasSourceCompatibility(String javaVersion) {
+		return hasProperty("sourceCompatibility", javaVersion);
+	}
+
+	/**
+	 * Assert {@code build.gradle.kts} defines a top-level property with the specified
+	 * name and value.
+	 * @param name the name of the property
+	 * @param value the value
+	 * @return {@code this} assertion object
+	 */
+	public KotlinDslGradleBuildAssert hasProperty(String name, String value) {
+		return contains(String.format("%s = '%s'", name, value));
+	}
+
+}

--- a/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/KotlinDslGradleSettingsAssert.java
+++ b/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/KotlinDslGradleSettingsAssert.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.test.buildsystem.gradle;
+
+import io.spring.initializr.generator.test.io.AbstractTextAssert;
+
+/**
+ * Simple assertions for a gradle settings using the Kotlin DSL.
+ *
+ * @author Prithvi singh
+ */
+public class KotlinDslGradleSettingsAssert extends AbstractTextAssert<KotlinDslGradleSettingsAssert> {
+
+	protected KotlinDslGradleSettingsAssert(String content) {
+		super(content, KotlinDslGradleSettingsAssert.class);
+	}
+
+	/**
+	 * Assert {@code settings.gradle.kts} defines the specified project name.
+	 * @param name the name of the project
+	 * @return {@code this} assertion object
+	 */
+	public KotlinDslGradleSettingsAssert hasProjectName(String name) {
+		return hasProperty("rootProject.name", name);
+	}
+
+	/**
+	 * Assert {@code settings.gradle.kts} defines a property with the specified name and
+	 * value.
+	 * @param name the name of the property
+	 * @param value the value
+	 * @return {@code this} assertion object
+	 */
+	public KotlinDslGradleSettingsAssert hasProperty(String name, String value) {
+		return contains(String.format("%s = '%s", name, value));
+	}
+
+}

--- a/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/io/AbstractTextAssert.java
+++ b/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/io/AbstractTextAssert.java
@@ -32,6 +32,7 @@ import org.springframework.util.StreamUtils;
  *
  * @param <SELF> the type of the concrete assert implementations
  * @author Stephane Nicoll
+ * @author Prithvi singh
  */
 public abstract class AbstractTextAssert<SELF extends AbstractStringAssert<SELF>> extends AbstractStringAssert<SELF> {
 
@@ -82,6 +83,24 @@ public abstract class AbstractTextAssert<SELF extends AbstractStringAssert<SELF>
 	 */
 	public ListAssert<String> lines() {
 		return new ListAssert<>(TextTestUtils.readAllLines(this.actual));
+	}
+
+	/**
+	 * Assert {@code build.gradle} or {@code build.gradle.kts} contains only the specified
+	 * properties.
+	 * @param values the property value pairs
+	 * @return this for method chaining.
+	 */
+	public SELF containsOnlyExtProperties(String... values) {
+		StringBuilder builder = new StringBuilder(String.format("ext {%n"));
+		if (values.length % 2 == 1) {
+			throw new IllegalArgumentException("Size must be even, it is a set of property=value pairs");
+		}
+		for (int i = 0; i < values.length; i += 2) {
+			builder.append(String.format("\tset('%s', \"%s\")%n", values[i], values[i + 1]));
+		}
+		builder.append("}");
+		return contains(builder.toString());
 	}
 
 }

--- a/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/project/AbstractModuleAssert.java
+++ b/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/project/AbstractModuleAssert.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 
 import io.spring.initializr.generator.language.Language;
 import io.spring.initializr.generator.test.buildsystem.gradle.GroovyDslGradleBuildAssert;
+import io.spring.initializr.generator.test.buildsystem.gradle.KotlinDslGradleBuildAssert;
 import io.spring.initializr.generator.test.buildsystem.maven.MavenBuildAssert;
 
 /**
@@ -106,6 +107,26 @@ public abstract class AbstractModuleAssert<SELF extends AbstractModuleAssert<SEL
 	public GroovyDslGradleBuildAssert groovyDslGradleBuild() {
 		hasGroovyDslGradleBuild();
 		return new GroovyDslGradleBuildAssert(this.actual.resolve("build.gradle"));
+	}
+
+	/**
+	 * Assert the module defines a {@code build.gradle.kts}.
+	 * @return {@code this} assertion object
+	 */
+	public SELF hasKotlinDslGradleBuild() {
+		filePaths().contains("build.gradle.kts");
+		return this.myself;
+	}
+
+	/**
+	 * Assert this module has a {@code build.gradle.kts} and return an
+	 * {@link KotlinDslGradleBuildAssert assert} for the {@code build.gradle.kts} file of
+	 * this module, to allow chaining of gradle-specific assertions from this call.
+	 * @return a {@link KotlinDslGradleBuildAssert}
+	 */
+	public KotlinDslGradleBuildAssert kotlinDslGradleBuild() {
+		hasKotlinDslGradleBuild();
+		return new KotlinDslGradleBuildAssert(this.actual.resolve("build.gradle.kts"));
 	}
 
 }

--- a/initializr-generator-test/src/test/java/io/spring/initializr/generator/test/buildsystem/gradle/KotlinDslGradleBuildAssertTests.java
+++ b/initializr-generator-test/src/test/java/io/spring/initializr/generator/test/buildsystem/gradle/KotlinDslGradleBuildAssertTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.test.buildsystem.gradle;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.assertj.core.api.AssertProvider;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.StreamUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for {@link KotlinDslGradleBuildAssert}
+ *
+ * @author Prithvi singh
+ */
+class KotlinDslGradleBuildAssertTests {
+
+	@Test
+	void hasPluginWithId() {
+		assertThat(forSampleGradleBuild()).hasPlugin("java");
+	}
+
+	@Test
+	void hasPluginWithIdAndVersion() {
+		assertThat(forSampleGradleBuild()).hasPlugin("com.example", "1.0.0.RELEASE");
+	}
+
+	@Test
+	void hasPluginWrongId() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forSampleGradleBuild()).hasPlugin("com.another", "1.0.0.RELEASE"));
+	}
+
+	@Test
+	void hasPluginWrongValue() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forSampleGradleBuild()).hasPlugin("com.example", "2.0.0.RELEASE"));
+	}
+
+	@Test
+	void hasVersion() {
+		assertThat(forSampleGradleBuild()).hasVersion("0.0.1-SNAPSHOT");
+	}
+
+	@Test
+	void hasVersionWithWrongValue() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forSampleGradleBuild()).hasVersion("0.0.3-SNAPSHOT"));
+	}
+
+	@Test
+	void hasSourceCompatibility() {
+		assertThat(forSampleGradleBuild()).hasSourceCompatibility("1.8");
+	}
+
+	@Test
+	void hasSourceCompatibilityWithWrongValue() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forSampleGradleBuild()).hasSourceCompatibility("11"));
+	}
+
+	@Test
+	void containsOnlyExtProperties() {
+		assertThat(forSampleGradleBuild()).containsOnlyExtProperties("acmeVersion", "Brussels.SR2");
+	}
+
+	@Test
+	void containsOnlyExtPropertiesWithExtraValue() {
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(forSampleGradleBuild())
+			.containsOnlyExtProperties("acmeVersion", "Brussels.SR2", "wrong", "1.0.0"));
+	}
+
+	private AssertProvider<KotlinDslGradleBuildAssert> forSampleGradleBuild() {
+		String path = "project/build/gradle/sample-build.gradle.kts";
+		try (InputStream in = new ClassPathResource(path).getInputStream()) {
+			String content = StreamUtils.copyToString(in, StandardCharsets.UTF_8);
+			return () -> new KotlinDslGradleBuildAssert(content);
+		}
+		catch (IOException ex) {
+			throw new IllegalStateException("No content found at " + path, ex);
+		}
+	}
+
+}

--- a/initializr-generator-test/src/test/java/io/spring/initializr/generator/test/buildsystem/gradle/KotlinDslGradleSettingsAssertTests.java
+++ b/initializr-generator-test/src/test/java/io/spring/initializr/generator/test/buildsystem/gradle/KotlinDslGradleSettingsAssertTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.test.buildsystem.gradle;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.assertj.core.api.AssertProvider;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.StreamUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for {@link KotlinDslGradleSettingsAssert}
+ *
+ * @author Prithvi singh
+ */
+class KotlinDslGradleSettingsAssertTests {
+
+	@Test
+	void hasProjectName() {
+		assertThat(forSampleGradleSettings()).hasProjectName("demo");
+	}
+
+	@Test
+	void hasProjectNameWithWrongValue() {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forSampleGradleSettings()).hasProjectName("another-project"));
+	}
+
+	private AssertProvider<KotlinDslGradleSettingsAssert> forSampleGradleSettings() {
+		String path = "project/build/gradle/sample-settings.gradle.kts";
+		try (InputStream in = new ClassPathResource(path).getInputStream()) {
+			String content = StreamUtils.copyToString(in, StandardCharsets.UTF_8);
+			return () -> new KotlinDslGradleSettingsAssert(content);
+		}
+		catch (IOException ex) {
+			throw new IllegalStateException("No content found at " + path, ex);
+		}
+	}
+
+}

--- a/initializr-generator-test/src/test/java/io/spring/initializr/generator/test/project/ModuleAssertTests.java
+++ b/initializr-generator-test/src/test/java/io/spring/initializr/generator/test/project/ModuleAssertTests.java
@@ -189,6 +189,19 @@ class ModuleAssertTests {
 	}
 
 	@Test
+	void hasKotlinDslGradleBuild(@TempDir Path dir) throws IOException {
+		createFiles(dir, "build.gradle.kts");
+		assertThat(forDirectory(dir)).hasKotlinDslGradleBuild();
+	}
+
+	@Test
+	void hasKotlinDslGradleBuildWithMissingBuildFile(@TempDir Path dir) throws IOException {
+		createFiles(dir, "build.gradle.wrongkts");
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forDirectory(dir)).hasKotlinDslGradleBuild());
+	}
+
+	@Test
 	void hasGradleWrapper(@TempDir Path dir) throws IOException {
 		createFiles(dir, "gradlew", "gradlew.bat", "gradle/wrapper/gradle-wrapper.properties",
 				"gradle/wrapper/gradle-wrapper.jar");
@@ -219,6 +232,19 @@ class ModuleAssertTests {
 	void groovyDslGradleBuildWithMissingBuildFile(@TempDir Path dir) {
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forDirectory(dir)).groovyDslGradleBuild());
+	}
+
+	@Test
+	void kotlinDslGradleBuild(@TempDir Path dir) throws IOException {
+		createFileFrom(new ClassPathResource("project/build/gradle/sample-build.gradle.kts"),
+				dir.resolve("build.gradle.kts"));
+		assertThat(forDirectory(dir)).kotlinDslGradleBuild().hasVersion("0.0.1-SNAPSHOT").hasSourceCompatibility("1.8");
+	}
+
+	@Test
+	void kotlinDslGradleBuildWithMissingBuildFile(@TempDir Path dir) {
+		assertThatExceptionOfType(AssertionError.class)
+			.isThrownBy(() -> assertThat(forDirectory(dir)).kotlinDslGradleBuild());
 	}
 
 	private AssertProvider<ModuleAssert> forDirectory(Path projectDirectory) {

--- a/initializr-generator-test/src/test/resources/project/build/gradle/sample-build.gradle.kts
+++ b/initializr-generator-test/src/test/resources/project/build/gradle/sample-build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+	id('com.example') version '1.0.0.RELEASE'
+	id('java')
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '1.8'
+
+repositories {
+	mavenCentral()
+}
+
+ext {
+	set('acmeVersion', "Brussels.SR2")
+}
+
+dependencies {
+	implementation 'com.example.acme:library'
+	testImplementation 'com.example.acme:library-test'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "com.example.acme:library-bom:${acmeVersion}"
+	}
+}
+

--- a/initializr-generator-test/src/test/resources/project/build/gradle/sample-settings.gradle.kts
+++ b/initializr-generator-test/src/test/resources/project/build/gradle/sample-settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = 'demo'


### PR DESCRIPTION
This PR resolves #1348  in which a build assert support for Kotlin DSL has been added.


