### PR TITLE
Use assignment to set repository url in Groovy Gradle builds

### DIFF
--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-build.gradle.gen
@@ -15,8 +15,8 @@ java {
 
 repositories {
 	mavenCentral()
-	maven { url 'https://example.com/foo' }
-	maven { url 'https://example.com/bar' }
+	maven { url = 'https://example.com/foo' }
+	maven { url = 'https://example.com/bar' }
 }
 
 dependencies {

--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.gen
@@ -15,7 +15,7 @@ java {
 
 repositories {
 	mavenCentral()
-	maven { url 'https://repo.spring.io/milestone' }
+	maven { url = 'https://repo.spring.io/milestone' }
 }
 
 dependencies {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriter.java
@@ -92,7 +92,7 @@ public class GroovyDslGradleBuildWriter extends GradleBuildWriter {
 		if (MavenRepository.MAVEN_CENTRAL.equals(repository)) {
 			return "mavenCentral()";
 		}
-		return "maven { url '" + repository.getUrl() + "' }";
+		return "maven { url = '" + repository.getUrl() + "' }";
 	}
 
 	@Override

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleSettingsWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleSettingsWriter.java
@@ -30,7 +30,7 @@ public class GroovyDslGradleSettingsWriter extends GradleSettingsWriter {
 
 	@Override
 	protected String urlAssignment(String url) {
-		return "url " + wrapWithQuotes(url);
+		return "url = " + wrapWithQuotes(url);
 	}
 
 }

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
@@ -133,7 +133,7 @@ class GroovyDslGradleBuildWriterTests extends GradleBuildWriterTests {
 		build.repositories().add(MavenRepository.withIdAndUrl("spring-milestones", "https://repo.spring.io/milestone"));
 		assertThat(write(build)).contains("""
 				repositories {
-					maven { url 'https://repo.spring.io/milestone' }
+					maven { url = 'https://repo.spring.io/milestone' }
 				}""");
 	}
 
@@ -144,7 +144,7 @@ class GroovyDslGradleBuildWriterTests extends GradleBuildWriterTests {
 			.add(MavenRepository.withIdAndUrl("spring-snapshots", "https://repo.spring.io/snapshot").onlySnapshots());
 		assertThat(write(build)).contains("""
 				repositories {
-					maven { url 'https://repo.spring.io/snapshot' }
+					maven { url = 'https://repo.spring.io/snapshot' }
 				}""");
 	}
 

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleSettingsWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleSettingsWriterTests.java
@@ -63,7 +63,7 @@ class GroovyDslGradleSettingsWriterTests {
 		assertThat(generateSettings(build)).contains("""
 				pluginManagement {
 					repositories {
-						maven { url 'https://repo.spring.io/milestone' }
+						maven { url = 'https://repo.spring.io/milestone' }
 						gradlePluginPortal()
 					}
 				}""");
@@ -79,7 +79,7 @@ class GroovyDslGradleSettingsWriterTests {
 		assertThat(generateSettings(build)).contains("""
 				pluginManagement {
 					repositories {
-						maven { url 'https://repo.spring.io/snapshot' }
+						maven { url = 'https://repo.spring.io/snapshot' }
 						gradlePluginPortal()
 					}
 				}""");


### PR DESCRIPTION
## Summary

Gradle builds using Groovy, which use custom Maven repositories like the Spring milestone or snapshot repos, currently log deprecation warnings as they use the syntax

```
maven { url 'https://repo.spring.io/snapshot' }
```

instead of the preferred

```
maven { url = 'https://repo.spring.io/snapshot' }
```

Gradle's guidance on this is available here: https://docs.gradle.org/8.14/userguide/upgrading_version_8.html#groovy_space_assignment_syntax

The PR resolves this issue.

## How to reproduce

In the Spring Initializr, build a Gradle project with Groovy and choose a Spring Boot snapshot release.

When one then executes for example
```
./gradlew clean --warning-mode all
```

the build will log
```
Settings file 'settings.gradle': line 3
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('url = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.14/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
        at settings_8j6gtdsyzf202bs1oyal9e9vj$_run_closure1$_closure2$_closure3.doCall$original(settings.gradle:3)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at settings_8j6gtdsyzf202bs1oyal9e9vj$_run_closure1$_closure2.doCall$original(settings.gradle:3)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :
Build file 'build.gradle': line 18
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('url = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.14/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
        at build_4owna3ovmuwuctycxsbmt7eu6$_run_closure2$_closure6.doCall$original(build.gradle:18)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_4owna3ovmuwuctycxsbmt7eu6$_run_closure2.doCall$original(build.gradle:18)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```