### PR TITLE
Add optional 'command' to Docker compose service

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/container/docker/compose/ComposeFileWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/container/docker/compose/ComposeFileWriter.java
@@ -22,11 +22,14 @@ import java.util.Set;
 
 import io.spring.initializr.generator.io.IndentingWriter;
 
+import org.springframework.util.StringUtils;
+
 /**
  * A {@link ComposeFile} writer for {@code compose.yaml}.
  *
  * @author Stephane Nicoll
  * @author Moritz Halbritter
+ * @author Chris Bono
  */
 public class ComposeFileWriter {
 
@@ -51,6 +54,7 @@ public class ComposeFileWriter {
 				writer.println("image: '%s:%s'".formatted(service.getImage(), service.getImageTag()));
 				writerServiceEnvironment(writer, service.getEnvironment());
 				writerServicePorts(writer, service.getPorts());
+				writeServiceComamnd(writer, service.getCommand());
 			});
 		});
 	}
@@ -77,6 +81,13 @@ public class ComposeFileWriter {
 				writer.println("- '%d'".formatted(port));
 			}
 		});
+	}
+
+	private void writeServiceComamnd(IndentingWriter writer, String command) {
+		if (!StringUtils.hasText(command)) {
+			return;
+		}
+		writer.println("command: '%s'".formatted(command));
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/container/docker/compose/ComposeService.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/container/docker/compose/ComposeService.java
@@ -29,6 +29,7 @@ import java.util.TreeSet;
  *
  * @author Moritz Halbritter
  * @author Stephane Nicoll
+ * @author Chris Bono
  */
 public final class ComposeService {
 
@@ -44,6 +45,8 @@ public final class ComposeService {
 
 	private final Set<Integer> ports;
 
+	private final String command;
+
 	private ComposeService(Builder builder) {
 		this.name = builder.name;
 		this.image = builder.image;
@@ -51,6 +54,7 @@ public final class ComposeService {
 		this.imageWebsite = builder.imageWebsite;
 		this.environment = Collections.unmodifiableMap(new TreeMap<>(builder.environment));
 		this.ports = Collections.unmodifiableSet(new TreeSet<>(builder.ports));
+		this.command = builder.command;
 	}
 
 	public String getName() {
@@ -77,6 +81,10 @@ public final class ComposeService {
 		return this.ports;
 	}
 
+	public String getCommand() {
+		return this.command;
+	}
+
 	/**
 	 * Builder for {@link ComposeService}.
 	 */
@@ -93,6 +101,8 @@ public final class ComposeService {
 		private final Map<String, String> environment = new TreeMap<>();
 
 		private final Set<Integer> ports = new TreeSet<>();
+
+		private String command;
 
 		protected Builder(String name) {
 			this.name = name;
@@ -136,6 +146,11 @@ public final class ComposeService {
 
 		public Builder ports(int... ports) {
 			return ports(Arrays.stream(ports).boxed().toList());
+		}
+
+		public Builder command(String command) {
+			this.command = command;
+			return this;
 		}
 
 		/**

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/container/docker/compose/ComposeFileWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/container/docker/compose/ComposeFileWriterTests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Moritz Halbritter
  * @author Stephane Nicoll
+ * @author Chris Bono
  */
 class ComposeFileWriterTests {
 
@@ -57,7 +58,8 @@ class ComposeFileWriterTests {
 						.imageWebsite("https://www.docker.elastic.co/r/elasticsearch")
 						.environment("ELASTIC_PASSWORD", "secret")
 						.environment("discovery.type", "single-node")
-						.ports(9200, 9300));
+						.ports(9200, 9300)
+						.command("bin/run thing"));
 		assertThat(write(file)).isEqualToIgnoringNewLines("""
 				services:
 					elasticsearch:
@@ -68,6 +70,7 @@ class ComposeFileWriterTests {
 						ports:
 							- '9200'
 							- '9300'
+						command: 'bin/run thing'
 				""");
 	}
 

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/container/docker/compose/ComposeServiceContainerTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/container/docker/compose/ComposeServiceContainerTests.java
@@ -125,6 +125,7 @@ class ComposeServiceContainerTests {
 			service.imageWebsite("https://example.com/my-image");
 			service.environment("param", "value");
 			service.ports(8080);
+			service.command("run");
 		});
 		assertThat(container.values()).singleElement().satisfies((service) -> {
 			assertThat(service.getName()).isEqualTo("test");
@@ -133,6 +134,7 @@ class ComposeServiceContainerTests {
 			assertThat(service.getImageWebsite()).isEqualTo("https://example.com/my-image");
 			assertThat(service.getEnvironment()).containsOnly(entry("param", "value"));
 			assertThat(service.getPorts()).containsOnly(8080);
+			assertThat(service.getCommand()).isEqualTo("run");
 		});
 	}
 
@@ -145,6 +147,7 @@ class ComposeServiceContainerTests {
 			service.imageWebsite("https://example.com/my-image");
 			service.environment("param", "value");
 			service.ports(7070);
+			service.command("run");
 		});
 		container.add("test", (service) -> {
 			service.image("my-image");
@@ -152,6 +155,7 @@ class ComposeServiceContainerTests {
 			service.imageWebsite("https://example.com/my-image");
 			service.environment("param", "value2");
 			service.ports(8080);
+			service.command("run2");
 		});
 		assertThat(container.values()).singleElement().satisfies((service) -> {
 			assertThat(service.getName()).isEqualTo("test");
@@ -160,6 +164,7 @@ class ComposeServiceContainerTests {
 			assertThat(service.getImageWebsite()).isEqualTo("https://example.com/my-image");
 			assertThat(service.getEnvironment()).containsOnly(entry("param", "value2"));
 			assertThat(service.getPorts()).containsOnly(7070, 8080);
+			assertThat(service.getCommand()).isEqualTo("run2");
 		});
 	}
 


### PR DESCRIPTION
Allows specifying a `command` on the testcontainer. Required by Pulsar as their official image requires a flag/command to start it in standalone mode. 