### PR TITLE
Wrong Java version in Kotlin DSL with Java 20+

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriter.java
@@ -100,7 +100,7 @@ public class KotlinDslGradleBuildWriter extends GradleBuildWriter {
 			if (generation >= 1 && generation <= 10) {
 				sb.append("VERSION_1_").append(generation);
 			}
-			else if (generation <= 17) {
+			else if (generation <= 24) {
 				sb.append("VERSION_").append(generation);
 			}
 			else {

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriterTests.java
@@ -57,7 +57,7 @@ class KotlinDslGradleBuildWriterTests extends GradleBuildWriterTests {
 
 	@ParameterizedTest
 	@MethodSource("sourceCompatibilityParameters")
-	void gradleBuildWithSourceCompatibility15(String sourceCompatibility, String javaVersionConstant) {
+	void gradleBuildWithSourceCompatibilities(String sourceCompatibility, String javaVersionConstant) {
 		GradleBuild build = new GradleBuild();
 		build.settings().sourceCompatibility(sourceCompatibility);
 		assertThat(write(build)).contains("""
@@ -82,7 +82,9 @@ class KotlinDslGradleBuildWriterTests extends GradleBuildWriterTests {
 				Arguments.arguments("15", "JavaVersion.VERSION_15"),
 				Arguments.arguments("16", "JavaVersion.VERSION_16"),
 				Arguments.arguments("17", "JavaVersion.VERSION_17"),
-				Arguments.arguments("18", "JavaVersion.VERSION_HIGHER"));
+				Arguments.arguments("18", "JavaVersion.VERSION_18"),
+				Arguments.arguments("24", "JavaVersion.VERSION_24"),
+				Arguments.arguments("25", "JavaVersion.VERSION_HIGHER"));
 	}
 
 	@Test


### PR DESCRIPTION
This PR resolves https://github.com/spring-io/initializr/issues/1442

After generating a project from the https://start.spring.io/ website with the following settings:
- Java 20
- Gradle Kotlin
  
After execute command: ./gradle build I receive an error with the error message "ERROR_NAME" because the version in Gradle is marked as VERSION_HIGHER. A quick solution is to change the version to VERSION_20.

