### PR TITLE
Add plugin management generation for Maven

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuild.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuild.java
@@ -27,6 +27,7 @@ import io.spring.initializr.generator.buildsystem.maven.MavenBuildSettings.Build
  * @author Andy Wilkinson
  * @author Stephane Nicoll
  * @author Niklas Herder
+ * @author Maurice Zeijen
  */
 public class MavenBuild extends Build {
 
@@ -35,6 +36,8 @@ public class MavenBuild extends Build {
 	private final MavenResourceContainer resources = new MavenResourceContainer();
 
 	private final MavenResourceContainer testResources = new MavenResourceContainer();
+
+	private final MavenPluginContainer pluginManagementPlugins = new MavenPluginContainer();
 
 	private final MavenPluginContainer plugins = new MavenPluginContainer();
 
@@ -97,6 +100,15 @@ public class MavenBuild extends Build {
 	 */
 	public MavenResourceContainer testResources() {
 		return this.testResources;
+	}
+
+	/**
+	 * Return the {@linkplain MavenPluginContainer plugin container} to use to configure
+	 * plugin management plugins.
+	 * @return the {@link MavenPluginContainer}
+	 */
+	public MavenPluginContainer pluginManagementPlugins() {
+		return this.pluginManagementPlugins;
 	}
 
 	/**

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
@@ -61,6 +61,7 @@ import org.springframework.util.StringUtils;
  * @author Jafer Khan Shamshad
  * @author Joachim Pasquali
  * @author Niklas Herder
+ * @author Maurice Zeijen
  */
 public class MavenBuildWriter {
 
@@ -358,7 +359,8 @@ public class MavenBuildWriter {
 		MavenBuildSettings settings = build.getSettings();
 		if (settings.getDefaultGoal() == null && settings.getFinalName() == null
 				&& settings.getSourceDirectory() == null && settings.getTestSourceDirectory() == null
-				&& build.resources().isEmpty() && build.testResources().isEmpty() && build.plugins().isEmpty()
+				&& build.resources().isEmpty() && build.testResources().isEmpty()
+				&& build.pluginManagementPlugins().isEmpty() && build.plugins().isEmpty()
 				&& build.extensions().isEmpty()) {
 			return;
 		}
@@ -369,6 +371,7 @@ public class MavenBuildWriter {
 			writeSingleElement(writer, "sourceDirectory", settings.getSourceDirectory());
 			writeSingleElement(writer, "testSourceDirectory", settings.getTestSourceDirectory());
 			writeResources(writer, build.resources(), build.testResources());
+			writePluginManagement(writer, build.pluginManagementPlugins());
 			writeCollectionElement(writer, "plugins", build.plugins().values(), this::writePlugin);
 			writeCollectionElement(writer, "extensions", build.extensions().values(), this::writeExtension);
 		});
@@ -406,6 +409,13 @@ public class MavenBuildWriter {
 
 	private void writeResourceExclude(IndentingWriter writer, String exclude) {
 		writeSingleElement(writer, "exclude", exclude);
+	}
+
+	private void writePluginManagement(IndentingWriter writer, MavenPluginContainer pluginManagementContainer) {
+		if (!pluginManagementContainer.isEmpty()) {
+			writeElement(writer, "pluginManagement", () -> writeCollectionElement(writer, "plugins",
+					pluginManagementContainer.values(), this::writePlugin));
+		}
 	}
 
 	private void writePlugin(IndentingWriter writer, MavenPlugin plugin) {
@@ -596,13 +606,15 @@ public class MavenBuildWriter {
 	private void writeProfileBuild(IndentingWriter writer, MavenProfile profile) {
 		MavenProfile.Settings settings = profile.getSettings();
 		if (settings.getDefaultGoal() == null && settings.getFinalName() == null && profile.resources().isEmpty()
-				&& profile.testResources().isEmpty() && profile.plugins().isEmpty()) {
+				&& profile.testResources().isEmpty() && profile.pluginManagementPlugins().isEmpty()
+				&& profile.plugins().isEmpty()) {
 			return;
 		}
 		writeElement(writer, "build", () -> {
 			writeSingleElement(writer, "defaultGoal", settings.getDefaultGoal());
 			writeSingleElement(writer, "finalName", settings.getFinalName());
 			writeResources(writer, profile.resources(), profile.testResources());
+			writePluginManagement(writer, profile.pluginManagementPlugins());
 			writeCollectionElement(writer, "plugins", profile.plugins().values(), this::writePlugin);
 		});
 	}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenProfile.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenProfile.java
@@ -27,6 +27,7 @@ import io.spring.initializr.generator.buildsystem.PropertyContainer;
  *
  * @author Daniel Andres Pelaez Lopez
  * @author Stephane Nicoll
+ * @author Maurice Zeijen
  */
 public class MavenProfile {
 
@@ -43,6 +44,8 @@ public class MavenProfile {
 	private final MavenResourceContainer resources = new MavenResourceContainer();
 
 	private final MavenResourceContainer testResources = new MavenResourceContainer();
+
+	private final MavenPluginContainer pluginManagementPlugins = new MavenPluginContainer();
 
 	private final MavenPluginContainer plugins = new MavenPluginContainer();
 
@@ -182,6 +185,15 @@ public class MavenProfile {
 	 */
 	public MavenResourceContainer testResources() {
 		return this.testResources;
+	}
+
+	/**
+	 * Return the {@linkplain MavenPluginContainer plugin container} to use to configure
+	 * plugin management plugins.
+	 * @return the {@link MavenPluginContainer}
+	 */
+	public MavenPluginContainer pluginManagementPlugins() {
+		return this.pluginManagementPlugins;
 	}
 
 	/**

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildTests.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Stephane Nicoll
  * @author Olga Maciaszek-Sharma
+ * @author Maurice Zeijen
  */
 class MavenBuildTests {
 
@@ -54,6 +55,17 @@ class MavenBuildTests {
 		assertThat(build.testResources().values()).singleElement().satisfies((resource) -> {
 			assertThat(resource.getDirectory()).isEqualTo("src/test/custom");
 			assertThat(resource.getExcludes()).containsExactly("**/*.gen");
+		});
+	}
+
+	@Test
+	void mavenPluginManagementCanBeConfigured() {
+		MavenBuild build = new MavenBuild();
+		build.pluginManagementPlugins().add("com.example", "test-plugin", (plugin) -> plugin.version("1.2.3"));
+		assertThat(build.pluginManagementPlugins().values()).singleElement().satisfies((testPlugin) -> {
+			assertThat(testPlugin.getGroupId()).isEqualTo("com.example");
+			assertThat(testPlugin.getArtifactId()).isEqualTo("test-plugin");
+			assertThat(testPlugin.getVersion()).isEqualTo("1.2.3");
 		});
 	}
 
@@ -182,6 +194,22 @@ class MavenBuildTests {
 		build.profiles().remove("test");
 		assertThat(build.profiles().ids()).isEmpty();
 		assertThat(build.profiles().values()).isEmpty();
+	}
+
+	@Test
+	void mavenPluginManagementInProfileCanBeConfigured() {
+		MavenBuild build = new MavenBuild();
+		build.profiles()
+			.id("test")
+			.pluginManagementPlugins()
+			.add("com.example", "test-plugin", (plugin) -> plugin.version("1.2.3"));
+		assertThat(build.profiles().values()).singleElement()
+			.satisfies((profile) -> assertThat(profile.pluginManagementPlugins().values()).singleElement()
+				.satisfies((testPlugin) -> {
+					assertThat(testPlugin.getGroupId()).isEqualTo("com.example");
+					assertThat(testPlugin.getArtifactId()).isEqualTo("test-plugin");
+					assertThat(testPlugin.getVersion()).isEqualTo("1.2.3");
+				}));
 	}
 
 }

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriterTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Olga Maciaszek-Sharma
  * @author Jafer Khan Shamshad
  * @author Joachim Pasquali
+ * @author Maurice Zeijen
  */
 class MavenBuildWriterTests {
 
@@ -601,6 +602,20 @@ class MavenBuildWriterTests {
 			assertThat(pom).textAtPath("/project/build/testResources/testResource/includes").isNullOrEmpty();
 			assertThat(pom).textAtPath("/project/build/testResources/testResource/excludes/exclude")
 				.isEqualTo("**/*.gen");
+		});
+	}
+
+	@Test
+	void pomWithPluginManagement() {
+		MavenBuild build = new MavenBuild();
+		build.settings().coordinates("com.example.demo", "demo");
+		build.pluginManagementPlugins()
+			.add("org.springframework.boot", "spring-boot-maven-plugin", (plugin) -> plugin.version("1.2.3"));
+		generatePom(build, (pom) -> {
+			NodeAssert plugin = pom.nodeAtPath("/project/build/pluginManagement/plugins/plugin");
+			assertThat(plugin).textAtPath("groupId").isEqualTo("org.springframework.boot");
+			assertThat(plugin).textAtPath("artifactId").isEqualTo("spring-boot-maven-plugin");
+			assertThat(plugin).textAtPath("version").isEqualTo("1.2.3");
 		});
 	}
 
@@ -1167,6 +1182,23 @@ class MavenBuildWriterTests {
 			assertThat(profile).textAtPath("build/testResources/testResource/filtering").isEqualTo("true");
 			assertThat(profile).textAtPath("build/testResources/testResource/includes").isNullOrEmpty();
 			assertThat(profile).textAtPath("build/testResources/testResource/excludes/exclude").isEqualTo("**/*.gen");
+		});
+	}
+
+	@Test
+	void pomWithProfilePluginManagement() {
+		MavenBuild build = new MavenBuild();
+		build.profiles()
+			.id("profile1")
+			.pluginManagementPlugins()
+			.add("org.springframework.boot", "spring-boot-maven-plugin", (plugin) -> plugin.version("1.2.3"));
+		generatePom(build, (pom) -> {
+			NodeAssert profile = pom.nodeAtPath("/project/profiles/profile");
+			assertThat(profile).textAtPath("id").isEqualTo("profile1");
+			NodeAssert plugin = profile.nodeAtPath("build/pluginManagement/plugins/plugin");
+			assertThat(plugin).textAtPath("groupId").isEqualTo("org.springframework.boot");
+			assertThat(plugin).textAtPath("artifactId").isEqualTo("spring-boot-maven-plugin");
+			assertThat(plugin).textAtPath("version").isEqualTo("1.2.3");
 		});
 	}
 


### PR DESCRIPTION
This allows writing plugin management plugin elements in the POM within the build and profiles elements.

Being able to add plugin management in the POM is useful when generating multi-module projects, which we do at my company. This allows to define the versions, and other configuration, of plugins within the root module, so that it is inherited by the child modules.