### PR TITLE
added interface creation in JavaSourceCodeWriter

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriter.java
@@ -71,6 +71,7 @@ public class JavaSourceCodeWriter implements SourceCodeWriter<JavaSourceCode> {
 		typeModifiers.put(Modifier::isStatic, "static");
 		typeModifiers.put(Modifier::isFinal, "final");
 		typeModifiers.put(Modifier::isStrict, "strictfp");
+		typeModifiers.put(Modifier::isInterface, "interface");
 		TYPE_MODIFIERS = typeModifiers;
 		Map<Predicate<Integer>, String> fieldModifiers = new LinkedHashMap<>();
 		fieldModifiers.put(Modifier::isPublic, "public");
@@ -121,7 +122,13 @@ public class JavaSourceCodeWriter implements SourceCodeWriter<JavaSourceCode> {
 			for (JavaTypeDeclaration type : compilationUnit.getTypeDeclarations()) {
 				writeAnnotations(writer, type, writer::println);
 				writeModifiers(writer, TYPE_MODIFIERS, type.getModifiers());
-				writer.print("class " + type.getName());
+
+				if (!Modifier.isInterface(type.getModifiers())) {
+					writer.print("class ");
+				}
+
+				writer.print(type.getName());
+
 				if (type.getExtends() != null) {
 					writer.print(" extends " + getUnqualifiedName(type.getExtends()));
 				}

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriterTests.java
@@ -134,6 +134,16 @@ class JavaSourceCodeWriterTests {
 	}
 
 	@Test
+	void shouldAddInterface() throws IOException {
+		JavaSourceCode sourceCode = new JavaSourceCode();
+		JavaCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		JavaTypeDeclaration test = compilationUnit.createTypeDeclaration("Test");
+		test.modifiers(Modifier.INTERFACE);
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.java");
+		assertThat(lines).containsExactly("package com.example;", "", "interface Test {", "", "}");
+	}
+
+	@Test
 	void method() throws IOException {
 		JavaSourceCode sourceCode = new JavaSourceCode();
 		JavaCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");


### PR DESCRIPTION
It used to be that JavaTypeDeclaration could not be an interface. I added Interface in the typeModifiers and if the type declaration is an Interface, the "class" keyword is skipped.