### PR TITLE
Web endpoints should only accept GET or POST or both as appropriate

### DIFF
--- a/initializr-web/src/main/java/io/spring/initializr/web/controller/CommandLineMetadataController.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/controller/CommandLineMetadataController.java
@@ -29,8 +29,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -50,7 +50,7 @@ public class CommandLineMetadataController extends AbstractMetadataController {
 		this.commandLineHelpGenerator = new CommandLineHelpGenerator(templateRenderer);
 	}
 
-	@RequestMapping(path = "/", produces = "text/plain")
+	@GetMapping(path = "/", produces = "text/plain")
 	public ResponseEntity<String> serviceCapabilitiesText(
 			@RequestHeader(value = HttpHeaders.USER_AGENT, required = false) String userAgent) throws IOException {
 		String appUrl = generateAppUrl();

--- a/initializr-web/src/main/java/io/spring/initializr/web/controller/ProjectGenerationController.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/controller/ProjectGenerationController.java
@@ -56,6 +56,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -107,21 +108,21 @@ public abstract class ProjectGenerationController<R extends ProjectRequest> {
 		response.sendError(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
 	}
 
-	@RequestMapping(path = { "/pom", "/pom.xml" })
+	@RequestMapping(path = { "/pom", "/pom.xml" }, method = { RequestMethod.GET, RequestMethod.POST })
 	public ResponseEntity<byte[]> pom(R request) {
 		request.setType("maven-build");
 		byte[] mavenPom = this.projectGenerationInvoker.invokeBuildGeneration(request);
 		return createResponseEntity(mavenPom, "application/octet-stream", "pom.xml");
 	}
 
-	@RequestMapping(path = { "/build", "/build.gradle" })
+	@RequestMapping(path = { "/build", "/build.gradle" }, method = { RequestMethod.GET, RequestMethod.POST })
 	public ResponseEntity<byte[]> gradle(R request) {
 		request.setType("gradle-build");
 		byte[] gradleBuild = this.projectGenerationInvoker.invokeBuildGeneration(request);
 		return createResponseEntity(gradleBuild, "application/octet-stream", "build.gradle");
 	}
 
-	@RequestMapping("/starter.zip")
+	@RequestMapping(path = "/starter.zip", method = { RequestMethod.GET, RequestMethod.POST })
 	public ResponseEntity<byte[]> springZip(R request) throws IOException {
 		ProjectGenerationResult result = this.projectGenerationInvoker.invokeProjectStructureGeneration(request);
 		Path archive = createArchive(result, "zip", ZipArchiveOutputStream::new, ZipArchiveEntry::new,
@@ -129,7 +130,8 @@ public abstract class ProjectGenerationController<R extends ProjectRequest> {
 		return upload(archive, result.getRootDirectory(), generateFileName(request, "zip"), "application/zip");
 	}
 
-	@RequestMapping(path = "/starter.tgz", produces = "application/x-compress")
+	@RequestMapping(path = "/starter.tgz", method = { RequestMethod.GET, RequestMethod.POST },
+			produces = "application/x-compress")
 	public ResponseEntity<byte[]> springTgz(R request) throws IOException {
 		ProjectGenerationResult result = this.projectGenerationInvoker.invokeProjectStructureGeneration(request);
 		Path archive = createArchive(result, "tar.gz", this::createTarArchiveOutputStream, TarArchiveEntry::new,

--- a/initializr-web/src/main/java/io/spring/initializr/web/controller/ProjectMetadataController.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/controller/ProjectMetadataController.java
@@ -40,7 +40,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -65,38 +65,38 @@ public class ProjectMetadataController extends AbstractMetadataController {
 		this.dependencyMetadataProvider = dependencyMetadataProvider;
 	}
 
-	@RequestMapping(path = "/metadata/config", produces = "application/json")
+	@GetMapping(path = "/metadata/config", produces = "application/json")
 	public InitializrMetadata config() {
 		return this.metadataProvider.get();
 	}
 
-	@RequestMapping(path = { "/", "/metadata/client" }, produces = "application/hal+json")
+	@GetMapping(path = { "/", "/metadata/client" }, produces = "application/hal+json")
 	public ResponseEntity<String> serviceCapabilitiesHal() {
 		return serviceCapabilitiesFor(InitializrMetadataVersion.V2_1, HAL_JSON_CONTENT_TYPE);
 	}
 
-	@RequestMapping(path = { "/", "/metadata/client" }, produces = { "application/vnd.initializr.v2.2+json" })
+	@GetMapping(path = { "/", "/metadata/client" }, produces = { "application/vnd.initializr.v2.2+json" })
 	public ResponseEntity<String> serviceCapabilitiesV22() {
 		return serviceCapabilitiesFor(InitializrMetadataVersion.V2_2);
 	}
 
-	@RequestMapping(path = { "/", "/metadata/client" },
+	@GetMapping(path = { "/", "/metadata/client" },
 			produces = { "application/vnd.initializr.v2.1+json", "application/json" })
 	public ResponseEntity<String> serviceCapabilitiesV21() {
 		return serviceCapabilitiesFor(InitializrMetadataVersion.V2_1);
 	}
 
-	@RequestMapping(path = { "/", "/metadata/client" }, produces = "application/vnd.initializr.v2+json")
+	@GetMapping(path = { "/", "/metadata/client" }, produces = "application/vnd.initializr.v2+json")
 	public ResponseEntity<String> serviceCapabilitiesV2() {
 		return serviceCapabilitiesFor(InitializrMetadataVersion.V2);
 	}
 
-	@RequestMapping(path = "/dependencies", produces = "application/vnd.initializr.v2.2+json")
+	@GetMapping(path = "/dependencies", produces = "application/vnd.initializr.v2.2+json")
 	public ResponseEntity<String> dependenciesV22(@RequestParam(required = false) String bootVersion) {
 		return dependenciesFor(InitializrMetadataVersion.V2_2, bootVersion);
 	}
 
-	@RequestMapping(path = "/dependencies", produces = { "application/vnd.initializr.v2.1+json", "application/json" })
+	@GetMapping(path = "/dependencies", produces = { "application/vnd.initializr.v2.1+json", "application/json" })
 	public ResponseEntity<String> dependenciesV21(@RequestParam(required = false) String bootVersion) {
 		return dependenciesFor(InitializrMetadataVersion.V2_1, bootVersion);
 	}

--- a/initializr-web/src/main/java/io/spring/initializr/web/controller/SpringCliDistributionController.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/controller/SpringCliDistributionController.java
@@ -19,7 +19,7 @@ package io.spring.initializr.web.controller;
 import io.spring.initializr.metadata.InitializrMetadataProvider;
 
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 
 /**
  * {@link Controller} that provides access to the Spring CLI.
@@ -35,13 +35,13 @@ public class SpringCliDistributionController {
 		this.metadataProvider = metadataProvider;
 	}
 
-	@RequestMapping(path = { "/spring", "/spring.zip" })
+	@GetMapping(path = { "/spring", "/spring.zip" })
 	public String spring() {
 		String url = this.metadataProvider.get().createCliDistributionURl("zip");
 		return "redirect:" + url;
 	}
 
-	@RequestMapping(path = { "/spring.tar.gz", "spring.tgz" })
+	@GetMapping(path = { "/spring.tar.gz", "spring.tgz" })
 	public String springTgz() {
 		String url = this.metadataProvider.get().createCliDistributionURl("tar.gz");
 		return "redirect:" + url;


### PR DESCRIPTION
All the endpoints in initializr use `@RequestMapping` with no explicit `RequestMethod`, probably for historical reasons (`@GetMapping` and friends didn't exist when we started this project). It would be more expressive to show which methods are expected to be used, and I doubt anyone actually relies on being able to PATCH, PUT or POST these endpoints. They might get a surprise if they tried to DELETE as well.

Fixes #1453