### PR TITLE
Upgrade to Maven Resolver 1.9.7 and Maven Resolver Provider 3.9.1

### DIFF
--- a/initializr-parent/pom.xml
+++ b/initializr-parent/pom.xml
@@ -17,8 +17,8 @@
 		<java.version>17</java.version>
 		<commons-compress.version>1.23.0</commons-compress.version>
 		<commons-text.version>1.10.0</commons-text.version>
-		<maven-resolver.version>1.7.3</maven-resolver.version>
-		<maven-resolver-provider.version>3.8.7</maven-resolver-provider.version>
+		<maven-resolver.version>1.9.7</maven-resolver.version>
+		<maven-resolver-provider.version>3.9.1</maven-resolver-provider.version>
 		<spring-boot.version>3.1.0</spring-boot.version>
 		<spring-cloud-contract.version>4.0.2</spring-cloud-contract.version>
 	</properties>

--- a/initializr-version-resolver/src/main/java/io/spring/initializr/versionresolver/MavenResolverDependencyManagementVersionResolver.java
+++ b/initializr-version-resolver/src/main/java/io/spring/initializr/versionresolver/MavenResolverDependencyManagementVersionResolver.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
@@ -81,6 +82,15 @@ class MavenResolverDependencyManagementVersionResolver implements DependencyMana
 		LocalRepository localRepository = new LocalRepository(cacheLocation.toFile());
 		this.repositorySystem = serviceLocator.getService(RepositorySystem.class);
 		session.setLocalRepositoryManager(this.repositorySystem.newLocalRepositoryManager(session, localRepository));
+		final Properties systemProperties = new Properties();
+
+		Properties sysProp = System.getProperties();
+		synchronized (sysProp) {
+			systemProperties.putAll(sysProp);
+		}
+
+		session.setSystemProperties(systemProperties);
+		session.setConfigProperties(systemProperties);
 		session.setReadOnly();
 		this.repositorySystemSession = session;
 	}


### PR DESCRIPTION
This PR closes issues #1399 and #1400.

Maven resolver provider 3.9.1 has dependency maven resolver 1.9.7. Thus, this PR may close both the issues.