### PR TITLE
Upgrade to Spring Boot 3.5.2

### DIFF
--- a/initializr-parent/pom.xml
+++ b/initializr-parent/pom.xml
@@ -35,7 +35,7 @@
 		<commons-text.version>1.12.0</commons-text.version>
 		<maven.version>3.9.6</maven.version>
 		<maven-resolver.version>1.9.20</maven-resolver.version>
-		<spring-boot.version>3.5.0</spring-boot.version>
+		<spring-boot.version>3.5.2</spring-boot.version>
 		<spring-cloud-contract.version>4.2.0</spring-cloud-contract.version>
 	</properties>
 	<scm>


### PR DESCRIPTION
https://spring.io/blog/2025/06/19/spring-boot-3-5-2-available-now