### PR TITLE
Add support for repeatable annotations

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/Annotatable.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/Annotatable.java
@@ -21,14 +21,15 @@ package io.spring.initializr.generator.language;
  *
  * @author Andy Wilkinson
  * @author Stephane Nicoll
+ * @author Sijun Yang
  */
 public interface Annotatable {
 
 	/**
-	 * Return the {@link AnnotationContainer} to use to configure the annotations of this
+	 * Return the {@link AnnotationHolder} to use to configure the annotations of this
 	 * element.
-	 * @return the annotation container
+	 * @return the annotation holder
 	 */
-	AnnotationContainer annotations();
+	AnnotationHolder annotations();
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/AnnotationContainer.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/AnnotationContainer.java
@@ -24,11 +24,12 @@ import java.util.stream.Stream;
 import io.spring.initializr.generator.language.Annotation.Builder;
 
 /**
- * A container for {@linkplain Annotation annotations} defined on an annotated element.
+ * An {@link AnnotationHolder} implementation that holds at most one annotation per type.
  *
  * @author Stephane Nicoll
+ * @author Sijun Yang
  */
-public class AnnotationContainer {
+public class AnnotationContainer implements AnnotationHolder {
 
 	private final Map<ClassName, Builder> annotations;
 
@@ -40,38 +41,22 @@ public class AnnotationContainer {
 		this.annotations = annotations;
 	}
 
-	/**
-	 * Specify if this container is empty.
-	 * @return {@code true} if no annotation is registered
-	 */
+	@Override
 	public boolean isEmpty() {
 		return this.annotations.isEmpty();
 	}
 
-	/**
-	 * Specify if this container has a an annotation with the specified {@link ClassName}.
-	 * @param className the class name of an annotation
-	 * @return {@code true} if the annotation with the specified class name exists
-	 */
+	@Override
 	public boolean has(ClassName className) {
 		return this.annotations.containsKey(className);
 	}
 
-	/**
-	 * Return the {@link Annotation annotations}.
-	 * @return the annotations
-	 */
+	@Override
 	public Stream<Annotation> values() {
 		return this.annotations.values().stream().map(Builder::build);
 	}
 
-	/**
-	 * Add a single {@link Annotation} with the specified class name and {@link Consumer}
-	 * to customize it. If the annotation has already been added, the consumer can be used
-	 * to further tune attributes
-	 * @param className the class name of an annotation
-	 * @param annotation a {@link Consumer} to customize the {@link Annotation}
-	 */
+	@Override
 	public void add(ClassName className, Consumer<Builder> annotation) {
 		Builder builder = this.annotations.computeIfAbsent(className, (key) -> new Builder(className));
 		if (annotation != null) {
@@ -79,24 +64,17 @@ public class AnnotationContainer {
 		}
 	}
 
-	/**
-	 * Add a single {@link Annotation} with the specified class name. Does nothing If the
-	 * annotation has already been added.
-	 * @param className the class name of an annotation
-	 */
+	@Override
 	public void add(ClassName className) {
 		add(className, null);
 	}
 
-	/**
-	 * Remove the annotation with the specified {@link ClassName}.
-	 * @param className the class name of the annotation
-	 * @return {@code true} if such an annotation exists, {@code false} otherwise
-	 */
+	@Override
 	public boolean remove(ClassName className) {
 		return this.annotations.remove(className) != null;
 	}
 
+	@Override
 	public AnnotationContainer deepCopy() {
 		Map<ClassName, Builder> copy = new LinkedHashMap<>();
 		this.annotations.forEach((className, builder) -> copy.put(className, new Builder(builder)));

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/AnnotationContainer.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/AnnotationContainer.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 import io.spring.initializr.generator.language.Annotation.Builder;
 
 /**
- * An {@link AnnotationHolder} implementation that holds at most one annotation per type.
+ * An {@link AnnotationHolder} implementation that holds a single annotation per type.
  *
  * @author Stephane Nicoll
  * @author Sijun Yang

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/AnnotationHolder.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/AnnotationHolder.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2012 - present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.language;
+
+import io.spring.initializr.generator.language.Annotation.Builder;
+
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * A holder for {@linkplain Annotation annotations} defined on an annotated element.
+ *
+ * @author Stephane Nicoll
+ * @author Sijun Yang
+ */
+public interface AnnotationHolder {
+
+    /**
+     * Specify if this holder is empty.
+     * @return {@code true} if no annotation is registered
+     */
+    boolean isEmpty();
+
+    /**
+     * Specify if this holder has an annotation with the specified {@link ClassName}.
+     * @param className the class name of an annotation
+     * @return {@code true} if the annotation with the specified class name exists
+     */
+    boolean has(ClassName className);
+
+    /**
+     * Return the {@link Annotation annotations}.
+     * @return the annotations
+     */
+    Stream<Annotation> values();
+
+    /**
+     * Add a single {@link Annotation} with the specified class name and {@link Consumer}
+     * to customize it. If the annotation has already been added, the consumer can be used
+     * to further tune attributes
+     * @param className the class name of an annotation
+     * @param annotation a {@link Consumer} to customize the {@link Annotation}
+     */
+    void add(ClassName className, Consumer<Builder> annotation);
+
+    /**
+     * Add a single {@link Annotation} with the specified class name. Does nothing If the
+     * annotation has already been added.
+     * @param className the class name of an annotation
+     */
+    void add(ClassName className);
+
+    /**
+     * Remove the annotation with the specified {@link ClassName}.
+     * @param className the class name of the annotation
+     * @return {@code true} if such an annotation exists, {@code false} otherwise
+     */
+    boolean remove(ClassName className);
+
+    /**
+     * Create a deep copy of this annotation holder.
+     * @return a new annotation holder with the same annotations
+     */
+    AnnotationHolder deepCopy();
+
+}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/AnnotationHolder.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/AnnotationHolder.java
@@ -29,52 +29,52 @@ import java.util.stream.Stream;
  */
 public interface AnnotationHolder {
 
-    /**
-     * Specify if this holder is empty.
-     * @return {@code true} if no annotation is registered
-     */
-    boolean isEmpty();
+	/**
+	 * Specify if this holder is empty.
+	 * @return {@code true} if no annotation is registered
+	 */
+	boolean isEmpty();
 
-    /**
-     * Specify if this holder has an annotation with the specified {@link ClassName}.
-     * @param className the class name of an annotation
-     * @return {@code true} if the annotation with the specified class name exists
-     */
-    boolean has(ClassName className);
+	/**
+	 * Specify if this holder has an annotation with the specified {@link ClassName}.
+	 * @param className the class name of an annotation
+	 * @return {@code true} if the annotation with the specified class name exists
+	 */
+	boolean has(ClassName className);
 
-    /**
-     * Return the {@link Annotation annotations}.
-     * @return the annotations
-     */
-    Stream<Annotation> values();
+	/**
+	 * Return the {@link Annotation annotations}.
+	 * @return the annotations
+	 */
+	Stream<Annotation> values();
 
-    /**
-     * Add a single {@link Annotation} with the specified class name and {@link Consumer}
-     * to customize it. If the annotation has already been added, the consumer can be used
-     * to further tune attributes
-     * @param className the class name of an annotation
-     * @param annotation a {@link Consumer} to customize the {@link Annotation}
-     */
-    void add(ClassName className, Consumer<Builder> annotation);
+	/**
+	 * Add a single {@link Annotation} with the specified class name and {@link Consumer}
+	 * to customize it. If the annotation has already been added, the consumer can be used
+	 * to further tune attributes
+	 * @param className the class name of an annotation
+	 * @param annotation a {@link Consumer} to customize the {@link Annotation}
+	 */
+	void add(ClassName className, Consumer<Builder> annotation);
 
-    /**
-     * Add a single {@link Annotation} with the specified class name. Does nothing If the
-     * annotation has already been added.
-     * @param className the class name of an annotation
-     */
-    void add(ClassName className);
+	/**
+	 * Add a single {@link Annotation} with the specified class name. Does nothing If the
+	 * annotation has already been added.
+	 * @param className the class name of an annotation
+	 */
+	void add(ClassName className);
 
-    /**
-     * Remove the annotation with the specified {@link ClassName}.
-     * @param className the class name of the annotation
-     * @return {@code true} if such an annotation exists, {@code false} otherwise
-     */
-    boolean remove(ClassName className);
+	/**
+	 * Remove the annotation with the specified {@link ClassName}.
+	 * @param className the class name of the annotation
+	 * @return {@code true} if such an annotation exists, {@code false} otherwise
+	 */
+	boolean remove(ClassName className);
 
-    /**
-     * Create a deep copy of this annotation holder.
-     * @return a new annotation holder with the same annotations
-     */
-    AnnotationHolder deepCopy();
+	/**
+	 * Create a deep copy of this annotation holder.
+	 * @return a new annotation holder with the same annotations
+	 */
+	AnnotationHolder deepCopy();
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/AnnotationHolder.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/AnnotationHolder.java
@@ -24,7 +24,6 @@ import io.spring.initializr.generator.language.Annotation.Builder;
 /**
  * A holder for {@linkplain Annotation annotations} defined on an annotated element.
  *
- * @author Stephane Nicoll
  * @author Sijun Yang
  */
 public interface AnnotationHolder {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/AnnotationHolder.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/AnnotationHolder.java
@@ -16,10 +16,10 @@
 
 package io.spring.initializr.generator.language;
 
-import io.spring.initializr.generator.language.Annotation.Builder;
-
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+
+import io.spring.initializr.generator.language.Annotation.Builder;
 
 /**
  * A holder for {@linkplain Annotation annotations} defined on an annotated element.

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/CompilationUnit.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/CompilationUnit.java
@@ -74,6 +74,10 @@ public abstract class CompilationUnit<T extends TypeDeclaration> {
 		return Collections.unmodifiableList(this.typeDeclarations);
 	}
 
+	protected void addTypeDeclaration(T typeDeclaration) {
+		this.typeDeclarations.add(typeDeclaration);
+	}
+
 	protected abstract T doCreateTypeDeclaration(String name);
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/MultipleAnnotationContainer.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/MultipleAnnotationContainer.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2012 - present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.language;
+
+import io.spring.initializr.generator.language.Annotation.Builder;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * An {@link AnnotationHolder} implementation that can hold multiple annotations per type.
+ *
+ * @author Sijun Yang
+ */
+public class MultipleAnnotationContainer implements AnnotationHolder {
+
+    private final Map<ClassName, List<Builder>> annotations;
+
+    public MultipleAnnotationContainer() {
+        this(new LinkedHashMap<>());
+    }
+
+    private MultipleAnnotationContainer(Map<ClassName, List<Builder>> annotations) {
+        this.annotations = annotations;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.annotations.isEmpty() ||
+                this.annotations.values().stream().allMatch(List::isEmpty);
+    }
+
+    @Override
+    public boolean has(ClassName className) {
+        List<Builder> builders = this.annotations.get(className);
+        return builders != null && !builders.isEmpty();
+    }
+
+    @Override
+    public Stream<Annotation> values() {
+        return this.annotations.values().stream()
+                .flatMap(List::stream)
+                .map(Builder::build);
+    }
+
+    /**
+     * Add operation is not supported for {@link MultipleAnnotationContainer}.
+     * Use {@link #addToList(ClassName, Consumer)} instead to explicitly add to the list.
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public void add(ClassName className, Consumer<Builder> annotation) {
+        throw new UnsupportedOperationException(
+                "Add operation with potential overwrite is not supported for MultipleAnnotationContainer. " +
+                        "Use addToList() to explicitly add annotations to the list.");
+    }
+
+    /**
+     * Add operation is not supported for {@link MultipleAnnotationContainer}.
+     * Use {@link #addToList(ClassName)} instead to explicitly add to the list.
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public void add(ClassName className) {
+        throw new UnsupportedOperationException(
+                "Add operation with potential overwrite is not supported for MultipleAnnotationContainer. " +
+                        "Use addToList() to explicitly add annotations to the list.");
+    }
+
+    /**
+     * Add an annotation to the list of annotations with the specified class name.
+     * Always adds a new annotation.
+     * @param className the class name of an annotation
+     * @param annotation a {@link Consumer} to customize the {@link Annotation}
+     */
+    public void addToList(ClassName className, Consumer<Builder> annotation) {
+        List<Builder> builders = this.annotations.computeIfAbsent(className, (key) -> new ArrayList<>());
+        Builder builder = new Builder(className);
+        if (annotation != null) {
+            annotation.accept(builder);
+        }
+        builders.add(builder);
+    }
+
+    /**
+     * Add an annotation to the list of annotations with the specified class name.
+     * Always adds a new annotation.
+     * @param className the class name of an annotation
+     */
+    public void addToList(ClassName className) {
+        addToList(className, null);
+    }
+
+    /**
+     * Return all annotations with the specified class name.
+     * @param className the class name of an annotation
+     * @return a stream of all annotations with the specified class name
+     */
+    public Stream<Annotation> valuesOf(ClassName className) {
+        List<Builder> builders = this.annotations.get(className);
+        if (builders == null || builders.isEmpty()) {
+            return Stream.empty();
+        }
+        return builders.stream().map(Builder::build);
+    }
+
+    /**
+     * Return the number of annotations with the specified class name.
+     * @param className the class name of an annotation
+     * @return the count of annotations with the specified class name
+     */
+    public int countOf(ClassName className) {
+        List<Builder> builders = this.annotations.get(className);
+        return builders != null ? builders.size() : 0;
+    }
+
+    /**
+     * Remove all annotations with the specified class name.
+     * @param className the class name of the annotation
+     * @return the number of annotations that were removed
+     */
+    public int removeAll(ClassName className) {
+        List<Builder> builders = this.annotations.remove(className);
+        return builders != null ? builders.size() : 0;
+    }
+
+    @Override
+    public boolean remove(ClassName className) {
+        int removedCount = removeAll(className);
+        return removedCount > 0;
+    }
+
+    /**
+     * Check if this container has multiple annotations with the specified class name.
+     * @param className the class name of an annotation
+     * @return {@code true} if there are multiple annotations with the specified class name
+     */
+    public boolean hasMultiple(ClassName className) {
+        List<Builder> builders = this.annotations.get(className);
+        return builders != null && builders.size() > 1;
+    }
+
+    @Override
+    public MultipleAnnotationContainer deepCopy() {
+        Map<ClassName, List<Builder>> copy = new LinkedHashMap<>();
+        this.annotations.forEach((className, builders) -> {
+            List<Builder> buildersCopy = new ArrayList<>();
+            builders.forEach(builder -> buildersCopy.add(new Builder(builder)));
+            copy.put(className, buildersCopy);
+        });
+        return new MultipleAnnotationContainer(copy);
+    }
+
+}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/MultipleAnnotationContainer.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/MultipleAnnotationContainer.java
@@ -16,11 +16,14 @@
 
 package io.spring.initializr.generator.language;
 
-import io.spring.initializr.generator.language.Annotation.Builder;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+
+import io.spring.initializr.generator.language.Annotation.Builder;
 
 /**
  * An {@link AnnotationHolder} implementation that can hold multiple annotations per type.
@@ -123,7 +126,7 @@ public class MultipleAnnotationContainer implements AnnotationHolder {
 	 */
 	public int countOf(ClassName className) {
 		List<Builder> builders = this.annotations.get(className);
-		return builders != null ? builders.size() : 0;
+		return (builders != null) ? builders.size() : 0;
 	}
 
 	/**
@@ -133,7 +136,7 @@ public class MultipleAnnotationContainer implements AnnotationHolder {
 	 */
 	public int removeAll(ClassName className) {
 		List<Builder> builders = this.annotations.remove(className);
-		return builders != null ? builders.size() : 0;
+		return (builders != null) ? builders.size() : 0;
 	}
 
 	@Override
@@ -158,7 +161,7 @@ public class MultipleAnnotationContainer implements AnnotationHolder {
 		Map<ClassName, List<Builder>> copy = new LinkedHashMap<>();
 		this.annotations.forEach((className, builders) -> {
 			List<Builder> buildersCopy = new ArrayList<>();
-			builders.forEach(builder -> buildersCopy.add(new Builder(builder)));
+			builders.forEach((builder) -> buildersCopy.add(new Builder(builder)));
 			copy.put(className, buildersCopy);
 		});
 		return new MultipleAnnotationContainer(copy);

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/MultipleAnnotationContainer.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/MultipleAnnotationContainer.java
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 import io.spring.initializr.generator.language.Annotation.Builder;
 
 /**
- * An {@link AnnotationHolder} implementation that can hold multiple annotations per type.
+ * An {@link AnnotationHolder} implementation that holds multiple annotations per type.
  *
  * @author Sijun Yang
  */

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/MultipleAnnotationContainer.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/MultipleAnnotationContainer.java
@@ -29,141 +29,139 @@ import java.util.stream.Stream;
  */
 public class MultipleAnnotationContainer implements AnnotationHolder {
 
-    private final Map<ClassName, List<Builder>> annotations;
+	private final Map<ClassName, List<Builder>> annotations;
 
-    public MultipleAnnotationContainer() {
-        this(new LinkedHashMap<>());
-    }
+	public MultipleAnnotationContainer() {
+		this(new LinkedHashMap<>());
+	}
 
-    private MultipleAnnotationContainer(Map<ClassName, List<Builder>> annotations) {
-        this.annotations = annotations;
-    }
+	private MultipleAnnotationContainer(Map<ClassName, List<Builder>> annotations) {
+		this.annotations = annotations;
+	}
 
-    @Override
-    public boolean isEmpty() {
-        return this.annotations.isEmpty() ||
-                this.annotations.values().stream().allMatch(List::isEmpty);
-    }
+	@Override
+	public boolean isEmpty() {
+		return this.annotations.isEmpty() || this.annotations.values().stream().allMatch(List::isEmpty);
+	}
 
-    @Override
-    public boolean has(ClassName className) {
-        List<Builder> builders = this.annotations.get(className);
-        return builders != null && !builders.isEmpty();
-    }
+	@Override
+	public boolean has(ClassName className) {
+		List<Builder> builders = this.annotations.get(className);
+		return builders != null && !builders.isEmpty();
+	}
 
-    @Override
-    public Stream<Annotation> values() {
-        return this.annotations.values().stream()
-                .flatMap(List::stream)
-                .map(Builder::build);
-    }
+	@Override
+	public Stream<Annotation> values() {
+		return this.annotations.values().stream().flatMap(List::stream).map(Builder::build);
+	}
 
-    /**
-     * Add operation is not supported for {@link MultipleAnnotationContainer}.
-     * Use {@link #addToList(ClassName, Consumer)} instead to explicitly add to the list.
-     * @throws UnsupportedOperationException always
-     */
-    @Override
-    public void add(ClassName className, Consumer<Builder> annotation) {
-        throw new UnsupportedOperationException(
-                "Add operation with potential overwrite is not supported for MultipleAnnotationContainer. " +
-                        "Use addToList() to explicitly add annotations to the list.");
-    }
+	/**
+	 * Add operation is not supported for {@link MultipleAnnotationContainer}. Use
+	 * {@link #addToList(ClassName, Consumer)} instead to explicitly add to the list.
+	 * @throws UnsupportedOperationException always
+	 */
+	@Override
+	public void add(ClassName className, Consumer<Builder> annotation) {
+		throw new UnsupportedOperationException(
+				"Add operation with potential overwrite is not supported for MultipleAnnotationContainer. "
+						+ "Use addToList() to explicitly add annotations to the list.");
+	}
 
-    /**
-     * Add operation is not supported for {@link MultipleAnnotationContainer}.
-     * Use {@link #addToList(ClassName)} instead to explicitly add to the list.
-     * @throws UnsupportedOperationException always
-     */
-    @Override
-    public void add(ClassName className) {
-        throw new UnsupportedOperationException(
-                "Add operation with potential overwrite is not supported for MultipleAnnotationContainer. " +
-                        "Use addToList() to explicitly add annotations to the list.");
-    }
+	/**
+	 * Add operation is not supported for {@link MultipleAnnotationContainer}. Use
+	 * {@link #addToList(ClassName)} instead to explicitly add to the list.
+	 * @throws UnsupportedOperationException always
+	 */
+	@Override
+	public void add(ClassName className) {
+		throw new UnsupportedOperationException(
+				"Add operation with potential overwrite is not supported for MultipleAnnotationContainer. "
+						+ "Use addToList() to explicitly add annotations to the list.");
+	}
 
-    /**
-     * Add an annotation to the list of annotations with the specified class name.
-     * Always adds a new annotation.
-     * @param className the class name of an annotation
-     * @param annotation a {@link Consumer} to customize the {@link Annotation}
-     */
-    public void addToList(ClassName className, Consumer<Builder> annotation) {
-        List<Builder> builders = this.annotations.computeIfAbsent(className, (key) -> new ArrayList<>());
-        Builder builder = new Builder(className);
-        if (annotation != null) {
-            annotation.accept(builder);
-        }
-        builders.add(builder);
-    }
+	/**
+	 * Add an annotation to the list of annotations with the specified class name. Always
+	 * adds a new annotation.
+	 * @param className the class name of an annotation
+	 * @param annotation a {@link Consumer} to customize the {@link Annotation}
+	 */
+	public void addToList(ClassName className, Consumer<Builder> annotation) {
+		List<Builder> builders = this.annotations.computeIfAbsent(className, (key) -> new ArrayList<>());
+		Builder builder = new Builder(className);
+		if (annotation != null) {
+			annotation.accept(builder);
+		}
+		builders.add(builder);
+	}
 
-    /**
-     * Add an annotation to the list of annotations with the specified class name.
-     * Always adds a new annotation.
-     * @param className the class name of an annotation
-     */
-    public void addToList(ClassName className) {
-        addToList(className, null);
-    }
+	/**
+	 * Add an annotation to the list of annotations with the specified class name. Always
+	 * adds a new annotation.
+	 * @param className the class name of an annotation
+	 */
+	public void addToList(ClassName className) {
+		addToList(className, null);
+	}
 
-    /**
-     * Return all annotations with the specified class name.
-     * @param className the class name of an annotation
-     * @return a stream of all annotations with the specified class name
-     */
-    public Stream<Annotation> valuesOf(ClassName className) {
-        List<Builder> builders = this.annotations.get(className);
-        if (builders == null || builders.isEmpty()) {
-            return Stream.empty();
-        }
-        return builders.stream().map(Builder::build);
-    }
+	/**
+	 * Return all annotations with the specified class name.
+	 * @param className the class name of an annotation
+	 * @return a stream of all annotations with the specified class name
+	 */
+	public Stream<Annotation> valuesOf(ClassName className) {
+		List<Builder> builders = this.annotations.get(className);
+		if (builders == null || builders.isEmpty()) {
+			return Stream.empty();
+		}
+		return builders.stream().map(Builder::build);
+	}
 
-    /**
-     * Return the number of annotations with the specified class name.
-     * @param className the class name of an annotation
-     * @return the count of annotations with the specified class name
-     */
-    public int countOf(ClassName className) {
-        List<Builder> builders = this.annotations.get(className);
-        return builders != null ? builders.size() : 0;
-    }
+	/**
+	 * Return the number of annotations with the specified class name.
+	 * @param className the class name of an annotation
+	 * @return the count of annotations with the specified class name
+	 */
+	public int countOf(ClassName className) {
+		List<Builder> builders = this.annotations.get(className);
+		return builders != null ? builders.size() : 0;
+	}
 
-    /**
-     * Remove all annotations with the specified class name.
-     * @param className the class name of the annotation
-     * @return the number of annotations that were removed
-     */
-    public int removeAll(ClassName className) {
-        List<Builder> builders = this.annotations.remove(className);
-        return builders != null ? builders.size() : 0;
-    }
+	/**
+	 * Remove all annotations with the specified class name.
+	 * @param className the class name of the annotation
+	 * @return the number of annotations that were removed
+	 */
+	public int removeAll(ClassName className) {
+		List<Builder> builders = this.annotations.remove(className);
+		return builders != null ? builders.size() : 0;
+	}
 
-    @Override
-    public boolean remove(ClassName className) {
-        int removedCount = removeAll(className);
-        return removedCount > 0;
-    }
+	@Override
+	public boolean remove(ClassName className) {
+		int removedCount = removeAll(className);
+		return removedCount > 0;
+	}
 
-    /**
-     * Check if this container has multiple annotations with the specified class name.
-     * @param className the class name of an annotation
-     * @return {@code true} if there are multiple annotations with the specified class name
-     */
-    public boolean hasMultiple(ClassName className) {
-        List<Builder> builders = this.annotations.get(className);
-        return builders != null && builders.size() > 1;
-    }
+	/**
+	 * Check if this container has multiple annotations with the specified class name.
+	 * @param className the class name of an annotation
+	 * @return {@code true} if there are multiple annotations with the specified class
+	 * name
+	 */
+	public boolean hasMultiple(ClassName className) {
+		List<Builder> builders = this.annotations.get(className);
+		return builders != null && builders.size() > 1;
+	}
 
-    @Override
-    public MultipleAnnotationContainer deepCopy() {
-        Map<ClassName, List<Builder>> copy = new LinkedHashMap<>();
-        this.annotations.forEach((className, builders) -> {
-            List<Builder> buildersCopy = new ArrayList<>();
-            builders.forEach(builder -> buildersCopy.add(new Builder(builder)));
-            copy.put(className, buildersCopy);
-        });
-        return new MultipleAnnotationContainer(copy);
-    }
+	@Override
+	public MultipleAnnotationContainer deepCopy() {
+		Map<ClassName, List<Builder>> copy = new LinkedHashMap<>();
+		this.annotations.forEach((className, builders) -> {
+			List<Builder> buildersCopy = new ArrayList<>();
+			builders.forEach(builder -> buildersCopy.add(new Builder(builder)));
+			copy.put(className, buildersCopy);
+		});
+		return new MultipleAnnotationContainer(copy);
+	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/Parameter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/Parameter.java
@@ -30,7 +30,7 @@ public final class Parameter implements Annotatable {
 
 	private final String type;
 
-	private final AnnotationContainer annotations;
+	private final AnnotationHolder annotations;
 
 	private Parameter(Builder builder) {
 		this.name = builder.name;
@@ -94,7 +94,7 @@ public final class Parameter implements Annotatable {
 	}
 
 	@Override
-	public AnnotationContainer annotations() {
+	public AnnotationHolder annotations() {
 		return this.annotations;
 	}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/TypeDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/TypeDeclaration.java
@@ -36,6 +36,11 @@ public class TypeDeclaration implements Annotatable {
 
 	private List<String> implementsClassNames = Collections.emptyList();
 
+	/**
+	 * Creates a new instance.
+	 * @param name the type name
+	 * @param annotations the annotation holder
+	 */
 	public TypeDeclaration(String name, AnnotationHolder annotations) {
 		this.name = name;
 		this.annotations = annotations;

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/TypeDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/TypeDeclaration.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 public class TypeDeclaration implements Annotatable {
 
-	private final AnnotationContainer annotations = new AnnotationContainer();
+	private final AnnotationHolder annotations;
 
 	private final String name;
 
@@ -36,12 +36,17 @@ public class TypeDeclaration implements Annotatable {
 
 	private List<String> implementsClassNames = Collections.emptyList();
 
+	public TypeDeclaration(String name, AnnotationHolder annotations) {
+		this.name = name;
+		this.annotations = annotations;
+	}
+
 	/**
 	 * Creates a new instance.
 	 * @param name the type name
 	 */
 	public TypeDeclaration(String name) {
-		this.name = name;
+		this(name, new AnnotationContainer());
 	}
 
 	/**
@@ -69,7 +74,7 @@ public class TypeDeclaration implements Annotatable {
 	}
 
 	@Override
-	public AnnotationContainer annotations() {
+	public AnnotationHolder annotations() {
 		return this.annotations;
 	}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyCompilationUnit.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyCompilationUnit.java
@@ -16,6 +16,7 @@
 
 package io.spring.initializr.generator.language.groovy;
 
+import io.spring.initializr.generator.language.AnnotationHolder;
 import io.spring.initializr.generator.language.CompilationUnit;
 
 /**
@@ -32,6 +33,19 @@ public class GroovyCompilationUnit extends CompilationUnit<GroovyTypeDeclaration
 	@Override
 	protected GroovyTypeDeclaration doCreateTypeDeclaration(String name) {
 		return new GroovyTypeDeclaration(name);
+	}
+
+	/**
+	 * Creates a new {@link GroovyTypeDeclaration} with the specified name and
+	 * {@link AnnotationHolder}.
+	 * @param name the name of the type declaration
+	 * @param annotations the annotation holder to use
+	 * @return a new GroovyTypeDeclaration instance
+	 */
+	public GroovyTypeDeclaration createTypeDeclaration(String name, AnnotationHolder annotations) {
+		GroovyTypeDeclaration typeDeclaration = new GroovyTypeDeclaration(name, annotations);
+		addTypeDeclaration(typeDeclaration);
+		return typeDeclaration;
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyFieldDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyFieldDeclaration.java
@@ -39,17 +39,13 @@ public final class GroovyFieldDeclaration implements Annotatable {
 
 	private final boolean initialized;
 
-	public GroovyFieldDeclaration(Builder builder, AnnotationHolder annotations) {
-		this.annotations = annotations;
+	private GroovyFieldDeclaration(Builder builder) {
+		this.annotations = builder.annotations;
 		this.modifiers = builder.modifiers;
 		this.name = builder.name;
 		this.returnType = builder.returnType;
 		this.value = builder.value;
 		this.initialized = builder.initialized;
-	}
-
-	private GroovyFieldDeclaration(Builder builder) {
-		this(builder, new AnnotationContainer());
 	}
 
 	/**
@@ -111,6 +107,8 @@ public final class GroovyFieldDeclaration implements Annotatable {
 	 */
 	public static final class Builder {
 
+		private AnnotationHolder annotations = new AnnotationContainer();
+
 		private final String name;
 
 		private String returnType;
@@ -132,6 +130,16 @@ public final class GroovyFieldDeclaration implements Annotatable {
 		 */
 		public Builder modifiers(int modifiers) {
 			this.modifiers = modifiers;
+			return this;
+		}
+
+		/**
+		 * Sets the annotation holder.
+		 * @param annotations the annotation holder
+		 * @return this for method chaining
+		 */
+		public Builder annotations(AnnotationHolder annotations) {
+			this.annotations = annotations;
 			return this;
 		}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyFieldDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyFieldDeclaration.java
@@ -18,6 +18,7 @@ package io.spring.initializr.generator.language.groovy;
 
 import io.spring.initializr.generator.language.Annotatable;
 import io.spring.initializr.generator.language.AnnotationContainer;
+import io.spring.initializr.generator.language.AnnotationHolder;
 
 /**
  * Declaration of a field written in Groovy.
@@ -26,7 +27,7 @@ import io.spring.initializr.generator.language.AnnotationContainer;
  */
 public final class GroovyFieldDeclaration implements Annotatable {
 
-	private final AnnotationContainer annotations = new AnnotationContainer();
+	private final AnnotationHolder annotations;
 
 	private final int modifiers;
 
@@ -38,12 +39,17 @@ public final class GroovyFieldDeclaration implements Annotatable {
 
 	private final boolean initialized;
 
-	private GroovyFieldDeclaration(Builder builder) {
+	public GroovyFieldDeclaration(Builder builder, AnnotationHolder annotations) {
+		this.annotations = annotations;
 		this.modifiers = builder.modifiers;
 		this.name = builder.name;
 		this.returnType = builder.returnType;
 		this.value = builder.value;
 		this.initialized = builder.initialized;
+	}
+
+	private GroovyFieldDeclaration(Builder builder) {
+		this(builder, new AnnotationContainer());
 	}
 
 	/**
@@ -56,7 +62,7 @@ public final class GroovyFieldDeclaration implements Annotatable {
 	}
 
 	@Override
-	public AnnotationContainer annotations() {
+	public AnnotationHolder annotations() {
 		return this.annotations;
 	}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyMethodDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyMethodDeclaration.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import io.spring.initializr.generator.language.Annotatable;
 import io.spring.initializr.generator.language.AnnotationContainer;
+import io.spring.initializr.generator.language.AnnotationHolder;
 import io.spring.initializr.generator.language.CodeBlock;
 import io.spring.initializr.generator.language.Parameter;
 
@@ -33,7 +34,7 @@ import io.spring.initializr.generator.language.Parameter;
  */
 public final class GroovyMethodDeclaration implements Annotatable {
 
-	private final AnnotationContainer annotations = new AnnotationContainer();
+	private final AnnotationHolder annotations;
 
 	private final String name;
 
@@ -45,12 +46,17 @@ public final class GroovyMethodDeclaration implements Annotatable {
 
 	private final CodeBlock code;
 
-	private GroovyMethodDeclaration(Builder builder, CodeBlock code) {
+	private GroovyMethodDeclaration(Builder builder, CodeBlock code, AnnotationHolder annotations) {
+		this.annotations = annotations;
 		this.name = builder.name;
 		this.returnType = builder.returnType;
 		this.modifiers = builder.modifiers;
 		this.parameters = List.copyOf(builder.parameters);
 		this.code = code;
+	}
+
+	public GroovyMethodDeclaration(Builder builder, CodeBlock code) {
+		this(builder, code, new AnnotationContainer());
 	}
 
 	/**
@@ -83,7 +89,7 @@ public final class GroovyMethodDeclaration implements Annotatable {
 	}
 
 	@Override
-	public AnnotationContainer annotations() {
+	public AnnotationHolder annotations() {
 		return this.annotations;
 	}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyMethodDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyMethodDeclaration.java
@@ -50,7 +50,7 @@ public final class GroovyMethodDeclaration implements Annotatable {
 		this.annotations = builder.annotations;
 		this.name = builder.name;
 		this.returnType = builder.returnType;
-		this.parameters = new ArrayList<>(builder.parameters);
+		this.parameters = List.copyOf(builder.parameters);
 		this.modifiers = builder.modifiers;
 		this.code = code;
 	}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyMethodDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyMethodDeclaration.java
@@ -46,17 +46,13 @@ public final class GroovyMethodDeclaration implements Annotatable {
 
 	private final CodeBlock code;
 
-	private GroovyMethodDeclaration(Builder builder, CodeBlock code, AnnotationHolder annotations) {
-		this.annotations = annotations;
+	public GroovyMethodDeclaration(Builder builder, CodeBlock code) {
+		this.annotations = builder.annotations;
 		this.name = builder.name;
 		this.returnType = builder.returnType;
+		this.parameters = new ArrayList<>(builder.parameters);
 		this.modifiers = builder.modifiers;
-		this.parameters = List.copyOf(builder.parameters);
 		this.code = code;
-	}
-
-	public GroovyMethodDeclaration(Builder builder, CodeBlock code) {
-		this(builder, code, new AnnotationContainer());
 	}
 
 	/**
@@ -98,6 +94,8 @@ public final class GroovyMethodDeclaration implements Annotatable {
 	 */
 	public static final class Builder {
 
+		private AnnotationHolder annotations = new AnnotationContainer();
+
 		private final String name;
 
 		private List<Parameter> parameters = new ArrayList<>();
@@ -137,6 +135,16 @@ public final class GroovyMethodDeclaration implements Annotatable {
 		 */
 		public Builder parameters(Parameter... parameters) {
 			this.parameters = Arrays.asList(parameters);
+			return this;
+		}
+
+		/**
+		 * Sets the annotation holder.
+		 * @param annotations the annotation holder
+		 * @return this for method chaining
+		 */
+		public Builder annotations(AnnotationHolder annotations) {
+			this.annotations = annotations;
 			return this;
 		}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyMethodDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyMethodDeclaration.java
@@ -46,12 +46,12 @@ public final class GroovyMethodDeclaration implements Annotatable {
 
 	private final CodeBlock code;
 
-	public GroovyMethodDeclaration(Builder builder, CodeBlock code) {
+	private GroovyMethodDeclaration(Builder builder, CodeBlock code) {
 		this.annotations = builder.annotations;
 		this.name = builder.name;
 		this.returnType = builder.returnType;
-		this.parameters = List.copyOf(builder.parameters);
 		this.modifiers = builder.modifiers;
+		this.parameters = List.copyOf(builder.parameters);
 		this.code = code;
 	}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyTypeDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovyTypeDeclaration.java
@@ -19,6 +19,7 @@ package io.spring.initializr.generator.language.groovy;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.spring.initializr.generator.language.AnnotationHolder;
 import io.spring.initializr.generator.language.TypeDeclaration;
 
 /**
@@ -36,6 +37,10 @@ public class GroovyTypeDeclaration extends TypeDeclaration {
 
 	GroovyTypeDeclaration(String name) {
 		super(name);
+	}
+
+	GroovyTypeDeclaration(String name, AnnotationHolder annotations) {
+		super(name, annotations);
 	}
 
 	/**

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaCompilationUnit.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaCompilationUnit.java
@@ -16,6 +16,7 @@
 
 package io.spring.initializr.generator.language.java;
 
+import io.spring.initializr.generator.language.AnnotationHolder;
 import io.spring.initializr.generator.language.CompilationUnit;
 
 /**
@@ -32,6 +33,19 @@ public class JavaCompilationUnit extends CompilationUnit<JavaTypeDeclaration> {
 	@Override
 	protected JavaTypeDeclaration doCreateTypeDeclaration(String name) {
 		return new JavaTypeDeclaration(name);
+	}
+
+	/**
+	 * Creates a new {@link JavaTypeDeclaration} with the specified name and
+	 * {@link AnnotationHolder}.
+	 * @param name the name of the type declaration
+	 * @param annotations the annotation holder to use
+	 * @return a new JavaTypeDeclaration instance
+	 */
+	public JavaTypeDeclaration createTypeDeclaration(String name, AnnotationHolder annotations) {
+		JavaTypeDeclaration typeDeclaration = new JavaTypeDeclaration(name, annotations);
+		addTypeDeclaration(typeDeclaration);
+		return typeDeclaration;
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaFieldDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaFieldDeclaration.java
@@ -18,6 +18,7 @@ package io.spring.initializr.generator.language.java;
 
 import io.spring.initializr.generator.language.Annotatable;
 import io.spring.initializr.generator.language.AnnotationContainer;
+import io.spring.initializr.generator.language.AnnotationHolder;
 
 /**
  * Declaration of a field written in Java.
@@ -26,7 +27,7 @@ import io.spring.initializr.generator.language.AnnotationContainer;
  */
 public final class JavaFieldDeclaration implements Annotatable {
 
-	private final AnnotationContainer annotations = new AnnotationContainer();
+	private final AnnotationHolder annotations;
 
 	private final int modifiers;
 
@@ -38,12 +39,17 @@ public final class JavaFieldDeclaration implements Annotatable {
 
 	private final boolean initialized;
 
-	private JavaFieldDeclaration(Builder builder) {
+	public JavaFieldDeclaration(Builder builder, AnnotationHolder annotations) {
+		this.annotations = annotations;
 		this.modifiers = builder.modifiers;
 		this.name = builder.name;
 		this.returnType = builder.returnType;
 		this.value = builder.value;
 		this.initialized = builder.initialized;
+	}
+
+	private JavaFieldDeclaration(Builder builder) {
+		this(builder, new AnnotationContainer());
 	}
 
 	/**
@@ -56,7 +62,7 @@ public final class JavaFieldDeclaration implements Annotatable {
 	}
 
 	@Override
-	public AnnotationContainer annotations() {
+	public AnnotationHolder annotations() {
 		return this.annotations;
 	}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaFieldDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaFieldDeclaration.java
@@ -39,17 +39,13 @@ public final class JavaFieldDeclaration implements Annotatable {
 
 	private final boolean initialized;
 
-	public JavaFieldDeclaration(Builder builder, AnnotationHolder annotations) {
-		this.annotations = annotations;
+	private JavaFieldDeclaration(Builder builder) {
+		this.annotations = builder.annotations;
 		this.modifiers = builder.modifiers;
 		this.name = builder.name;
 		this.returnType = builder.returnType;
 		this.value = builder.value;
 		this.initialized = builder.initialized;
-	}
-
-	private JavaFieldDeclaration(Builder builder) {
-		this(builder, new AnnotationContainer());
 	}
 
 	/**
@@ -111,6 +107,8 @@ public final class JavaFieldDeclaration implements Annotatable {
 	 */
 	public static final class Builder {
 
+		private AnnotationHolder annotations = new AnnotationContainer();
+
 		private final String name;
 
 		private String returnType;
@@ -132,6 +130,16 @@ public final class JavaFieldDeclaration implements Annotatable {
 		 */
 		public Builder modifiers(int modifiers) {
 			this.modifiers = modifiers;
+			return this;
+		}
+
+		/**
+		 * Sets the annotation holder.
+		 * @param annotations the annotation holder
+		 * @return this for method chaining
+		 */
+		public Builder annotations(AnnotationHolder annotations) {
+			this.annotations = annotations;
 			return this;
 		}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaMethodDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaMethodDeclaration.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import io.spring.initializr.generator.language.Annotatable;
 import io.spring.initializr.generator.language.AnnotationContainer;
+import io.spring.initializr.generator.language.AnnotationHolder;
 import io.spring.initializr.generator.language.CodeBlock;
 import io.spring.initializr.generator.language.Parameter;
 
@@ -32,7 +33,7 @@ import io.spring.initializr.generator.language.Parameter;
  */
 public final class JavaMethodDeclaration implements Annotatable {
 
-	private final AnnotationContainer annotations = new AnnotationContainer();
+	private final AnnotationHolder annotations;
 
 	private final String name;
 
@@ -44,12 +45,17 @@ public final class JavaMethodDeclaration implements Annotatable {
 
 	private final CodeBlock code;
 
-	private JavaMethodDeclaration(Builder builder, CodeBlock code) {
+	public JavaMethodDeclaration(Builder builder, CodeBlock code, AnnotationHolder annotations) {
+		this.annotations = annotations;
 		this.name = builder.name;
 		this.returnType = builder.returnType;
 		this.modifiers = builder.modifiers;
 		this.parameters = List.copyOf(builder.parameters);
 		this.code = code;
+	}
+
+	private JavaMethodDeclaration(Builder builder, CodeBlock code) {
+		this(builder, code, new AnnotationContainer());
 	}
 
 	/**
@@ -82,7 +88,7 @@ public final class JavaMethodDeclaration implements Annotatable {
 	}
 
 	@Override
-	public AnnotationContainer annotations() {
+	public AnnotationHolder annotations() {
 		return this.annotations;
 	}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaMethodDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaMethodDeclaration.java
@@ -45,17 +45,13 @@ public final class JavaMethodDeclaration implements Annotatable {
 
 	private final CodeBlock code;
 
-	public JavaMethodDeclaration(Builder builder, CodeBlock code, AnnotationHolder annotations) {
-		this.annotations = annotations;
+	public JavaMethodDeclaration(Builder builder, CodeBlock code) {
+		this.annotations = builder.annotations;
 		this.name = builder.name;
 		this.returnType = builder.returnType;
 		this.modifiers = builder.modifiers;
 		this.parameters = List.copyOf(builder.parameters);
 		this.code = code;
-	}
-
-	private JavaMethodDeclaration(Builder builder, CodeBlock code) {
-		this(builder, code, new AnnotationContainer());
 	}
 
 	/**
@@ -97,6 +93,8 @@ public final class JavaMethodDeclaration implements Annotatable {
 	 */
 	public static final class Builder {
 
+		private AnnotationHolder annotations = new AnnotationContainer();
+
 		private final String name;
 
 		private List<Parameter> parameters = new ArrayList<>();
@@ -136,6 +134,16 @@ public final class JavaMethodDeclaration implements Annotatable {
 		 */
 		public Builder parameters(Parameter... parameters) {
 			this.parameters = Arrays.asList(parameters);
+			return this;
+		}
+
+		/**
+		 * Sets the annotation holder.
+		 * @param annotations the annotation holder
+		 * @return this for method chaining
+		 */
+		public Builder annotations(AnnotationHolder annotations) {
+			this.annotations = annotations;
 			return this;
 		}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaMethodDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaMethodDeclaration.java
@@ -45,7 +45,7 @@ public final class JavaMethodDeclaration implements Annotatable {
 
 	private final CodeBlock code;
 
-	public JavaMethodDeclaration(Builder builder, CodeBlock code) {
+	private JavaMethodDeclaration(Builder builder, CodeBlock code) {
 		this.annotations = builder.annotations;
 		this.name = builder.name;
 		this.returnType = builder.returnType;

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaTypeDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaTypeDeclaration.java
@@ -19,6 +19,7 @@ package io.spring.initializr.generator.language.java;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.spring.initializr.generator.language.AnnotationHolder;
 import io.spring.initializr.generator.language.TypeDeclaration;
 
 /**
@@ -37,6 +38,10 @@ public class JavaTypeDeclaration extends TypeDeclaration {
 
 	JavaTypeDeclaration(String name) {
 		super(name);
+	}
+
+	JavaTypeDeclaration(String name, AnnotationHolder annotations) {
+		super(name, annotations);
 	}
 
 	/**

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinCompilationUnit.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinCompilationUnit.java
@@ -19,6 +19,7 @@ package io.spring.initializr.generator.language.kotlin;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.spring.initializr.generator.language.AnnotationHolder;
 import io.spring.initializr.generator.language.CompilationUnit;
 
 /**
@@ -37,6 +38,19 @@ public class KotlinCompilationUnit extends CompilationUnit<KotlinTypeDeclaration
 	@Override
 	protected KotlinTypeDeclaration doCreateTypeDeclaration(String name) {
 		return new KotlinTypeDeclaration(name);
+	}
+
+	/**
+	 * Creates a new {@link KotlinTypeDeclaration} with the specified name and
+	 * {@link AnnotationHolder}.
+	 * @param name the name of the type declaration
+	 * @param annotations the annotation holder to use
+	 * @return a new KotlinTypeDeclaration instance
+	 */
+	public KotlinTypeDeclaration createTypeDeclaration(String name, AnnotationHolder annotations) {
+		KotlinTypeDeclaration typeDeclaration = new KotlinTypeDeclaration(name, annotations);
+		addTypeDeclaration(typeDeclaration);
+		return typeDeclaration;
 	}
 
 	/**

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinFunctionDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinFunctionDeclaration.java
@@ -45,17 +45,13 @@ public final class KotlinFunctionDeclaration implements Annotatable {
 
 	private final CodeBlock code;
 
-	private KotlinFunctionDeclaration(Builder builder, CodeBlock code, AnnotationHolder annotations) {
-		this.annotations = annotations;
+	private KotlinFunctionDeclaration(Builder builder, CodeBlock code) {
+		this.annotations = builder.annotations;
 		this.name = builder.name;
 		this.returnType = builder.returnType;
 		this.modifiers = builder.modifiers;
 		this.parameters = List.copyOf(builder.parameters);
 		this.code = code;
-	}
-
-	private KotlinFunctionDeclaration(Builder builder, CodeBlock code) {
-		this(builder, code, new AnnotationContainer());
 	}
 
 	/**
@@ -97,6 +93,8 @@ public final class KotlinFunctionDeclaration implements Annotatable {
 	 */
 	public static final class Builder {
 
+		private AnnotationHolder annotations = new AnnotationContainer();
+
 		private final String name;
 
 		private List<Parameter> parameters = new ArrayList<>();
@@ -136,6 +134,16 @@ public final class KotlinFunctionDeclaration implements Annotatable {
 		 */
 		public Builder parameters(Parameter... parameters) {
 			this.parameters = Arrays.asList(parameters);
+			return this;
+		}
+
+		/**
+		 * Sets the annotation holder.
+		 * @param annotations the annotation holder
+		 * @return this for method chaining
+		 */
+		public Builder annotations(AnnotationHolder annotations) {
+			this.annotations = annotations;
 			return this;
 		}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinFunctionDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinFunctionDeclaration.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import io.spring.initializr.generator.language.Annotatable;
 import io.spring.initializr.generator.language.AnnotationContainer;
+import io.spring.initializr.generator.language.AnnotationHolder;
 import io.spring.initializr.generator.language.CodeBlock;
 import io.spring.initializr.generator.language.Parameter;
 
@@ -32,7 +33,7 @@ import io.spring.initializr.generator.language.Parameter;
  */
 public final class KotlinFunctionDeclaration implements Annotatable {
 
-	private final AnnotationContainer annotations = new AnnotationContainer();
+	private final AnnotationHolder annotations;
 
 	private final String name;
 
@@ -44,12 +45,17 @@ public final class KotlinFunctionDeclaration implements Annotatable {
 
 	private final CodeBlock code;
 
-	private KotlinFunctionDeclaration(Builder builder, CodeBlock code) {
+	private KotlinFunctionDeclaration(Builder builder, CodeBlock code, AnnotationHolder annotations) {
+		this.annotations = annotations;
 		this.name = builder.name;
 		this.returnType = builder.returnType;
 		this.modifiers = builder.modifiers;
 		this.parameters = List.copyOf(builder.parameters);
 		this.code = code;
+	}
+
+	private KotlinFunctionDeclaration(Builder builder, CodeBlock code) {
+		this(builder, code, new AnnotationContainer());
 	}
 
 	/**
@@ -82,7 +88,7 @@ public final class KotlinFunctionDeclaration implements Annotatable {
 	}
 
 	@Override
-	public AnnotationContainer annotations() {
+	public AnnotationHolder annotations() {
 		return this.annotations;
 	}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinPropertyDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinPropertyDeclaration.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 import io.spring.initializr.generator.language.Annotatable;
 import io.spring.initializr.generator.language.Annotation;
 import io.spring.initializr.generator.language.AnnotationContainer;
+import io.spring.initializr.generator.language.AnnotationHolder;
 import io.spring.initializr.generator.language.ClassName;
 import io.spring.initializr.generator.language.CodeBlock;
 
@@ -34,7 +35,7 @@ import io.spring.initializr.generator.language.CodeBlock;
  */
 public final class KotlinPropertyDeclaration implements Annotatable {
 
-	private final AnnotationContainer annotations = new AnnotationContainer();
+	private final AnnotationHolder annotations;
 
 	private final boolean isVal;
 
@@ -50,7 +51,8 @@ public final class KotlinPropertyDeclaration implements Annotatable {
 
 	private final Accessor setter;
 
-	private KotlinPropertyDeclaration(Builder<?> builder) {
+	private KotlinPropertyDeclaration(Builder<?> builder, AnnotationHolder annotations) {
+		this.annotations = annotations;
 		this.name = builder.name;
 		this.returnType = builder.returnType;
 		this.modifiers = new ArrayList<>(builder.modifiers);
@@ -58,6 +60,10 @@ public final class KotlinPropertyDeclaration implements Annotatable {
 		this.valueCode = builder.valueCode;
 		this.getter = builder.getter;
 		this.setter = builder.setter;
+	}
+
+	public KotlinPropertyDeclaration(Builder<?> builder) {
+		this(builder, new AnnotationContainer());
 	}
 
 	/**
@@ -111,7 +117,7 @@ public final class KotlinPropertyDeclaration implements Annotatable {
 	}
 
 	@Override
-	public AnnotationContainer annotations() {
+	public AnnotationHolder annotations() {
 		return this.annotations;
 	}
 
@@ -308,7 +314,7 @@ public final class KotlinPropertyDeclaration implements Annotatable {
 
 	static final class Accessor implements Annotatable {
 
-		private final AnnotationContainer annotations;
+		private final AnnotationHolder annotations;
 
 		private final CodeBlock code;
 
@@ -322,7 +328,7 @@ public final class KotlinPropertyDeclaration implements Annotatable {
 		}
 
 		@Override
-		public AnnotationContainer annotations() {
+		public AnnotationHolder annotations() {
 			return this.annotations;
 		}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinPropertyDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinPropertyDeclaration.java
@@ -51,8 +51,8 @@ public final class KotlinPropertyDeclaration implements Annotatable {
 
 	private final Accessor setter;
 
-	private KotlinPropertyDeclaration(Builder<?> builder, AnnotationHolder annotations) {
-		this.annotations = annotations;
+	private KotlinPropertyDeclaration(Builder<?> builder) {
+		this.annotations = builder.annotations;
 		this.name = builder.name;
 		this.returnType = builder.returnType;
 		this.modifiers = new ArrayList<>(builder.modifiers);
@@ -60,10 +60,6 @@ public final class KotlinPropertyDeclaration implements Annotatable {
 		this.valueCode = builder.valueCode;
 		this.getter = builder.getter;
 		this.setter = builder.setter;
-	}
-
-	public KotlinPropertyDeclaration(Builder<?> builder) {
-		this(builder, new AnnotationContainer());
 	}
 
 	/**
@@ -128,6 +124,8 @@ public final class KotlinPropertyDeclaration implements Annotatable {
 	 */
 	public abstract static class Builder<T extends Builder<T>> {
 
+		private AnnotationHolder annotations = new AnnotationContainer();
+
 		private final boolean isVal;
 
 		private final String name;
@@ -188,6 +186,16 @@ public final class KotlinPropertyDeclaration implements Annotatable {
 		 */
 		public T modifiers(KotlinModifier... modifiers) {
 			this.modifiers = Arrays.asList(modifiers);
+			return self();
+		}
+
+		/**
+		 * Sets the annotation holder.
+		 * @param annotations the annotation holder
+		 * @return this for method chaining
+		 */
+		public T annotations(AnnotationHolder annotations) {
+			this.annotations = annotations;
 			return self();
 		}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriter.java
@@ -162,6 +162,7 @@ public class KotlinSourceCodeWriter implements SourceCodeWriter<KotlinSourceCode
 
 	private void writeProperty(IndentingWriter writer, KotlinPropertyDeclaration propertyDeclaration) {
 		writer.println();
+		writeAnnotations(writer, propertyDeclaration);
 		writeModifiers(writer, propertyDeclaration.getModifiers());
 		if (propertyDeclaration.isVal()) {
 			writer.print("val ");

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinTypeDeclaration.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinTypeDeclaration.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import io.spring.initializr.generator.language.AnnotationHolder;
 import io.spring.initializr.generator.language.TypeDeclaration;
 
 /**
@@ -37,6 +38,10 @@ public class KotlinTypeDeclaration extends TypeDeclaration {
 
 	KotlinTypeDeclaration(String name) {
 		super(name);
+	}
+
+	KotlinTypeDeclaration(String name, AnnotationHolder annotations) {
+		super(name, annotations);
 	}
 
 	/**

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/MultipleAnnotationContainerTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/MultipleAnnotationContainerTests.java
@@ -1,0 +1,165 @@
+package io.spring.initializr.generator.language;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link MultipleAnnotationContainer}.
+ *
+ * @author Sijun Yang
+ */
+class MultipleAnnotationContainerTests {
+
+    private static final ClassName TEST_CLASS_NAME = ClassName.of("com.example.Test");
+
+    private static final ClassName OTHER_CLASS_NAME = ClassName.of("com.example.Other");
+
+    @Test
+    void isEmptyWithEmptyContainer() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        assertThat(container.isEmpty()).isTrue();
+    }
+
+    @Test
+    void isEmptyWithAnnotation() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
+        assertThat(container.isEmpty()).isFalse();
+    }
+
+    @Test
+    void hasWithMatchingAnnotation() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
+        assertThat(container.has(TEST_CLASS_NAME)).isTrue();
+    }
+
+    @Test
+    void hasWithNonMatchingAnnotation() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
+        assertThat(container.has(OTHER_CLASS_NAME)).isFalse();
+    }
+
+    @Test
+    void valuesShouldReturnAllAnnotations() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "one"));
+        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "two"));
+        List<Annotation> annotations = container.values().collect(Collectors.toList());
+        assertThat(annotations).hasSize(2);
+        assertThat(annotations).allMatch(annotation -> annotation.getClassName().equals(TEST_CLASS_NAME));
+    }
+
+    @Test
+    void valuesOfShouldReturnMatchingAnnotationsOnly() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "one"));
+        container.addToList(OTHER_CLASS_NAME, builder -> builder.add("name", "other"));
+        List<Annotation> annotations = container.valuesOf(TEST_CLASS_NAME).collect(Collectors.toList());
+        assertThat(annotations).hasSize(1);
+        assertThat(annotations.get(0).getAttributes()).singleElement().satisfies((attribute) -> {
+            assertThat(attribute.getName()).isEqualTo("value");
+            assertThat(attribute.getValues()).containsExactly("one");
+        });
+    }
+
+    @Test
+    void valuesOfShouldReturnEmptyStreamForNonExistingClassName() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        container.addToList(TEST_CLASS_NAME);
+        assertThat(container.valuesOf(OTHER_CLASS_NAME)).isEmpty();
+    }
+
+    @Test
+    void countOfShouldReturnCorrectCount() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        container.addToList(TEST_CLASS_NAME);
+        container.addToList(TEST_CLASS_NAME);
+        assertThat(container.countOf(TEST_CLASS_NAME)).isEqualTo(2);
+        assertThat(container.countOf(OTHER_CLASS_NAME)).isZero();
+    }
+
+    @Test
+    void removeAllShouldRemoveAllAnnotationsOfClassName() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        container.addToList(TEST_CLASS_NAME);
+        container.addToList(TEST_CLASS_NAME);
+        int removed = container.removeAll(TEST_CLASS_NAME);
+        assertThat(removed).isEqualTo(2);
+        assertThat(container.has(TEST_CLASS_NAME)).isFalse();
+    }
+
+    @Test
+    void removeShouldReturnFalseIfAllAnnotationRemoved() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        container.addToList(TEST_CLASS_NAME);
+        container.addToList(TEST_CLASS_NAME);
+        assertThat(container.remove(TEST_CLASS_NAME)).isTrue();
+        assertThat(container.has(TEST_CLASS_NAME)).isFalse();
+    }
+
+    @Test
+    void removeShouldReturnFalseIfNoAnnotationRemoved() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        assertThat(container.remove(TEST_CLASS_NAME)).isFalse();
+    }
+
+    @Test
+    void hasMultipleReturnsTrueForMultipleAnnotations() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        container.addToList(TEST_CLASS_NAME);
+        container.addToList(TEST_CLASS_NAME);
+        assertThat(container.hasMultiple(TEST_CLASS_NAME)).isTrue();
+        assertThat(container.hasMultiple(OTHER_CLASS_NAME)).isFalse();
+    }
+
+    @Test
+    void addUnsupportedMethodsThrowException() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        assertThatThrownBy(() -> container.add(TEST_CLASS_NAME))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> container.add(TEST_CLASS_NAME, builder -> {}))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void deepCopyShouldCreateDistinctObjectReferences() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
+
+        MultipleAnnotationContainer copy = container.deepCopy();
+
+        assertThat(copy).isNotSameAs(container);
+
+        List<Annotation> originalAnnotations = container.valuesOf(TEST_CLASS_NAME).collect(Collectors.toList());
+        List<Annotation> copiedAnnotations = copy.valuesOf(TEST_CLASS_NAME).collect(Collectors.toList());
+
+        assertThat(copiedAnnotations).hasSize(originalAnnotations.size());
+        for (int i = 0; i < originalAnnotations.size(); i++) {
+            assertThat(copiedAnnotations.get(i)).isNotSameAs(originalAnnotations.get(i));
+        }
+    }
+
+    @Test
+    void deepCopyMutationShouldNotAffectOriginal() {
+        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "original"));
+
+        MultipleAnnotationContainer copy = container.deepCopy();
+
+        copy.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "new"));
+        copy.addToList(OTHER_CLASS_NAME, builder -> builder.add("other", "test"));
+
+        assertThat(container.countOf(TEST_CLASS_NAME)).isEqualTo(1);
+        assertThat(container.has(OTHER_CLASS_NAME)).isFalse();
+
+        assertThat(copy.countOf(TEST_CLASS_NAME)).isEqualTo(2);
+        assertThat(copy.has(OTHER_CLASS_NAME)).isTrue();
+    }
+}

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/MultipleAnnotationContainerTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/MultipleAnnotationContainerTests.java
@@ -15,151 +15,151 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class MultipleAnnotationContainerTests {
 
-    private static final ClassName TEST_CLASS_NAME = ClassName.of("com.example.Test");
+	private static final ClassName TEST_CLASS_NAME = ClassName.of("com.example.Test");
 
-    private static final ClassName OTHER_CLASS_NAME = ClassName.of("com.example.Other");
+	private static final ClassName OTHER_CLASS_NAME = ClassName.of("com.example.Other");
 
-    @Test
-    void isEmptyWithEmptyContainer() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        assertThat(container.isEmpty()).isTrue();
-    }
+	@Test
+	void isEmptyWithEmptyContainer() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		assertThat(container.isEmpty()).isTrue();
+	}
 
-    @Test
-    void isEmptyWithAnnotation() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
-        assertThat(container.isEmpty()).isFalse();
-    }
+	@Test
+	void isEmptyWithAnnotation() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
+		assertThat(container.isEmpty()).isFalse();
+	}
 
-    @Test
-    void hasWithMatchingAnnotation() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
-        assertThat(container.has(TEST_CLASS_NAME)).isTrue();
-    }
+	@Test
+	void hasWithMatchingAnnotation() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
+		assertThat(container.has(TEST_CLASS_NAME)).isTrue();
+	}
 
-    @Test
-    void hasWithNonMatchingAnnotation() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
-        assertThat(container.has(OTHER_CLASS_NAME)).isFalse();
-    }
+	@Test
+	void hasWithNonMatchingAnnotation() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
+		assertThat(container.has(OTHER_CLASS_NAME)).isFalse();
+	}
 
-    @Test
-    void valuesShouldReturnAllAnnotations() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "one"));
-        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "two"));
-        List<Annotation> annotations = container.values().collect(Collectors.toList());
-        assertThat(annotations).hasSize(2);
-        assertThat(annotations).allMatch(annotation -> annotation.getClassName().equals(TEST_CLASS_NAME));
-    }
+	@Test
+	void valuesShouldReturnAllAnnotations() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "one"));
+		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "two"));
+		List<Annotation> annotations = container.values().collect(Collectors.toList());
+		assertThat(annotations).hasSize(2);
+		assertThat(annotations).allMatch(annotation -> annotation.getClassName().equals(TEST_CLASS_NAME));
+	}
 
-    @Test
-    void valuesOfShouldReturnMatchingAnnotationsOnly() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "one"));
-        container.addToList(OTHER_CLASS_NAME, builder -> builder.add("name", "other"));
-        List<Annotation> annotations = container.valuesOf(TEST_CLASS_NAME).collect(Collectors.toList());
-        assertThat(annotations).hasSize(1);
-        assertThat(annotations.get(0).getAttributes()).singleElement().satisfies((attribute) -> {
-            assertThat(attribute.getName()).isEqualTo("value");
-            assertThat(attribute.getValues()).containsExactly("one");
-        });
-    }
+	@Test
+	void valuesOfShouldReturnMatchingAnnotationsOnly() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "one"));
+		container.addToList(OTHER_CLASS_NAME, builder -> builder.add("name", "other"));
+		List<Annotation> annotations = container.valuesOf(TEST_CLASS_NAME).collect(Collectors.toList());
+		assertThat(annotations).hasSize(1);
+		assertThat(annotations.get(0).getAttributes()).singleElement().satisfies((attribute) -> {
+			assertThat(attribute.getName()).isEqualTo("value");
+			assertThat(attribute.getValues()).containsExactly("one");
+		});
+	}
 
-    @Test
-    void valuesOfShouldReturnEmptyStreamForNonExistingClassName() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        container.addToList(TEST_CLASS_NAME);
-        assertThat(container.valuesOf(OTHER_CLASS_NAME)).isEmpty();
-    }
+	@Test
+	void valuesOfShouldReturnEmptyStreamForNonExistingClassName() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		container.addToList(TEST_CLASS_NAME);
+		assertThat(container.valuesOf(OTHER_CLASS_NAME)).isEmpty();
+	}
 
-    @Test
-    void countOfShouldReturnCorrectCount() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        container.addToList(TEST_CLASS_NAME);
-        container.addToList(TEST_CLASS_NAME);
-        assertThat(container.countOf(TEST_CLASS_NAME)).isEqualTo(2);
-        assertThat(container.countOf(OTHER_CLASS_NAME)).isZero();
-    }
+	@Test
+	void countOfShouldReturnCorrectCount() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		container.addToList(TEST_CLASS_NAME);
+		container.addToList(TEST_CLASS_NAME);
+		assertThat(container.countOf(TEST_CLASS_NAME)).isEqualTo(2);
+		assertThat(container.countOf(OTHER_CLASS_NAME)).isZero();
+	}
 
-    @Test
-    void removeAllShouldRemoveAllAnnotationsOfClassName() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        container.addToList(TEST_CLASS_NAME);
-        container.addToList(TEST_CLASS_NAME);
-        int removed = container.removeAll(TEST_CLASS_NAME);
-        assertThat(removed).isEqualTo(2);
-        assertThat(container.has(TEST_CLASS_NAME)).isFalse();
-    }
+	@Test
+	void removeAllShouldRemoveAllAnnotationsOfClassName() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		container.addToList(TEST_CLASS_NAME);
+		container.addToList(TEST_CLASS_NAME);
+		int removed = container.removeAll(TEST_CLASS_NAME);
+		assertThat(removed).isEqualTo(2);
+		assertThat(container.has(TEST_CLASS_NAME)).isFalse();
+	}
 
-    @Test
-    void removeShouldReturnFalseIfAllAnnotationRemoved() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        container.addToList(TEST_CLASS_NAME);
-        container.addToList(TEST_CLASS_NAME);
-        assertThat(container.remove(TEST_CLASS_NAME)).isTrue();
-        assertThat(container.has(TEST_CLASS_NAME)).isFalse();
-    }
+	@Test
+	void removeShouldReturnFalseIfAllAnnotationRemoved() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		container.addToList(TEST_CLASS_NAME);
+		container.addToList(TEST_CLASS_NAME);
+		assertThat(container.remove(TEST_CLASS_NAME)).isTrue();
+		assertThat(container.has(TEST_CLASS_NAME)).isFalse();
+	}
 
-    @Test
-    void removeShouldReturnFalseIfNoAnnotationRemoved() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        assertThat(container.remove(TEST_CLASS_NAME)).isFalse();
-    }
+	@Test
+	void removeShouldReturnFalseIfNoAnnotationRemoved() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		assertThat(container.remove(TEST_CLASS_NAME)).isFalse();
+	}
 
-    @Test
-    void hasMultipleReturnsTrueForMultipleAnnotations() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        container.addToList(TEST_CLASS_NAME);
-        container.addToList(TEST_CLASS_NAME);
-        assertThat(container.hasMultiple(TEST_CLASS_NAME)).isTrue();
-        assertThat(container.hasMultiple(OTHER_CLASS_NAME)).isFalse();
-    }
+	@Test
+	void hasMultipleReturnsTrueForMultipleAnnotations() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		container.addToList(TEST_CLASS_NAME);
+		container.addToList(TEST_CLASS_NAME);
+		assertThat(container.hasMultiple(TEST_CLASS_NAME)).isTrue();
+		assertThat(container.hasMultiple(OTHER_CLASS_NAME)).isFalse();
+	}
 
-    @Test
-    void addUnsupportedMethodsThrowException() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        assertThatThrownBy(() -> container.add(TEST_CLASS_NAME))
-                .isInstanceOf(UnsupportedOperationException.class);
-        assertThatThrownBy(() -> container.add(TEST_CLASS_NAME, builder -> {}))
-                .isInstanceOf(UnsupportedOperationException.class);
-    }
+	@Test
+	void addUnsupportedMethodsThrowException() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		assertThatThrownBy(() -> container.add(TEST_CLASS_NAME)).isInstanceOf(UnsupportedOperationException.class);
+		assertThatThrownBy(() -> container.add(TEST_CLASS_NAME, builder -> {
+		})).isInstanceOf(UnsupportedOperationException.class);
+	}
 
-    @Test
-    void deepCopyShouldCreateDistinctObjectReferences() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
+	@Test
+	void deepCopyShouldCreateDistinctObjectReferences() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
 
-        MultipleAnnotationContainer copy = container.deepCopy();
+		MultipleAnnotationContainer copy = container.deepCopy();
 
-        assertThat(copy).isNotSameAs(container);
+		assertThat(copy).isNotSameAs(container);
 
-        List<Annotation> originalAnnotations = container.valuesOf(TEST_CLASS_NAME).collect(Collectors.toList());
-        List<Annotation> copiedAnnotations = copy.valuesOf(TEST_CLASS_NAME).collect(Collectors.toList());
+		List<Annotation> originalAnnotations = container.valuesOf(TEST_CLASS_NAME).collect(Collectors.toList());
+		List<Annotation> copiedAnnotations = copy.valuesOf(TEST_CLASS_NAME).collect(Collectors.toList());
 
-        assertThat(copiedAnnotations).hasSize(originalAnnotations.size());
-        for (int i = 0; i < originalAnnotations.size(); i++) {
-            assertThat(copiedAnnotations.get(i)).isNotSameAs(originalAnnotations.get(i));
-        }
-    }
+		assertThat(copiedAnnotations).hasSize(originalAnnotations.size());
+		for (int i = 0; i < originalAnnotations.size(); i++) {
+			assertThat(copiedAnnotations.get(i)).isNotSameAs(originalAnnotations.get(i));
+		}
+	}
 
-    @Test
-    void deepCopyMutationShouldNotAffectOriginal() {
-        MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-        container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "original"));
+	@Test
+	void deepCopyMutationShouldNotAffectOriginal() {
+		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
+		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "original"));
 
-        MultipleAnnotationContainer copy = container.deepCopy();
+		MultipleAnnotationContainer copy = container.deepCopy();
 
-        copy.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "new"));
-        copy.addToList(OTHER_CLASS_NAME, builder -> builder.add("other", "test"));
+		copy.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "new"));
+		copy.addToList(OTHER_CLASS_NAME, builder -> builder.add("other", "test"));
 
-        assertThat(container.countOf(TEST_CLASS_NAME)).isEqualTo(1);
-        assertThat(container.has(OTHER_CLASS_NAME)).isFalse();
+		assertThat(container.countOf(TEST_CLASS_NAME)).isEqualTo(1);
+		assertThat(container.has(OTHER_CLASS_NAME)).isFalse();
 
-        assertThat(copy.countOf(TEST_CLASS_NAME)).isEqualTo(2);
-        assertThat(copy.has(OTHER_CLASS_NAME)).isTrue();
-    }
+		assertThat(copy.countOf(TEST_CLASS_NAME)).isEqualTo(2);
+		assertThat(copy.has(OTHER_CLASS_NAME)).isTrue();
+	}
+
 }

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/MultipleAnnotationContainerTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/MultipleAnnotationContainerTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 - present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.spring.initializr.generator.language;
 
 import org.junit.jupiter.api.Test;
@@ -28,39 +44,39 @@ class MultipleAnnotationContainerTests {
 	@Test
 	void isEmptyWithAnnotation() {
 		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
+		container.addToList(TEST_CLASS_NAME, (builder) -> builder.add("value", "test"));
 		assertThat(container.isEmpty()).isFalse();
 	}
 
 	@Test
 	void hasWithMatchingAnnotation() {
 		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
+		container.addToList(TEST_CLASS_NAME, (builder) -> builder.add("value", "test"));
 		assertThat(container.has(TEST_CLASS_NAME)).isTrue();
 	}
 
 	@Test
 	void hasWithNonMatchingAnnotation() {
 		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
+		container.addToList(TEST_CLASS_NAME, (builder) -> builder.add("value", "test"));
 		assertThat(container.has(OTHER_CLASS_NAME)).isFalse();
 	}
 
 	@Test
 	void valuesShouldReturnAllAnnotations() {
 		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "one"));
-		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "two"));
+		container.addToList(TEST_CLASS_NAME, (builder) -> builder.add("value", "one"));
+		container.addToList(TEST_CLASS_NAME, (builder) -> builder.add("value", "two"));
 		List<Annotation> annotations = container.values().collect(Collectors.toList());
 		assertThat(annotations).hasSize(2);
-		assertThat(annotations).allMatch(annotation -> annotation.getClassName().equals(TEST_CLASS_NAME));
+		assertThat(annotations).allMatch((annotation) -> annotation.getClassName().equals(TEST_CLASS_NAME));
 	}
 
 	@Test
 	void valuesOfShouldReturnMatchingAnnotationsOnly() {
 		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "one"));
-		container.addToList(OTHER_CLASS_NAME, builder -> builder.add("name", "other"));
+		container.addToList(TEST_CLASS_NAME, (builder) -> builder.add("value", "one"));
+		container.addToList(OTHER_CLASS_NAME, (builder) -> builder.add("name", "other"));
 		List<Annotation> annotations = container.valuesOf(TEST_CLASS_NAME).collect(Collectors.toList());
 		assertThat(annotations).hasSize(1);
 		assertThat(annotations.get(0).getAttributes()).singleElement().satisfies((attribute) -> {
@@ -123,14 +139,14 @@ class MultipleAnnotationContainerTests {
 	void addUnsupportedMethodsThrowException() {
 		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
 		assertThatThrownBy(() -> container.add(TEST_CLASS_NAME)).isInstanceOf(UnsupportedOperationException.class);
-		assertThatThrownBy(() -> container.add(TEST_CLASS_NAME, builder -> {
+		assertThatThrownBy(() -> container.add(TEST_CLASS_NAME, (builder) -> {
 		})).isInstanceOf(UnsupportedOperationException.class);
 	}
 
 	@Test
 	void deepCopyShouldCreateDistinctObjectReferences() {
 		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "test"));
+		container.addToList(TEST_CLASS_NAME, (builder) -> builder.add("value", "test"));
 
 		MultipleAnnotationContainer copy = container.deepCopy();
 
@@ -148,12 +164,12 @@ class MultipleAnnotationContainerTests {
 	@Test
 	void deepCopyMutationShouldNotAffectOriginal() {
 		MultipleAnnotationContainer container = new MultipleAnnotationContainer();
-		container.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "original"));
+		container.addToList(TEST_CLASS_NAME, (builder) -> builder.add("value", "original"));
 
 		MultipleAnnotationContainer copy = container.deepCopy();
 
-		copy.addToList(TEST_CLASS_NAME, builder -> builder.add("value", "new"));
-		copy.addToList(OTHER_CLASS_NAME, builder -> builder.add("other", "test"));
+		copy.addToList(TEST_CLASS_NAME, (builder) -> builder.add("value", "new"));
+		copy.addToList(OTHER_CLASS_NAME, (builder) -> builder.add("other", "test"));
 
 		assertThat(container.countOf(TEST_CLASS_NAME)).isEqualTo(1);
 		assertThat(container.has(OTHER_CLASS_NAME)).isFalse();

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/groovy/GroovySourceCodeWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/groovy/GroovySourceCodeWriterTests.java
@@ -331,8 +331,8 @@ class GroovySourceCodeWriterTests {
 		classAnnotations.addToList(ClassName.of("com.example.TestClassAnnotation"));
 		GroovyTypeDeclaration test = compilationUnit.createTypeDeclaration("Test", classAnnotations);
 		List<String> lines = writeSingleType(sourceCode, "com/example/Test.groovy");
-		assertThat(lines).containsExactly("package com.example", "", "@TestClassAnnotation",
-				"@TestClassAnnotation", "class Test {", "", "}");
+		assertThat(lines).containsExactly("package com.example", "", "@TestClassAnnotation", "@TestClassAnnotation",
+				"class Test {", "", "}");
 	}
 
 	@Test
@@ -344,12 +344,12 @@ class GroovySourceCodeWriterTests {
 		fieldAnnotations.addToList(ClassName.of("com.example.TestFiledAnnotation"));
 		fieldAnnotations.addToList(ClassName.of("com.example.TestFiledAnnotation"));
 		GroovyFieldDeclaration field = GroovyFieldDeclaration.field("testField")
-				.annotations(fieldAnnotations)
-				.returning("java.lang.String");
+			.annotations(fieldAnnotations)
+			.returning("java.lang.String");
 		test.addFieldDeclaration(field);
 		List<String> lines = writeSingleType(sourceCode, "com/example/Test.groovy");
-		assertThat(lines).containsExactly("package com.example", "", "class Test {", "",
-				"    @TestFiledAnnotation", "    @TestFiledAnnotation", "    String testField", "", "}");
+		assertThat(lines).containsExactly("package com.example", "", "class Test {", "", "    @TestFiledAnnotation",
+				"    @TestFiledAnnotation", "    String testField", "", "}");
 	}
 
 	@Test
@@ -361,14 +361,14 @@ class GroovySourceCodeWriterTests {
 		methodAnnotations.addToList(ClassName.of("com.example.TestMethodAnnotation"));
 		methodAnnotations.addToList(ClassName.of("com.example.TestMethodAnnotation"));
 		GroovyMethodDeclaration method = GroovyMethodDeclaration.method("testMethod")
-				.annotations(methodAnnotations)
-				.returning("void")
-				.parameters()
-				.body(CodeBlock.of(""));
+			.annotations(methodAnnotations)
+			.returning("void")
+			.parameters()
+			.body(CodeBlock.of(""));
 		test.addMethodDeclaration(method);
 		List<String> lines = writeSingleType(sourceCode, "com/example/Test.groovy");
-		assertThat(lines).containsExactly("package com.example", "", "class Test {", "",
-				"    @TestMethodAnnotation", "    @TestMethodAnnotation", "    void testMethod() {", "    }", "", "}");
+		assertThat(lines).containsExactly("package com.example", "", "class Test {", "", "    @TestMethodAnnotation",
+				"    @TestMethodAnnotation", "    void testMethod() {", "    }", "", "}");
 	}
 
 	private List<String> writeSingleType(GroovySourceCode sourceCode, String location) throws IOException {

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/groovy/GroovySourceCodeWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/groovy/GroovySourceCodeWriterTests.java
@@ -33,6 +33,7 @@ import io.spring.initializr.generator.language.Annotation.Builder;
 import io.spring.initializr.generator.language.ClassName;
 import io.spring.initializr.generator.language.CodeBlock;
 import io.spring.initializr.generator.language.Language;
+import io.spring.initializr.generator.language.MultipleAnnotationContainer;
 import io.spring.initializr.generator.language.Parameter;
 import io.spring.initializr.generator.language.SourceStructure;
 import org.junit.jupiter.api.Test;
@@ -319,6 +320,55 @@ class GroovySourceCodeWriterTests {
 		assertThat(lines).containsExactly("package com.example", "", "import com.example.another.MyService",
 				"import com.example.stereotype.Service", "", "class Test {", "",
 				"    void something(@Service MyService service) {", "    }", "", "}");
+	}
+
+	@Test
+	void multipleAnnotationsOnClass() throws IOException {
+		GroovySourceCode sourceCode = new GroovySourceCode();
+		GroovyCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		MultipleAnnotationContainer classAnnotations = new MultipleAnnotationContainer();
+		classAnnotations.addToList(ClassName.of("com.example.TestClassAnnotation"));
+		classAnnotations.addToList(ClassName.of("com.example.TestClassAnnotation"));
+		GroovyTypeDeclaration test = compilationUnit.createTypeDeclaration("Test", classAnnotations);
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.groovy");
+		assertThat(lines).containsExactly("package com.example", "", "@TestClassAnnotation",
+				"@TestClassAnnotation", "class Test {", "", "}");
+	}
+
+	@Test
+	void multipleAnnotationsOnField() throws IOException {
+		GroovySourceCode sourceCode = new GroovySourceCode();
+		GroovyCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		GroovyTypeDeclaration test = compilationUnit.createTypeDeclaration("Test");
+		MultipleAnnotationContainer fieldAnnotations = new MultipleAnnotationContainer();
+		fieldAnnotations.addToList(ClassName.of("com.example.TestFiledAnnotation"));
+		fieldAnnotations.addToList(ClassName.of("com.example.TestFiledAnnotation"));
+		GroovyFieldDeclaration field = GroovyFieldDeclaration.field("testField")
+				.annotations(fieldAnnotations)
+				.returning("java.lang.String");
+		test.addFieldDeclaration(field);
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.groovy");
+		assertThat(lines).containsExactly("package com.example", "", "class Test {", "",
+				"    @TestFiledAnnotation", "    @TestFiledAnnotation", "    String testField", "", "}");
+	}
+
+	@Test
+	void multipleAnnotationsOnMethod() throws IOException {
+		GroovySourceCode sourceCode = new GroovySourceCode();
+		GroovyCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		GroovyTypeDeclaration test = compilationUnit.createTypeDeclaration("Test");
+		MultipleAnnotationContainer methodAnnotations = new MultipleAnnotationContainer();
+		methodAnnotations.addToList(ClassName.of("com.example.TestMethodAnnotation"));
+		methodAnnotations.addToList(ClassName.of("com.example.TestMethodAnnotation"));
+		GroovyMethodDeclaration method = GroovyMethodDeclaration.method("testMethod")
+				.annotations(methodAnnotations)
+				.returning("void")
+				.parameters()
+				.body(CodeBlock.of(""));
+		test.addMethodDeclaration(method);
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.groovy");
+		assertThat(lines).containsExactly("package com.example", "", "class Test {", "",
+				"    @TestMethodAnnotation", "    @TestMethodAnnotation", "    void testMethod() {", "    }", "", "}");
 	}
 
 	private List<String> writeSingleType(GroovySourceCode sourceCode, String location) throws IOException {

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriterTests.java
@@ -335,10 +335,10 @@ class JavaSourceCodeWriterTests {
 		MultipleAnnotationContainer classAnnotations = new MultipleAnnotationContainer();
 		classAnnotations.addToList(ClassName.of("com.example.TestClassAnnotation"));
 		classAnnotations.addToList(ClassName.of("com.example.TestClassAnnotation"));
-        compilationUnit.createTypeDeclaration("Test", classAnnotations);
-        List<String> lines = writeSingleType(sourceCode, "com/example/Test.java");
-		assertThat(lines).containsExactly("package com.example;", "", "@TestClassAnnotation",
-				"@TestClassAnnotation", "class Test {", "", "}");
+		compilationUnit.createTypeDeclaration("Test", classAnnotations);
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.java");
+		assertThat(lines).containsExactly("package com.example;", "", "@TestClassAnnotation", "@TestClassAnnotation",
+				"class Test {", "", "}");
 	}
 
 	@Test
@@ -350,9 +350,9 @@ class JavaSourceCodeWriterTests {
 		fieldAnnotations.addToList(ClassName.of("com.example.TestFiledAnnotation"));
 		fieldAnnotations.addToList(ClassName.of("com.example.TestFiledAnnotation"));
 		JavaFieldDeclaration field = JavaFieldDeclaration.field("testField")
-				.annotations(fieldAnnotations)
-				.modifiers(Modifier.PRIVATE)
-				.returning("java.lang.String");
+			.annotations(fieldAnnotations)
+			.modifiers(Modifier.PRIVATE)
+			.returning("java.lang.String");
 		test.addFieldDeclaration(field);
 		List<String> lines = writeSingleType(sourceCode, "com/example/Test.java");
 		assertThat(lines).containsExactly("package com.example;", "", "class Test {", "", "    @TestFiledAnnotation",
@@ -368,14 +368,14 @@ class JavaSourceCodeWriterTests {
 		methodAnnotations.addToList(ClassName.of("com.example.TestMethodAnnotation"));
 		methodAnnotations.addToList(ClassName.of("com.example.TestMethodAnnotation"));
 		JavaMethodDeclaration method = JavaMethodDeclaration.method("testMethod")
-				.annotations(methodAnnotations)
-				.returning("void")
-				.parameters()
-				.body(CodeBlock.of(""));
+			.annotations(methodAnnotations)
+			.returning("void")
+			.parameters()
+			.body(CodeBlock.of(""));
 		test.addMethodDeclaration(method);
 		List<String> lines = writeSingleType(sourceCode, "com/example/Test.java");
-		assertThat(lines).containsExactly("package com.example;", "", "class Test {", "",
-				"    @TestMethodAnnotation", "    @TestMethodAnnotation", "    void testMethod() {", "    }", "", "}");
+		assertThat(lines).containsExactly("package com.example;", "", "class Test {", "", "    @TestMethodAnnotation",
+				"    @TestMethodAnnotation", "    void testMethod() {", "    }", "", "}");
 	}
 
 	private List<String> writeSingleType(JavaSourceCode sourceCode, String location) throws IOException {

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriterTests.java
@@ -33,6 +33,7 @@ import io.spring.initializr.generator.language.Annotation.Builder;
 import io.spring.initializr.generator.language.ClassName;
 import io.spring.initializr.generator.language.CodeBlock;
 import io.spring.initializr.generator.language.Language;
+import io.spring.initializr.generator.language.MultipleAnnotationContainer;
 import io.spring.initializr.generator.language.Parameter;
 import io.spring.initializr.generator.language.SourceStructure;
 import org.junit.jupiter.api.Test;
@@ -325,6 +326,56 @@ class JavaSourceCodeWriterTests {
 		assertThat(lines).containsExactly("package com.example;", "", "import com.example.another.MyService;",
 				"import com.example.stereotype.Service;", "", "class Test {", "",
 				"    void something(@Service MyService service) {", "    }", "", "}");
+	}
+
+	@Test
+	void multipleAnnotationsOnClass() throws IOException {
+		JavaSourceCode sourceCode = new JavaSourceCode();
+		JavaCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		MultipleAnnotationContainer classAnnotations = new MultipleAnnotationContainer();
+		classAnnotations.addToList(ClassName.of("com.example.TestClassAnnotation"));
+		classAnnotations.addToList(ClassName.of("com.example.TestClassAnnotation"));
+        compilationUnit.createTypeDeclaration("Test", classAnnotations);
+        List<String> lines = writeSingleType(sourceCode, "com/example/Test.java");
+		assertThat(lines).containsExactly("package com.example;", "", "@TestClassAnnotation",
+				"@TestClassAnnotation", "class Test {", "", "}");
+	}
+
+	@Test
+	void multipleAnnotationsOnField() throws IOException {
+		JavaSourceCode sourceCode = new JavaSourceCode();
+		JavaCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		JavaTypeDeclaration test = compilationUnit.createTypeDeclaration("Test");
+		MultipleAnnotationContainer fieldAnnotations = new MultipleAnnotationContainer();
+		fieldAnnotations.addToList(ClassName.of("com.example.TestFiledAnnotation"));
+		fieldAnnotations.addToList(ClassName.of("com.example.TestFiledAnnotation"));
+		JavaFieldDeclaration field = JavaFieldDeclaration.field("testField")
+				.annotations(fieldAnnotations)
+				.modifiers(Modifier.PRIVATE)
+				.returning("java.lang.String");
+		test.addFieldDeclaration(field);
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.java");
+		assertThat(lines).containsExactly("package com.example;", "", "class Test {", "", "    @TestFiledAnnotation",
+				"    @TestFiledAnnotation", "    private String testField;", "", "}");
+	}
+
+	@Test
+	void multipleAnnotationsOnMethod() throws IOException {
+		JavaSourceCode sourceCode = new JavaSourceCode();
+		JavaCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		JavaTypeDeclaration test = compilationUnit.createTypeDeclaration("Test");
+		MultipleAnnotationContainer methodAnnotations = new MultipleAnnotationContainer();
+		methodAnnotations.addToList(ClassName.of("com.example.TestMethodAnnotation"));
+		methodAnnotations.addToList(ClassName.of("com.example.TestMethodAnnotation"));
+		JavaMethodDeclaration method = JavaMethodDeclaration.method("testMethod")
+				.annotations(methodAnnotations)
+				.returning("void")
+				.parameters()
+				.body(CodeBlock.of(""));
+		test.addMethodDeclaration(method);
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.java");
+		assertThat(lines).containsExactly("package com.example;", "", "class Test {", "",
+				"    @TestMethodAnnotation", "    @TestMethodAnnotation", "    void testMethod() {", "    }", "", "}");
 	}
 
 	private List<String> writeSingleType(JavaSourceCode sourceCode, String location) throws IOException {

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriterTests.java
@@ -32,6 +32,7 @@ import io.spring.initializr.generator.language.Annotation.Builder;
 import io.spring.initializr.generator.language.ClassName;
 import io.spring.initializr.generator.language.CodeBlock;
 import io.spring.initializr.generator.language.Language;
+import io.spring.initializr.generator.language.MultipleAnnotationContainer;
 import io.spring.initializr.generator.language.Parameter;
 import io.spring.initializr.generator.language.SourceStructure;
 import org.junit.jupiter.api.Test;
@@ -384,6 +385,54 @@ class KotlinSourceCodeWriterTests {
 		assertThat(lines).containsExactly("package com.example", "", "import com.example.another.MyService",
 				"import com.example.stereotype.Service", "", "class Test {", "",
 				"    fun something(@Service service: MyService) {", "    }", "", "}");
+	}
+
+	@Test
+	void multipleAnnotationsOnClass() throws IOException {
+		KotlinSourceCode sourceCode = new KotlinSourceCode();
+		KotlinCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		MultipleAnnotationContainer classAnnotations = new MultipleAnnotationContainer();
+		classAnnotations.addToList(ClassName.of("com.example.TestClassAnnotation"));
+		classAnnotations.addToList(ClassName.of("com.example.TestClassAnnotation"));
+		KotlinTypeDeclaration test = compilationUnit.createTypeDeclaration("Test", classAnnotations);
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.kt");
+		assertThat(lines).containsExactly("package com.example", "", "@TestClassAnnotation",
+				"@TestClassAnnotation", "class Test");
+	}
+
+	@Test
+	void multipleAnnotationsOnProperty() throws IOException {
+		KotlinSourceCode sourceCode = new KotlinSourceCode();
+		KotlinCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		KotlinTypeDeclaration test = compilationUnit.createTypeDeclaration("Test");
+		MultipleAnnotationContainer propertyAnnotations = new MultipleAnnotationContainer();
+		propertyAnnotations.addToList(ClassName.of("com.example.TestPropertyAnnotation"));
+		propertyAnnotations.addToList(ClassName.of("com.example.TestPropertyAnnotation"));
+		KotlinPropertyDeclaration property = KotlinPropertyDeclaration.val("testProperty")
+				.annotations(propertyAnnotations)
+				.returning("String").emptyValue();
+		test.addPropertyDeclaration(property);
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.kt");
+		assertThat(lines).containsExactly("package com.example", "", "class Test {", "",
+				"    @TestPropertyAnnotation", "    @TestPropertyAnnotation", "    val testProperty: String", "", "}");
+	}
+
+	@Test
+	void multipleAnnotationsOnFunction() throws IOException {
+		KotlinSourceCode sourceCode = new KotlinSourceCode();
+		KotlinCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		KotlinTypeDeclaration test = compilationUnit.createTypeDeclaration("Test");
+		MultipleAnnotationContainer functionAnnotations = new MultipleAnnotationContainer();
+		functionAnnotations.addToList(ClassName.of("com.example.TestFunctionAnnotation"));
+		functionAnnotations.addToList(ClassName.of("com.example.TestFunctionAnnotation"));
+		KotlinFunctionDeclaration function = KotlinFunctionDeclaration.function("testFunction")
+				.annotations(functionAnnotations)
+				.body(CodeBlock.of(""));
+		test.addFunctionDeclaration(function);
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.kt");
+		assertThat(lines).containsExactly("package com.example", "", "class Test {", "",
+				"    @TestFunctionAnnotation", "    @TestFunctionAnnotation", "    fun testFunction() {",
+				"    }", "", "}");
 	}
 
 	@Test

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriterTests.java
@@ -396,8 +396,8 @@ class KotlinSourceCodeWriterTests {
 		classAnnotations.addToList(ClassName.of("com.example.TestClassAnnotation"));
 		KotlinTypeDeclaration test = compilationUnit.createTypeDeclaration("Test", classAnnotations);
 		List<String> lines = writeSingleType(sourceCode, "com/example/Test.kt");
-		assertThat(lines).containsExactly("package com.example", "", "@TestClassAnnotation",
-				"@TestClassAnnotation", "class Test");
+		assertThat(lines).containsExactly("package com.example", "", "@TestClassAnnotation", "@TestClassAnnotation",
+				"class Test");
 	}
 
 	@Test
@@ -409,12 +409,13 @@ class KotlinSourceCodeWriterTests {
 		propertyAnnotations.addToList(ClassName.of("com.example.TestPropertyAnnotation"));
 		propertyAnnotations.addToList(ClassName.of("com.example.TestPropertyAnnotation"));
 		KotlinPropertyDeclaration property = KotlinPropertyDeclaration.val("testProperty")
-				.annotations(propertyAnnotations)
-				.returning("String").emptyValue();
+			.annotations(propertyAnnotations)
+			.returning("String")
+			.emptyValue();
 		test.addPropertyDeclaration(property);
 		List<String> lines = writeSingleType(sourceCode, "com/example/Test.kt");
-		assertThat(lines).containsExactly("package com.example", "", "class Test {", "",
-				"    @TestPropertyAnnotation", "    @TestPropertyAnnotation", "    val testProperty: String", "", "}");
+		assertThat(lines).containsExactly("package com.example", "", "class Test {", "", "    @TestPropertyAnnotation",
+				"    @TestPropertyAnnotation", "    val testProperty: String", "", "}");
 	}
 
 	@Test
@@ -426,13 +427,12 @@ class KotlinSourceCodeWriterTests {
 		functionAnnotations.addToList(ClassName.of("com.example.TestFunctionAnnotation"));
 		functionAnnotations.addToList(ClassName.of("com.example.TestFunctionAnnotation"));
 		KotlinFunctionDeclaration function = KotlinFunctionDeclaration.function("testFunction")
-				.annotations(functionAnnotations)
-				.body(CodeBlock.of(""));
+			.annotations(functionAnnotations)
+			.body(CodeBlock.of(""));
 		test.addFunctionDeclaration(function);
 		List<String> lines = writeSingleType(sourceCode, "com/example/Test.kt");
-		assertThat(lines).containsExactly("package com.example", "", "class Test {", "",
-				"    @TestFunctionAnnotation", "    @TestFunctionAnnotation", "    fun testFunction() {",
-				"    }", "", "}");
+		assertThat(lines).containsExactly("package com.example", "", "class Test {", "", "    @TestFunctionAnnotation",
+				"    @TestFunctionAnnotation", "    fun testFunction() {", "    }", "", "}");
 	}
 
 	@Test


### PR DESCRIPTION
Resolves issue #1624 by adding support for multiple annotations of the same type.

Key changes:
- Add `AnnotationHolder` interface to abstract how annotations are stored
- `AnnotationContainer` now implements `AnnotationHolder` for single-annotation scenarios
- Add `MultipleAnnotationContainer` that implements `AnnotationHolder` to support multiple annotations of the same type
- Update `Annotatable` interface to use `AnnotationHolder` instead of `AnnotationContainer`
- Allow choosing `AnnotationHolder` implementation when creating `Annotatable` implementations
- Fix `KotlinSourceCodeWriter#writeProperty` to correctly write annotations
- Add tests

---
Note: While unrelated to the current changes, I find the behavior of `AnnotationContainer#add` a bit unintuitive. Despite its name, the method either customizes the existing annotation or skips adding if one already exists. It might be worth considering replacing it with more explicit methods in the future.


Fixes gh-1624