### PR TITLE
Make it possible to customize the SourceCodeWriters

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/groovy/GroovyProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/groovy/GroovyProjectGenerationConfiguration.java
@@ -59,22 +59,27 @@ public class GroovyProjectGenerationConfiguration {
 	}
 
 	@Bean
+	public GroovySourceCodeWriter groovySourceCodeWriter() {
+		return new GroovySourceCodeWriter(this.indentingWriterFactory);
+	}
+
+	@Bean
 	public MainSourceCodeProjectContributor<GroovyTypeDeclaration, GroovyCompilationUnit, GroovySourceCode> mainGroovySourceCodeProjectContributor(
 			ObjectProvider<MainApplicationTypeCustomizer<?>> mainApplicationTypeCustomizers,
 			ObjectProvider<MainCompilationUnitCustomizer<?, ?>> mainCompilationUnitCustomizers,
-			ObjectProvider<MainSourceCodeCustomizer<?, ?, ?>> mainSourceCodeCustomizers) {
-		return new MainSourceCodeProjectContributor<>(this.description, GroovySourceCode::new,
-				new GroovySourceCodeWriter(this.indentingWriterFactory), mainApplicationTypeCustomizers,
-				mainCompilationUnitCustomizers, mainSourceCodeCustomizers);
+			ObjectProvider<MainSourceCodeCustomizer<?, ?, ?>> mainSourceCodeCustomizers,
+			GroovySourceCodeWriter groovySourceCodeWriter) {
+		return new MainSourceCodeProjectContributor<>(this.description, GroovySourceCode::new, groovySourceCodeWriter,
+				mainApplicationTypeCustomizers, mainCompilationUnitCustomizers, mainSourceCodeCustomizers);
 	}
 
 	@Bean
 	public TestSourceCodeProjectContributor<GroovyTypeDeclaration, GroovyCompilationUnit, GroovySourceCode> testGroovySourceCodeProjectContributor(
 			ObjectProvider<TestApplicationTypeCustomizer<?>> testApplicationTypeCustomizers,
-			ObjectProvider<TestSourceCodeCustomizer<?, ?, ?>> testSourceCodeCustomizers) {
-		return new TestSourceCodeProjectContributor<>(this.description, GroovySourceCode::new,
-				new GroovySourceCodeWriter(this.indentingWriterFactory), testApplicationTypeCustomizers,
-				testSourceCodeCustomizers);
+			ObjectProvider<TestSourceCodeCustomizer<?, ?, ?>> testSourceCodeCustomizers,
+			GroovySourceCodeWriter groovySourceCodeWriter) {
+		return new TestSourceCodeProjectContributor<>(this.description, GroovySourceCode::new, groovySourceCodeWriter,
+				testApplicationTypeCustomizers, testSourceCodeCustomizers);
 	}
 
 }

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/java/JavaProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/java/JavaProjectGenerationConfiguration.java
@@ -59,22 +59,27 @@ public class JavaProjectGenerationConfiguration {
 	}
 
 	@Bean
+	public JavaSourceCodeWriter javaSourceCodeWriter() {
+		return new JavaSourceCodeWriter(this.indentingWriterFactory);
+	}
+
+	@Bean
 	public MainSourceCodeProjectContributor<JavaTypeDeclaration, JavaCompilationUnit, JavaSourceCode> mainJavaSourceCodeProjectContributor(
 			ObjectProvider<MainApplicationTypeCustomizer<?>> mainApplicationTypeCustomizers,
 			ObjectProvider<MainCompilationUnitCustomizer<?, ?>> mainCompilationUnitCustomizers,
-			ObjectProvider<MainSourceCodeCustomizer<?, ?, ?>> mainSourceCodeCustomizers) {
-		return new MainSourceCodeProjectContributor<>(this.description, JavaSourceCode::new,
-				new JavaSourceCodeWriter(this.indentingWriterFactory), mainApplicationTypeCustomizers,
-				mainCompilationUnitCustomizers, mainSourceCodeCustomizers);
+			ObjectProvider<MainSourceCodeCustomizer<?, ?, ?>> mainSourceCodeCustomizers,
+			JavaSourceCodeWriter javaSourceCodeWriter) {
+		return new MainSourceCodeProjectContributor<>(this.description, JavaSourceCode::new, javaSourceCodeWriter,
+				mainApplicationTypeCustomizers, mainCompilationUnitCustomizers, mainSourceCodeCustomizers);
 	}
 
 	@Bean
 	public TestSourceCodeProjectContributor<JavaTypeDeclaration, JavaCompilationUnit, JavaSourceCode> testJavaSourceCodeProjectContributor(
 			ObjectProvider<TestApplicationTypeCustomizer<?>> testApplicationTypeCustomizers,
-			ObjectProvider<TestSourceCodeCustomizer<?, ?, ?>> testSourceCodeCustomizers) {
-		return new TestSourceCodeProjectContributor<>(this.description, JavaSourceCode::new,
-				new JavaSourceCodeWriter(this.indentingWriterFactory), testApplicationTypeCustomizers,
-				testSourceCodeCustomizers);
+			ObjectProvider<TestSourceCodeCustomizer<?, ?, ?>> testSourceCodeCustomizers,
+			JavaSourceCodeWriter javaSourceCodeWriter) {
+		return new TestSourceCodeProjectContributor<>(this.description, JavaSourceCode::new, javaSourceCodeWriter,
+				testApplicationTypeCustomizers, testSourceCodeCustomizers);
 	}
 
 }

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinProjectGenerationConfiguration.java
@@ -66,21 +66,26 @@ public class KotlinProjectGenerationConfiguration {
 	}
 
 	@Bean
+	public KotlinSourceCodeWriter kotlinSourceCodeWriter() {
+		return new KotlinSourceCodeWriter(this.description.getLanguage(), this.indentingWriterFactory);
+	}
+
+	@Bean
 	public MainSourceCodeProjectContributor<KotlinTypeDeclaration, KotlinCompilationUnit, KotlinSourceCode> mainKotlinSourceCodeProjectContributor(
 			ObjectProvider<MainApplicationTypeCustomizer<?>> mainApplicationTypeCustomizers,
 			ObjectProvider<MainCompilationUnitCustomizer<?, ?>> mainCompilationUnitCustomizers,
-			ObjectProvider<MainSourceCodeCustomizer<?, ?, ?>> mainSourceCodeCustomizers) {
-		return new MainSourceCodeProjectContributor<>(this.description, KotlinSourceCode::new,
-				new KotlinSourceCodeWriter(this.description.getLanguage(), this.indentingWriterFactory),
+			ObjectProvider<MainSourceCodeCustomizer<?, ?, ?>> mainSourceCodeCustomizers,
+			KotlinSourceCodeWriter kotlinSourceCodeWriter) {
+		return new MainSourceCodeProjectContributor<>(this.description, KotlinSourceCode::new, kotlinSourceCodeWriter,
 				mainApplicationTypeCustomizers, mainCompilationUnitCustomizers, mainSourceCodeCustomizers);
 	}
 
 	@Bean
 	public TestSourceCodeProjectContributor<KotlinTypeDeclaration, KotlinCompilationUnit, KotlinSourceCode> testKotlinSourceCodeProjectContributor(
 			ObjectProvider<TestApplicationTypeCustomizer<?>> testApplicationTypeCustomizers,
-			ObjectProvider<TestSourceCodeCustomizer<?, ?, ?>> testSourceCodeCustomizers) {
-		return new TestSourceCodeProjectContributor<>(this.description, KotlinSourceCode::new,
-				new KotlinSourceCodeWriter(this.description.getLanguage(), this.indentingWriterFactory),
+			ObjectProvider<TestSourceCodeCustomizer<?, ?, ?>> testSourceCodeCustomizers,
+			KotlinSourceCodeWriter kotlinSourceCodeWriter) {
+		return new TestSourceCodeProjectContributor<>(this.description, KotlinSourceCode::new, kotlinSourceCodeWriter,
 				testApplicationTypeCustomizers, testSourceCodeCustomizers);
 	}
 


### PR DESCRIPTION
Currently it is difficult to customize how the source code is written, since the `KotlinSourceCodeWriter`, `JavaSourceCodeWriter` and `GroovySourceCodeWriter` is created inline, inside the `ProjectGenerationConfiguration`. For example:

```kotlin
@Bean
public MainSourceCodeProjectContributor<KotlinTypeDeclaration, KotlinCompilationUnit, KotlinSourceCode> mainKotlinSourceCodeProjectContributor(
		ObjectProvider<MainApplicationTypeCustomizer<?>> mainApplicationTypeCustomizers,
		ObjectProvider<MainCompilationUnitCustomizer<?, ?>> mainCompilationUnitCustomizers,
		ObjectProvider<MainSourceCodeCustomizer<?, ?, ?>> mainSourceCodeCustomizers) {
	return new MainSourceCodeProjectContributor<>(this.description, KotlinSourceCode::new,
			new KotlinSourceCodeWriter(this.description.getLanguage(), this.indentingWriterFactory),
			mainApplicationTypeCustomizers, mainCompilationUnitCustomizers, mainSourceCodeCustomizers);
}
```

The change in this PR is to simply change the SourceCodeWriters into beans. This has two benefits. 1) It is easy to override if you need something custom when writing the source code, and 2) we can reused the instance for Main and Test. 