### PR TITLE
add customFields to InitializrConfiguration

### DIFF
--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/InitializrConfiguration.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/InitializrConfiguration.java
@@ -59,6 +59,18 @@ public class InitializrConfiguration {
 		this.env.validate();
 	}
 
+	// Add customFields
+	private Map<String, Object> customFields = Collections.emptyMap();
+
+	// Getter and Setter
+	public Map<String, Object> getCustomFields() {
+		return this.customFields;
+	}
+
+	public void setCustomFields(Map<String, Object> customFields) {
+		this.customFields = customFields;
+	}
+
 	public void merge(InitializrConfiguration other) {
 		this.env.merge(other.env);
 	}

--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/InitializrConfiguration.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/InitializrConfiguration.java
@@ -59,10 +59,15 @@ public class InitializrConfiguration {
 		this.env.validate();
 	}
 
-	// Add customFields
+	/**
+	 * The customFields feature in Spring Initializr enables additional, adaptable metadata beyond the standard fields.
+	 * This allows organizations to set environment-specific values like default configurations, dependencies,
+	 * version control, or deployment options—aligning generated projects directly with their standards.
+	 * By using customFields, organizations can add new metadata flexibly without altering core configurations,
+	 * making Initializr more adaptable and valuable for various use cases.
+	 */
 	private Map<String, Object> customFields = Collections.emptyMap();
 
-	// Getter and Setter
 	public Map<String, Object> getCustomFields() {
 		return this.customFields;
 	}

--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/InitializrConfiguration.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/InitializrConfiguration.java
@@ -60,11 +60,13 @@ public class InitializrConfiguration {
 	}
 
 	/**
-	 * The customFields feature in Spring Initializr enables additional, adaptable metadata beyond the standard fields.
-	 * This allows organizations to set environment-specific values like default configurations, dependencies,
-	 * version control, or deployment options—aligning generated projects directly with their standards.
-	 * By using customFields, organizations can add new metadata flexibly without altering core configurations,
-	 * making Initializr more adaptable and valuable for various use cases.
+	 * The customFields feature in Spring Initializr enables additional, adaptable
+	 * metadata beyond the standard fields. This allows organizations to set
+	 * environment-specific values like default configurations, dependencies, version
+	 * control, or deployment options—aligning generated projects directly with their
+	 * standards. By using customFields, organizations can add new metadata flexibly
+	 * without altering core configurations, making Initializr more adaptable and valuable
+	 * for various use cases.
 	 */
 	private Map<String, Object> customFields = Collections.emptyMap();
 

--- a/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerCustomFieldsIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerCustomFieldsIntegrationTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.web.controller;
+
+import io.spring.initializr.metadata.InitializrMetadata;
+import io.spring.initializr.metadata.InitializrMetadataBuilder;
+import io.spring.initializr.metadata.InitializrMetadataProvider;
+import io.spring.initializr.web.AbstractFullStackInitializrIntegrationTests;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.HttpClientErrorException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link ProjectMetadataController} on a real http server.
+ *
+ * @author Stephane Nicoll
+ */
+@ActiveProfiles("test-custom-fields")
+class ProjectMetadataControllerCustomFieldsIntegrationTests extends AbstractFullStackInitializrIntegrationTests {
+
+    @Autowired
+    private InitializrMetadataProvider metadataProvider;
+
+    @Test
+    void initializeRemoteConfig() throws Exception {
+        InitializrMetadata localMetadata = this.metadataProvider.get();
+        InitializrMetadata metadata = InitializrMetadataBuilder.create()
+                .withInitializrMetadata(new UrlResource(createUrl("/metadata/config")))
+                .build();
+        // Basic assertions
+        assertThat(metadata.getDependencies().getContent()).hasSameSizeAs(localMetadata.getDependencies().getContent());
+        assertThat(metadata.getTypes().getContent()).hasSameSizeAs(localMetadata.getTypes().getContent());
+        assertThat(metadata.getBootVersions().getContent()).hasSameSizeAs(localMetadata.getBootVersions().getContent());
+        assertThat(metadata.getPackagings().getContent()).hasSameSizeAs(localMetadata.getPackagings().getContent());
+        assertThat(metadata.getJavaVersions().getContent()).hasSameSizeAs(localMetadata.getJavaVersions().getContent());
+        assertThat(metadata.getLanguages().getContent()).hasSameSizeAs(localMetadata.getLanguages().getContent());
+    }
+
+    @Test
+    void textPlainNotAccepted() {
+        try {
+            execute("/metadata/config", String.class, null, "text/plain");
+        }
+        catch (HttpClientErrorException ex) {
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE);
+        }
+    }
+
+    @Test
+    void validateJson() throws JSONException {
+        ResponseEntity<String> response = execute("/metadata/config", String.class, null, "application/json");
+        validateContentType(response, MediaType.APPLICATION_JSON);
+        JSONObject json = new JSONObject(response.getBody());
+        JSONObject expected = readJsonFrom("metadata/config/test-custom-fields.json");
+        JSONAssert.assertEquals(expected, json, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    void metadataClientEndpoint() {
+        ResponseEntity<String> response = execute("/metadata/client", String.class, null, "application/json");
+        validateDefaultMetadata(response);
+    }
+
+    @Test
+    void dependenciesNoAcceptHeaderWithNoBootVersion() throws JSONException {
+        validateDependenciesMetadata("*/*", DEFAULT_METADATA_MEDIA_TYPE);
+    }
+
+    @Test
+    void dependenciesV21WithNoBootVersion() throws JSONException {
+        validateDependenciesMetadata("application/vnd.initializr.v2.1+json", DEFAULT_METADATA_MEDIA_TYPE);
+    }
+
+    @Test
+    void dependenciesV22WithNoBootVersion() throws JSONException {
+        validateDependenciesMetadata("application/vnd.initializr.v2.2+json", CURRENT_METADATA_MEDIA_TYPE);
+    }
+
+    private void validateDependenciesMetadata(String acceptHeader, MediaType expectedMediaType) throws JSONException {
+        ResponseEntity<String> response = execute("/dependencies", String.class, null, acceptHeader);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG)).isNotNull();
+        validateContentType(response, expectedMediaType);
+        validateDependenciesOutput("2.4.4", response.getBody());
+    }
+
+    @Test
+    void filteredDependencies() throws JSONException {
+        ResponseEntity<String> response = execute("/dependencies?bootVersion=2.6.1", String.class, null,
+                "application/json");
+        assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG)).isNotNull();
+        validateContentType(response, DEFAULT_METADATA_MEDIA_TYPE);
+        validateDependenciesOutput("2.6.1", response.getBody());
+    }
+
+    protected void validateDependenciesOutput(String version, String actual) throws JSONException {
+        JSONObject expected = readJsonFrom("metadata/dependencies/test-dependencies-" + version + ".json");
+        JSONAssert.assertEquals(expected, new JSONObject(actual), JSONCompareMode.STRICT);
+    }
+
+}

--- a/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerCustomFieldsIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerCustomFieldsIntegrationTests.java
@@ -43,4 +43,5 @@ class ProjectMetadataControllerCustomFieldsIntegrationTests extends AbstractFull
 		JSONObject expected = readJsonFrom("metadata/config/test-custom-fields.json");
 		JSONAssert.assertEquals(expected, json, JSONCompareMode.STRICT);
 	}
+
 }

--- a/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerCustomFieldsIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerCustomFieldsIntegrationTests.java
@@ -45,83 +45,83 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("test-custom-fields")
 class ProjectMetadataControllerCustomFieldsIntegrationTests extends AbstractFullStackInitializrIntegrationTests {
 
-    @Autowired
-    private InitializrMetadataProvider metadataProvider;
+	@Autowired
+	private InitializrMetadataProvider metadataProvider;
 
-    @Test
-    void initializeRemoteConfig() throws Exception {
-        InitializrMetadata localMetadata = this.metadataProvider.get();
-        InitializrMetadata metadata = InitializrMetadataBuilder.create()
-                .withInitializrMetadata(new UrlResource(createUrl("/metadata/config")))
-                .build();
-        // Basic assertions
-        assertThat(metadata.getDependencies().getContent()).hasSameSizeAs(localMetadata.getDependencies().getContent());
-        assertThat(metadata.getTypes().getContent()).hasSameSizeAs(localMetadata.getTypes().getContent());
-        assertThat(metadata.getBootVersions().getContent()).hasSameSizeAs(localMetadata.getBootVersions().getContent());
-        assertThat(metadata.getPackagings().getContent()).hasSameSizeAs(localMetadata.getPackagings().getContent());
-        assertThat(metadata.getJavaVersions().getContent()).hasSameSizeAs(localMetadata.getJavaVersions().getContent());
-        assertThat(metadata.getLanguages().getContent()).hasSameSizeAs(localMetadata.getLanguages().getContent());
-    }
+	@Test
+	void initializeRemoteConfig() throws Exception {
+		InitializrMetadata localMetadata = this.metadataProvider.get();
+		InitializrMetadata metadata = InitializrMetadataBuilder.create()
+			.withInitializrMetadata(new UrlResource(createUrl("/metadata/config")))
+			.build();
+		// Basic assertions
+		assertThat(metadata.getDependencies().getContent()).hasSameSizeAs(localMetadata.getDependencies().getContent());
+		assertThat(metadata.getTypes().getContent()).hasSameSizeAs(localMetadata.getTypes().getContent());
+		assertThat(metadata.getBootVersions().getContent()).hasSameSizeAs(localMetadata.getBootVersions().getContent());
+		assertThat(metadata.getPackagings().getContent()).hasSameSizeAs(localMetadata.getPackagings().getContent());
+		assertThat(metadata.getJavaVersions().getContent()).hasSameSizeAs(localMetadata.getJavaVersions().getContent());
+		assertThat(metadata.getLanguages().getContent()).hasSameSizeAs(localMetadata.getLanguages().getContent());
+	}
 
-    @Test
-    void textPlainNotAccepted() {
-        try {
-            execute("/metadata/config", String.class, null, "text/plain");
-        }
-        catch (HttpClientErrorException ex) {
-            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE);
-        }
-    }
+	@Test
+	void textPlainNotAccepted() {
+		try {
+			execute("/metadata/config", String.class, null, "text/plain");
+		}
+		catch (HttpClientErrorException ex) {
+			assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE);
+		}
+	}
 
-    @Test
-    void validateJson() throws JSONException {
-        ResponseEntity<String> response = execute("/metadata/config", String.class, null, "application/json");
-        validateContentType(response, MediaType.APPLICATION_JSON);
-        JSONObject json = new JSONObject(response.getBody());
-        JSONObject expected = readJsonFrom("metadata/config/test-custom-fields.json");
-        JSONAssert.assertEquals(expected, json, JSONCompareMode.STRICT);
-    }
+	@Test
+	void validateJson() throws JSONException {
+		ResponseEntity<String> response = execute("/metadata/config", String.class, null, "application/json");
+		validateContentType(response, MediaType.APPLICATION_JSON);
+		JSONObject json = new JSONObject(response.getBody());
+		JSONObject expected = readJsonFrom("metadata/config/test-custom-fields.json");
+		JSONAssert.assertEquals(expected, json, JSONCompareMode.STRICT);
+	}
 
-    @Test
-    void metadataClientEndpoint() {
-        ResponseEntity<String> response = execute("/metadata/client", String.class, null, "application/json");
-        validateDefaultMetadata(response);
-    }
+	@Test
+	void metadataClientEndpoint() {
+		ResponseEntity<String> response = execute("/metadata/client", String.class, null, "application/json");
+		validateDefaultMetadata(response);
+	}
 
-    @Test
-    void dependenciesNoAcceptHeaderWithNoBootVersion() throws JSONException {
-        validateDependenciesMetadata("*/*", DEFAULT_METADATA_MEDIA_TYPE);
-    }
+	@Test
+	void dependenciesNoAcceptHeaderWithNoBootVersion() throws JSONException {
+		validateDependenciesMetadata("*/*", DEFAULT_METADATA_MEDIA_TYPE);
+	}
 
-    @Test
-    void dependenciesV21WithNoBootVersion() throws JSONException {
-        validateDependenciesMetadata("application/vnd.initializr.v2.1+json", DEFAULT_METADATA_MEDIA_TYPE);
-    }
+	@Test
+	void dependenciesV21WithNoBootVersion() throws JSONException {
+		validateDependenciesMetadata("application/vnd.initializr.v2.1+json", DEFAULT_METADATA_MEDIA_TYPE);
+	}
 
-    @Test
-    void dependenciesV22WithNoBootVersion() throws JSONException {
-        validateDependenciesMetadata("application/vnd.initializr.v2.2+json", CURRENT_METADATA_MEDIA_TYPE);
-    }
+	@Test
+	void dependenciesV22WithNoBootVersion() throws JSONException {
+		validateDependenciesMetadata("application/vnd.initializr.v2.2+json", CURRENT_METADATA_MEDIA_TYPE);
+	}
 
-    private void validateDependenciesMetadata(String acceptHeader, MediaType expectedMediaType) throws JSONException {
-        ResponseEntity<String> response = execute("/dependencies", String.class, null, acceptHeader);
-        assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG)).isNotNull();
-        validateContentType(response, expectedMediaType);
-        validateDependenciesOutput("2.4.4", response.getBody());
-    }
+	private void validateDependenciesMetadata(String acceptHeader, MediaType expectedMediaType) throws JSONException {
+		ResponseEntity<String> response = execute("/dependencies", String.class, null, acceptHeader);
+		assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG)).isNotNull();
+		validateContentType(response, expectedMediaType);
+		validateDependenciesOutput("2.4.4", response.getBody());
+	}
 
-    @Test
-    void filteredDependencies() throws JSONException {
-        ResponseEntity<String> response = execute("/dependencies?bootVersion=2.6.1", String.class, null,
-                "application/json");
-        assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG)).isNotNull();
-        validateContentType(response, DEFAULT_METADATA_MEDIA_TYPE);
-        validateDependenciesOutput("2.6.1", response.getBody());
-    }
+	@Test
+	void filteredDependencies() throws JSONException {
+		ResponseEntity<String> response = execute("/dependencies?bootVersion=2.6.1", String.class, null,
+				"application/json");
+		assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG)).isNotNull();
+		validateContentType(response, DEFAULT_METADATA_MEDIA_TYPE);
+		validateDependenciesOutput("2.6.1", response.getBody());
+	}
 
-    protected void validateDependenciesOutput(String version, String actual) throws JSONException {
-        JSONObject expected = readJsonFrom("metadata/dependencies/test-dependencies-" + version + ".json");
-        JSONAssert.assertEquals(expected, new JSONObject(actual), JSONCompareMode.STRICT);
-    }
+	protected void validateDependenciesOutput(String version, String actual) throws JSONException {
+		JSONObject expected = readJsonFrom("metadata/dependencies/test-dependencies-" + version + ".json");
+		JSONAssert.assertEquals(expected, new JSONObject(actual), JSONCompareMode.STRICT);
+	}
 
 }

--- a/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerCustomFieldsIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerCustomFieldsIntegrationTests.java
@@ -16,9 +16,6 @@
 
 package io.spring.initializr.web.controller;
 
-import io.spring.initializr.metadata.InitializrMetadata;
-import io.spring.initializr.metadata.InitializrMetadataBuilder;
-import io.spring.initializr.metadata.InitializrMetadataProvider;
 import io.spring.initializr.web.AbstractFullStackInitializrIntegrationTests;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -26,52 +23,17 @@ import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.UrlResource;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.client.HttpClientErrorException;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration tests for {@link ProjectMetadataController} on a real http server.
  *
- * @author Stephane Nicoll
+ * @author Joar Varpe
  */
 @ActiveProfiles("test-custom-fields")
 class ProjectMetadataControllerCustomFieldsIntegrationTests extends AbstractFullStackInitializrIntegrationTests {
-
-	@Autowired
-	private InitializrMetadataProvider metadataProvider;
-
-	@Test
-	void initializeRemoteConfig() throws Exception {
-		InitializrMetadata localMetadata = this.metadataProvider.get();
-		InitializrMetadata metadata = InitializrMetadataBuilder.create()
-			.withInitializrMetadata(new UrlResource(createUrl("/metadata/config")))
-			.build();
-		// Basic assertions
-		assertThat(metadata.getDependencies().getContent()).hasSameSizeAs(localMetadata.getDependencies().getContent());
-		assertThat(metadata.getTypes().getContent()).hasSameSizeAs(localMetadata.getTypes().getContent());
-		assertThat(metadata.getBootVersions().getContent()).hasSameSizeAs(localMetadata.getBootVersions().getContent());
-		assertThat(metadata.getPackagings().getContent()).hasSameSizeAs(localMetadata.getPackagings().getContent());
-		assertThat(metadata.getJavaVersions().getContent()).hasSameSizeAs(localMetadata.getJavaVersions().getContent());
-		assertThat(metadata.getLanguages().getContent()).hasSameSizeAs(localMetadata.getLanguages().getContent());
-	}
-
-	@Test
-	void textPlainNotAccepted() {
-		try {
-			execute("/metadata/config", String.class, null, "text/plain");
-		}
-		catch (HttpClientErrorException ex) {
-			assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE);
-		}
-	}
 
 	@Test
 	void validateJson() throws JSONException {
@@ -81,47 +43,4 @@ class ProjectMetadataControllerCustomFieldsIntegrationTests extends AbstractFull
 		JSONObject expected = readJsonFrom("metadata/config/test-custom-fields.json");
 		JSONAssert.assertEquals(expected, json, JSONCompareMode.STRICT);
 	}
-
-	@Test
-	void metadataClientEndpoint() {
-		ResponseEntity<String> response = execute("/metadata/client", String.class, null, "application/json");
-		validateDefaultMetadata(response);
-	}
-
-	@Test
-	void dependenciesNoAcceptHeaderWithNoBootVersion() throws JSONException {
-		validateDependenciesMetadata("*/*", DEFAULT_METADATA_MEDIA_TYPE);
-	}
-
-	@Test
-	void dependenciesV21WithNoBootVersion() throws JSONException {
-		validateDependenciesMetadata("application/vnd.initializr.v2.1+json", DEFAULT_METADATA_MEDIA_TYPE);
-	}
-
-	@Test
-	void dependenciesV22WithNoBootVersion() throws JSONException {
-		validateDependenciesMetadata("application/vnd.initializr.v2.2+json", CURRENT_METADATA_MEDIA_TYPE);
-	}
-
-	private void validateDependenciesMetadata(String acceptHeader, MediaType expectedMediaType) throws JSONException {
-		ResponseEntity<String> response = execute("/dependencies", String.class, null, acceptHeader);
-		assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG)).isNotNull();
-		validateContentType(response, expectedMediaType);
-		validateDependenciesOutput("2.4.4", response.getBody());
-	}
-
-	@Test
-	void filteredDependencies() throws JSONException {
-		ResponseEntity<String> response = execute("/dependencies?bootVersion=2.6.1", String.class, null,
-				"application/json");
-		assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG)).isNotNull();
-		validateContentType(response, DEFAULT_METADATA_MEDIA_TYPE);
-		validateDependenciesOutput("2.6.1", response.getBody());
-	}
-
-	protected void validateDependenciesOutput(String version, String actual) throws JSONException {
-		JSONObject expected = readJsonFrom("metadata/dependencies/test-dependencies-" + version + ".json");
-		JSONAssert.assertEquals(expected, new JSONObject(actual), JSONCompareMode.STRICT);
-	}
-
 }

--- a/initializr-web/src/test/resources/application-test-custom-fields.yml
+++ b/initializr-web/src/test/resources/application-test-custom-fields.yml
@@ -1,0 +1,173 @@
+info:
+  spring-boot:
+    version: 2.4.4
+
+initializr:
+  customFields:
+    exampleField1: "Example String Value"
+    exampleField2: 123
+    exampleField3: true
+    nestedField:
+      nestedKey1: "Nested value"
+      nestedKey2: 42
+  env:
+    boms:
+      my-api-bom:
+        groupId: org.acme
+        artifactId: my-api-bom
+        versionProperty: my-api.version
+        additionalBoms: ['my-api-dependencies-bom']
+        mappings:
+          - compatibilityRange: "[2.3.0.RELEASE,2.4.6)"
+            version: 1.0.0.RELEASE
+            repositories: my-api-repo-1
+          - compatibilityRange: "2.4.6"
+            version: 2.0.0.RELEASE
+            repositories: my-api-repo-2
+      my-api-dependencies-bom:
+        groupId: org.acme
+        artifactId: my-api-dependencies-bom
+        version: 1.0.0.RELEASE
+        repositories: my-api-repo-3
+    kotlin:
+      defaultVersion: 1.5
+      mappings:
+        - compatibilityRange: "[2.3.0.RELEASE,2.4.0-M1)"
+          version: 1.3.72
+        - compatibilityRange: "[2.4.0-M1,2.5.0-M1)"
+          version: 1.4.31
+    repositories:
+      my-api-repo-1:
+        name: repo1
+        url: https://example.com/repo1
+      my-api-repo-2:
+        name: repo2
+        url: https://example.com/repo2
+      my-api-repo-3:
+        name: repo3
+        url: https://example.com/repo3
+  dependencies:
+    - name: Core
+      content:
+        - name: Web
+          id: web
+          description: Web dependency description
+          facets:
+            - web
+          links:
+            - rel: guide
+              href: https://example.com/guide
+              description: Building a RESTful Web Service
+            - rel: reference
+              href: https://example.com/doc
+        - name: Security
+          id: security
+        - name: Data JPA
+          id: data-jpa
+          aliases:
+            - jpa
+    - name: Other
+      content:
+        - name: Foo
+          groupId: org.acme
+          artifactId: foo
+          version: 1.3.5
+          weight: 42
+          keywords:
+            - thefoo
+            - dafoo
+          links:
+            - rel: guide
+              href: https://example.com/guide1
+            - rel: reference
+              href: https://example.com/{bootVersion}/doc
+            - rel: guide
+              href: https://example.com/guide2
+              description: Some guide for foo
+        - name: Bar
+          id: org.acme:bar
+          version: 2.1.0
+        - name: Biz
+          groupId: org.acme
+          artifactId: biz
+          scope: runtime
+          version: 1.3.5
+          compatibilityRange: 2.6.0-SNAPSHOT
+        - name: Bur
+          id: org.acme:bur
+          version: 2.1.0
+          scope: test
+          compatibilityRange: "[2.4.4,2.5.0-SNAPSHOT)"
+        - name: My API
+          id : my-api
+          groupId: org.acme
+          artifactId: my-api
+          scope: provided
+          bom: my-api-bom
+  types:
+    - name: Maven POM
+      id: maven-build
+      tags:
+        build: maven
+        format: build
+      default: false
+      action: /pom.xml
+    - name: Maven Project
+      id: maven-project
+      tags:
+        build: maven
+        format: project
+      default: true
+      action: /starter.zip
+    - name: Gradle Config
+      id: gradle-build
+      tags:
+        build: gradle
+        format: build
+      default: false
+      action: /build.gradle
+    - name: Gradle Project
+      id: gradle-project
+      tags:
+        build: gradle
+        format: project
+      default: false
+      action: /starter.zip
+  packagings:
+    - name: Jar
+      id: jar
+      default: true
+    - name: War
+      id: war
+      default: false
+  javaVersions:
+    - id: 1.6
+      default: false
+    - id: 1.7
+      default: false
+    - id: 1.8
+      default: true
+  languages:
+    - name: Groovy
+      id: groovy
+      default: false
+    - name: Java
+      id: java
+      default: true
+    - name: Kotlin
+      id: kotlin
+      default: false
+  bootVersions:
+    - name : Latest SNAPSHOT
+      id: 2.5.0-SNAPSHOT
+      default: false
+    - name: 2.4.4
+      id: 2.4.4
+      default: true
+    - name: 2.3.10
+      id: 2.3.10.RELEASE
+      default: false
+
+server:
+  error:
+    include-message: always

--- a/initializr-web/src/test/resources/metadata/config/test-custom-fields.json
+++ b/initializr-web/src/test/resources/metadata/config/test-custom-fields.json
@@ -30,117 +30,125 @@
     "type": "SINGLE_SELECT"
   },
   "configuration": {
-    "customFields": {},
+    "customFields": {
+      "exampleField1": "Example String Value",
+      "exampleField2": 123,
+      "exampleField3": true,
+      "nestedField": {
+        "nestedKey1": "Nested value",
+        "nestedKey2": 42
+      }
+    },
     "env": {
-    "artifactRepository": "https://repo.spring.io/release/",
-    "fallbackApplicationName": "Application",
-    "forceSsl": false,
-    "gradle": {
-      "dependencyManagementPluginVersion": "1.0.0.RELEASE"
-    },
-    "kotlin": {
-      "defaultVersion": "1.5",
-      "mappings": [
-        {
-          "compatibilityRange": "[2.3.0.RELEASE,2.4.0-M1)",
-          "version": "1.3.72"
-        },
-        {
-          "compatibilityRange": "[2.4.0-M1,2.5.0-M1)",
-          "version": "1.4.31"
-        }
-      ]
-    },
-    "maven": {
-      "parent": {
-        "groupId": null,
-        "artifactId": null,
-        "version": null,
-        "relativePath": "",
-        "includeSpringBootBom": false
-      }
-    },
-    "platform": {
-      "compatibilityRange": null,
-      "v1FormatCompatibilityRange": null,
-      "v2FormatCompatibilityRange": null
-    },
-    "googleAnalyticsTrackingCode": null,
-    "invalidApplicationNames": [
-      "SpringApplication",
-      "SpringBootApplication"
-    ],
-    "invalidPackageNames": [
-      "org.springframework"
-    ],
-    "repositories": {
-      "my-api-repo-1": {
-        "name": "repo1",
-        "url": "https://example.com/repo1",
-        "releasesEnabled": true,
-        "snapshotsEnabled": false
+      "artifactRepository": "https://repo.spring.io/release/",
+      "fallbackApplicationName": "Application",
+      "forceSsl": false,
+      "gradle": {
+        "dependencyManagementPluginVersion": "1.0.0.RELEASE"
       },
-      "my-api-repo-2": {
-        "name": "repo2",
-        "url": "https://example.com/repo2",
-        "releasesEnabled": true,
-        "snapshotsEnabled": false
-      },
-      "my-api-repo-3": {
-        "name": "repo3",
-        "url": "https://example.com/repo3",
-        "releasesEnabled": true,
-        "snapshotsEnabled": false
-      },
-      "spring-milestones": {
-        "name": "Spring Milestones",
-        "url": "https://repo.spring.io/milestone",
-        "releasesEnabled": true,
-        "snapshotsEnabled": false
-      },
-      "spring-snapshots": {
-        "name": "Spring Snapshots",
-        "url": "https://repo.spring.io/snapshot",
-        "releasesEnabled": false,
-        "snapshotsEnabled": true
-      }
-    },
-    "boms": {
-      "my-api-bom": {
-        "groupId": "org.acme",
-        "artifactId": "my-api-bom",
-        "versionProperty": "my-api.version",
-        "additionalBoms": [
-          "my-api-dependencies-bom"
-        ],
+      "kotlin": {
+        "defaultVersion": "1.5",
         "mappings": [
           {
-            "compatibilityRange": "[2.3.0.RELEASE,2.4.6)",
-            "repositories": [
-              "my-api-repo-1"
-            ],
-            "version": "1.0.0.RELEASE"
+            "compatibilityRange": "[2.3.0.RELEASE,2.4.0-M1)",
+            "version": "1.3.72"
           },
           {
-            "compatibilityRange": "2.4.6",
-            "repositories": [
-              "my-api-repo-2"
-            ],
-            "version": "2.0.0.RELEASE"
+            "compatibilityRange": "[2.4.0-M1,2.5.0-M1)",
+            "version": "1.4.31"
           }
         ]
       },
-      "my-api-dependencies-bom": {
-        "groupId": "org.acme",
-        "repositories": [
-          "my-api-repo-3"
-        ],
-        "artifactId": "my-api-dependencies-bom",
-        "version": "1.0.0.RELEASE"
-      }
-    },
-    "springBootMetadataUrl": "https://api.spring.io/projects/spring-boot/releases"
-  }},
+      "maven": {
+        "parent": {
+          "groupId": null,
+          "artifactId": null,
+          "version": null,
+          "relativePath": "",
+          "includeSpringBootBom": false
+        }
+      },
+      "platform": {
+        "compatibilityRange": null,
+        "v1FormatCompatibilityRange": null,
+        "v2FormatCompatibilityRange": null
+      },
+      "googleAnalyticsTrackingCode": null,
+      "invalidApplicationNames": [
+        "SpringApplication",
+        "SpringBootApplication"
+      ],
+      "invalidPackageNames": [
+        "org.springframework"
+      ],
+      "repositories": {
+        "my-api-repo-1": {
+          "name": "repo1",
+          "url": "https://example.com/repo1",
+          "releasesEnabled": true,
+          "snapshotsEnabled": false
+        },
+        "my-api-repo-2": {
+          "name": "repo2",
+          "url": "https://example.com/repo2",
+          "releasesEnabled": true,
+          "snapshotsEnabled": false
+        },
+        "my-api-repo-3": {
+          "name": "repo3",
+          "url": "https://example.com/repo3",
+          "releasesEnabled": true,
+          "snapshotsEnabled": false
+        },
+        "spring-milestones": {
+          "name": "Spring Milestones",
+          "url": "https://repo.spring.io/milestone",
+          "releasesEnabled": true,
+          "snapshotsEnabled": false
+        },
+        "spring-snapshots": {
+          "name": "Spring Snapshots",
+          "url": "https://repo.spring.io/snapshot",
+          "releasesEnabled": false,
+          "snapshotsEnabled": true
+        }
+      },
+      "boms": {
+        "my-api-bom": {
+          "groupId": "org.acme",
+          "artifactId": "my-api-bom",
+          "versionProperty": "my-api.version",
+          "additionalBoms": [
+            "my-api-dependencies-bom"
+          ],
+          "mappings": [
+            {
+              "compatibilityRange": "[2.3.0.RELEASE,2.4.6)",
+              "repositories": [
+                "my-api-repo-1"
+              ],
+              "version": "1.0.0.RELEASE"
+            },
+            {
+              "compatibilityRange": "2.4.6",
+              "repositories": [
+                "my-api-repo-2"
+              ],
+              "version": "2.0.0.RELEASE"
+            }
+          ]
+        },
+        "my-api-dependencies-bom": {
+          "groupId": "org.acme",
+          "repositories": [
+            "my-api-repo-3"
+          ],
+          "artifactId": "my-api-dependencies-bom",
+          "version": "1.0.0.RELEASE"
+        }
+      },
+      "springBootMetadataUrl": "https://api.spring.io/projects/spring-boot/releases"
+    }},
   "dependencies": {
     "content": [
       {


### PR DESCRIPTION
The customFields feature in Spring Initializr empowers users to define additional metadata beyond the standard options, offering a high degree of flexibility and adaptability. This feature allows organizations to configure values unique to their specific environments—such as default project configurations, organizational dependencies, version control requirements, deployment targets, and other custom options—thereby enabling projects generated by Initializr to seamlessly align with their internal standards and practices.

With customFields, organizations can dynamically add new metadata properties without the need to alter the core configuration, avoiding the overhead of modifying the base metadata structure whenever new requirements arise. This flexibility extends Spring Initializr’s usability, making it more responsive to evolving business needs and diverse project types. For instance, organizations can use customFields to incorporate information specific to internal workflows, compliance protocols, testing guidelines, or infrastructure requirements, injecting tailored configurations directly into newly generated projects.

By streamlining custom configuration management, customFields enhances Initializr’s adaptability and ensures it can support a broader range of use cases—providing value to organizations that rely on Initializr to maintain consistent, standardized, and easily configurable project setups across development teams.