### PR TITLE
Add support for labels in ComposeService

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/container/docker/compose/ComposeFileWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/container/docker/compose/ComposeFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Stephane Nicoll
  * @author Moritz Halbritter
+ * @author Eddú Meléndez
  */
 public class ComposeFileWriter {
 
@@ -52,6 +53,7 @@ public class ComposeFileWriter {
 			writer.indented(() -> {
 				writer.println("image: '%s:%s'".formatted(service.getImage(), service.getImageTag()));
 				writerServiceEnvironment(writer, service.getEnvironment());
+				writerServiceLabels(writer, service.getLabels());
 				writerServicePorts(writer, service.getPorts());
 				writeServiceCommand(writer, service.getCommand());
 			});
@@ -87,6 +89,18 @@ public class ComposeFileWriter {
 			return;
 		}
 		writer.println("command: '%s'".formatted(command));
+	}
+
+	private void writerServiceLabels(IndentingWriter writer, Map<String, String> labels) {
+		if (labels.isEmpty()) {
+			return;
+		}
+		writer.println("labels:");
+		writer.indented(() -> {
+			for (Map.Entry<String, String> env : labels.entrySet()) {
+				writer.println("- \"%s=%s\"".formatted(env.getKey(), env.getValue()));
+			}
+		});
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/container/docker/compose/ComposeFileWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/container/docker/compose/ComposeFileWriter.java
@@ -97,8 +97,8 @@ public class ComposeFileWriter {
 		}
 		writer.println("labels:");
 		writer.indented(() -> {
-			for (Map.Entry<String, String> env : labels.entrySet()) {
-				writer.println("- \"%s=%s\"".formatted(env.getKey(), env.getValue()));
+			for (Map.Entry<String, String> label : labels.entrySet()) {
+				writer.println("- \"%s=%s\"".formatted(label.getKey(), label.getValue()));
 			}
 		});
 	}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/container/docker/compose/ComposeService.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/container/docker/compose/ComposeService.java
@@ -47,7 +47,7 @@ public final class ComposeService {
 
 	private final String command;
 
-	private final Map<String, String> label;
+	private final Map<String, String> labels;
 
 	private ComposeService(Builder builder) {
 		this.name = builder.name;
@@ -57,7 +57,7 @@ public final class ComposeService {
 		this.environment = Collections.unmodifiableMap(new TreeMap<>(builder.environment));
 		this.ports = Collections.unmodifiableSet(new TreeSet<>(builder.ports));
 		this.command = builder.command;
-		this.label = Collections.unmodifiableMap(new TreeMap<>(builder.label));
+		this.labels = Collections.unmodifiableMap(new TreeMap<>(builder.labels));
 	}
 
 	public String getName() {
@@ -88,8 +88,8 @@ public final class ComposeService {
 		return this.command;
 	}
 
-	public Map<String, String> getLabel() {
-		return this.label;
+	public Map<String, String> getLabels() {
+		return this.labels;
 	}
 
 	/**
@@ -111,7 +111,7 @@ public final class ComposeService {
 
 		private String command;
 
-		private final Map<String, String> label = new TreeMap<>();
+		private final Map<String, String> labels = new TreeMap<>();
 
 		protected Builder(String name) {
 			this.name = name;
@@ -163,12 +163,12 @@ public final class ComposeService {
 		}
 
 		public Builder label(String key, String value) {
-			this.label.put(key, value);
+			this.labels.put(key, value);
 			return this;
 		}
 
 		public Builder label(Map<String, String> label) {
-			this.label.putAll(label);
+			this.labels.putAll(label);
 			return this;
 		}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/container/docker/compose/ComposeService.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/container/docker/compose/ComposeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import java.util.TreeSet;
  *
  * @author Moritz Halbritter
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  */
 public final class ComposeService {
 
@@ -46,6 +47,8 @@ public final class ComposeService {
 
 	private final String command;
 
+	private final Map<String, String> label;
+
 	private ComposeService(Builder builder) {
 		this.name = builder.name;
 		this.image = builder.image;
@@ -54,6 +57,7 @@ public final class ComposeService {
 		this.environment = Collections.unmodifiableMap(new TreeMap<>(builder.environment));
 		this.ports = Collections.unmodifiableSet(new TreeSet<>(builder.ports));
 		this.command = builder.command;
+		this.label = Collections.unmodifiableMap(new TreeMap<>(builder.label));
 	}
 
 	public String getName() {
@@ -84,6 +88,10 @@ public final class ComposeService {
 		return this.command;
 	}
 
+	public Map<String, String> getLabel() {
+		return this.label;
+	}
+
 	/**
 	 * Builder for {@link ComposeService}.
 	 */
@@ -102,6 +110,8 @@ public final class ComposeService {
 		private final Set<Integer> ports = new TreeSet<>();
 
 		private String command;
+
+		private final Map<String, String> label = new TreeMap<>();
 
 		protected Builder(String name) {
 			this.name = name;
@@ -149,6 +159,16 @@ public final class ComposeService {
 
 		public Builder command(String command) {
 			this.command = command;
+			return this;
+		}
+
+		public Builder label(String key, String value) {
+			this.label.put(key, value);
+			return this;
+		}
+
+		public Builder label(Map<String, String> label) {
+			this.label.putAll(label);
 			return this;
 		}
 

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/container/docker/compose/ComposeFileWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/container/docker/compose/ComposeFileWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Moritz Halbritter
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  */
 class ComposeFileWriterTests {
 
@@ -58,7 +59,8 @@ class ComposeFileWriterTests {
 						.environment("ELASTIC_PASSWORD", "secret")
 						.environment("discovery.type", "single-node")
 						.ports(9200, 9300)
-						.command("bin/run thing"));
+						.command("bin/run thing")
+						.label("foo", "bar"));
 		assertThat(write(file)).isEqualToIgnoringNewLines("""
 				services:
 					elasticsearch:
@@ -66,6 +68,8 @@ class ComposeFileWriterTests {
 						environment:
 							- 'ELASTIC_PASSWORD=secret'
 							- 'discovery.type=single-node'
+						labels:
+							- "foo=bar"
 						ports:
 							- '9200'
 							- '9300'

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/container/docker/compose/ComposeServiceContainerTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/container/docker/compose/ComposeServiceContainerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 the original author or authors.
+ * Copyright 2012-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.entry;
  * Tests for {@link ComposeServiceContainer}.
  *
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  */
 class ComposeServiceContainerTests {
 
@@ -126,6 +127,7 @@ class ComposeServiceContainerTests {
 			service.environment("param", "value");
 			service.ports(8080);
 			service.command("run");
+			service.label("foo", "bar");
 		});
 		assertThat(container.values()).singleElement().satisfies((service) -> {
 			assertThat(service.getName()).isEqualTo("test");
@@ -135,6 +137,7 @@ class ComposeServiceContainerTests {
 			assertThat(service.getEnvironment()).containsOnly(entry("param", "value"));
 			assertThat(service.getPorts()).containsOnly(8080);
 			assertThat(service.getCommand()).isEqualTo("run");
+			assertThat(service.getLabel()).containsOnly(entry("foo", "bar"));
 		});
 	}
 
@@ -182,6 +185,25 @@ class ComposeServiceContainerTests {
 		container.add("test", (service) -> service.image("my-image"));
 		assertThat(container.remove("another")).isFalse();
 		assertThat(container.isEmpty()).isFalse();
+	}
+
+	@Test
+	void labelKeysAreSorted() {
+		ComposeServiceContainer container = new ComposeServiceContainer();
+		container.add("test", (service) -> service.imageAndTag("my-image").label("z", "zz"));
+		container.add("test", (service) -> service.label("a", "aa"));
+		assertThat(container.values()).singleElement()
+			.satisfies((service) -> assertThat(service.getLabel()).containsExactly(entry("a", "aa"), entry("z", "zz")));
+	}
+
+	@Test
+	void labelIsMerged() {
+		ComposeServiceContainer container = new ComposeServiceContainer();
+		container.add("test", (service) -> service.imageAndTag("my-image").label(Map.of("a", "aa", "z", "zz")));
+		container.add("test", (service) -> service.label(Map.of("a", "aaa", "b", "bb")));
+		assertThat(container.values()).singleElement()
+			.satisfies((service) -> assertThat(service.getLabel()).containsExactly(entry("a", "aaa"), entry("b", "bb"),
+					entry("z", "zz")));
 	}
 
 }

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/container/docker/compose/ComposeServiceContainerTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/container/docker/compose/ComposeServiceContainerTests.java
@@ -137,7 +137,7 @@ class ComposeServiceContainerTests {
 			assertThat(service.getEnvironment()).containsOnly(entry("param", "value"));
 			assertThat(service.getPorts()).containsOnly(8080);
 			assertThat(service.getCommand()).isEqualTo("run");
-			assertThat(service.getLabel()).containsOnly(entry("foo", "bar"));
+			assertThat(service.getLabels()).containsOnly(entry("foo", "bar"));
 		});
 	}
 
@@ -193,7 +193,8 @@ class ComposeServiceContainerTests {
 		container.add("test", (service) -> service.imageAndTag("my-image").label("z", "zz"));
 		container.add("test", (service) -> service.label("a", "aa"));
 		assertThat(container.values()).singleElement()
-			.satisfies((service) -> assertThat(service.getLabel()).containsExactly(entry("a", "aa"), entry("z", "zz")));
+			.satisfies(
+					(service) -> assertThat(service.getLabels()).containsExactly(entry("a", "aa"), entry("z", "zz")));
 	}
 
 	@Test
@@ -202,7 +203,7 @@ class ComposeServiceContainerTests {
 		container.add("test", (service) -> service.imageAndTag("my-image").label(Map.of("a", "aa", "z", "zz")));
 		container.add("test", (service) -> service.label(Map.of("a", "aaa", "b", "bb")));
 		assertThat(container.values()).singleElement()
-			.satisfies((service) -> assertThat(service.getLabel()).containsExactly(entry("a", "aaa"), entry("b", "bb"),
+			.satisfies((service) -> assertThat(service.getLabels()).containsExactly(entry("a", "aaa"), entry("b", "bb"),
 					entry("z", "zz")));
 	}
 


### PR DESCRIPTION
`label` is required for custom images in docker compose using
`org.springframework.boot.service-connection`.