### PR TITLE
Add support for the inherited option on Maven plugins

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
@@ -61,6 +61,7 @@ import org.springframework.util.StringUtils;
  * @author Jafer Khan Shamshad
  * @author Joachim Pasquali
  * @author Niklas Herder
+ * @author Maurice Zeijen
  */
 public class MavenBuildWriter {
 
@@ -413,6 +414,9 @@ public class MavenBuildWriter {
 			writeSingleElement(writer, "groupId", plugin.getGroupId());
 			writeSingleElement(writer, "artifactId", plugin.getArtifactId());
 			writeSingleElement(writer, "version", plugin.getVersion());
+			if (!plugin.isInherited()) {
+				writeSingleElement(writer, "inherited", "false");
+			}
 			if (plugin.isExtensions()) {
 				writeSingleElement(writer, "extensions", "true");
 			}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenPlugin.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenPlugin.java
@@ -28,6 +28,7 @@ import java.util.function.Consumer;
  *
  * @author Andy Wilkinson
  * @author Olga Maciaszek-Sharma
+ * @author Maurice Zeijen
  */
 public class MavenPlugin {
 
@@ -38,6 +39,8 @@ public class MavenPlugin {
 	private final String version;
 
 	private final boolean extensions;
+
+	private final boolean inherited;
 
 	private final List<Execution> executions;
 
@@ -50,6 +53,7 @@ public class MavenPlugin {
 		this.artifactId = builder.artifactId;
 		this.version = builder.version;
 		this.extensions = builder.extensions;
+		this.inherited = builder.inherited;
 		this.executions = builder.executions.values().stream().map(ExecutionBuilder::build).toList();
 		this.dependencies = List.copyOf(builder.dependencies);
 		this.configuration = (builder.configurationBuilder == null) ? null : builder.configurationBuilder.build();
@@ -89,6 +93,14 @@ public class MavenPlugin {
 	}
 
 	/**
+	 * Return whether to propagate plugin configuration to child POMs.
+	 * @return {@code true} whether to propagate plugin configuration
+	 */
+	public boolean isInherited() {
+		return this.inherited;
+	}
+
+	/**
 	 * Return the {@linkplain Execution executions} of the plugin.
 	 * @return the executions
 	 */
@@ -125,6 +137,8 @@ public class MavenPlugin {
 
 		private boolean extensions;
 
+		private boolean inherited = true;
+
 		private final Map<String, ExecutionBuilder> executions = new LinkedHashMap<>();
 
 		private final List<Dependency> dependencies = new ArrayList<>();
@@ -154,6 +168,16 @@ public class MavenPlugin {
 		 */
 		public Builder extensions(boolean extensions) {
 			this.extensions = extensions;
+			return this;
+		}
+
+		/**
+		 * Set whether to propagate plugin configuration to child POMs.
+		 * @param inherited whether to propagate plugin configuration
+		 * @return this for method chaining
+		 */
+		public Builder inherited(boolean inherited) {
+			this.inherited = inherited;
 			return this;
 		}
 

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildTests.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Stephane Nicoll
  * @author Olga Maciaszek-Sharma
+ * @author Maurice Zeijen
  */
 class MavenBuildTests {
 
@@ -124,6 +125,22 @@ class MavenBuildTests {
 			assertThat(testPlugin.getExecutions().get(0).getId()).isEqualTo("first");
 			assertThat(testPlugin.getExecutions().get(0).getGoals()).containsExactly("run-this", "run-that");
 		});
+	}
+
+	@Test
+	void mavenPluginInheritedByDefault() {
+		MavenBuild build = new MavenBuild();
+		build.plugins().add("com.example", "test-plugin");
+		assertThat(build.plugins().values()).singleElement()
+			.satisfies((testPlugin) -> assertThat(testPlugin.isInherited()).isTrue());
+	}
+
+	@Test
+	void mavenPluginCanBeSetToNotBeInherited() {
+		MavenBuild build = new MavenBuild();
+		build.plugins().add("com.example", "test-plugin", (plugin) -> plugin.inherited(false));
+		assertThat(build.plugins().values()).singleElement()
+			.satisfies((testPlugin) -> assertThat(testPlugin.isInherited()).isFalse());
 	}
 
 	@Test

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriterTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Olga Maciaszek-Sharma
  * @author Jafer Khan Shamshad
  * @author Joachim Pasquali
+ * @author Maurice Zeijen
  */
 class MavenBuildWriterTests {
 
@@ -614,6 +615,7 @@ class MavenBuildWriterTests {
 			assertThat(plugin).textAtPath("groupId").isEqualTo("org.springframework.boot");
 			assertThat(plugin).textAtPath("artifactId").isEqualTo("spring-boot-maven-plugin");
 			assertThat(plugin).textAtPath("version").isNullOrEmpty();
+			assertThat(plugin).textAtPath("inherited").isNullOrEmpty();
 			assertThat(plugin).textAtPath("extensions").isNullOrEmpty();
 		});
 	}
@@ -684,6 +686,19 @@ class MavenBuildWriterTests {
 			assertThat(dependency).textAtPath("groupId").isEqualTo("org.jetbrains.kotlin");
 			assertThat(dependency).textAtPath("artifactId").isEqualTo("kotlin-maven-allopen");
 			assertThat(dependency).textAtPath("version").isEqualTo("${kotlin.version}");
+		});
+	}
+
+	@Test
+	void pomWithNonInheritedPlugin() {
+		MavenBuild build = new MavenBuild();
+		build.settings().coordinates("com.example.demo", "demo");
+		build.plugins().add("com.example.demo", "demo-plugin", (plugin) -> plugin.inherited(false));
+		generatePom(build, (pom) -> {
+			NodeAssert plugin = pom.nodeAtPath("/project/build/plugins/plugin");
+			assertThat(plugin).textAtPath("groupId").isEqualTo("com.example.demo");
+			assertThat(plugin).textAtPath("artifactId").isEqualTo("demo-plugin");
+			assertThat(plugin).textAtPath("inherited").isEqualTo("false");
 		});
 	}
 
@@ -1181,6 +1196,7 @@ class MavenBuildWriterTests {
 			assertThat(plugin).textAtPath("groupId").isEqualTo("org.springframework.boot");
 			assertThat(plugin).textAtPath("artifactId").isEqualTo("spring-boot-maven-plugin");
 			assertThat(plugin).textAtPath("version").isNullOrEmpty();
+			assertThat(plugin).textAtPath("inherited").isNullOrEmpty();
 			assertThat(plugin).textAtPath("extensions").isNullOrEmpty();
 		});
 	}


### PR DESCRIPTION
This allows writing the [inherited](https://maven.apache.org/guides/mini/guide-configuring-plugins.html#using-the-inherited-tag-in-build-plugins) element of a Maven plugin to the POM with the false value. When true, the inherited element is not written as it is the default value.

The inherited element in useful when generating multi-module projects, which we do at my company, as it allows to add Maven plugins of which the configuration should not be inherited by the child modules.