### PR TITLE
Set description for generated Gradle projects

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfiguration.java
@@ -86,7 +86,9 @@ public class GradleProjectGenerationConfiguration {
 
 	@Bean
 	public BuildCustomizer<GradleBuild> defaultGradleBuildCustomizer(ProjectDescription description) {
-		return (build) -> build.settings().sourceCompatibility(description.getLanguage().jvmVersion());
+		return (build) -> build.settings()
+			.sourceCompatibility(description.getLanguage().jvmVersion())
+			.description(description.getDescription());
 	}
 
 	@Bean

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleKtsProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleKtsProjectGenerationConfigurationTests.java
@@ -190,4 +190,14 @@ class GradleKtsProjectGenerationConfigurationTests {
 			.containsSequence("tasks.withType<Test> {", "    useJUnitPlatform()", "}");
 	}
 
+	@Test
+	void descriptionIsWrittenWhenBuildingGradleProject() {
+		MutableProjectDescription description = new MutableProjectDescription();
+		description.setDescription("Test Project");
+		description.setPlatformVersion(Version.parse("2.4.0"));
+		description.setLanguage(new JavaLanguage());
+		ProjectStructure project = this.projectTester.generate(description);
+		assertThat(project).textFile("build.gradle.kts").contains("description = \"Test Project\"");
+	}
+
 }

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfigurationTests.java
@@ -213,4 +213,14 @@ class GradleProjectGenerationConfigurationTests {
 				(context) -> assertThat(context).hasSingleBean(GradleAnnotationProcessorScopeBuildCustomizer.class));
 	}
 
+	@Test
+	void descriptionIsWrittenWhenBuildingGradleProject() {
+		MutableProjectDescription description = new MutableProjectDescription();
+		description.setDescription("Test Project");
+		description.setPlatformVersion(Version.parse("2.4.0"));
+		description.setLanguage(new JavaLanguage());
+		ProjectStructure project = this.projectTester.generate(description);
+		assertThat(project).textFile("build.gradle").contains("description = 'Test Project'");
+	}
+
 }

--- a/initializr-generator-spring/src/test/resources/project/gradle/annotation-processor-dependency-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/annotation-processor-dependency-build.gradle.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/annotation-processor-dependency-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/annotation-processor-dependency-build.gradle.kts.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/bom-ordering-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/bom-ordering-build.gradle.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/bom-ordering-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/bom-ordering-build.gradle.kts.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/bom-property-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/bom-property-build.gradle.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/bom-property-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/bom-property-build.gradle.kts.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/compile-only-dependency-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/compile-only-dependency-build.gradle.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/compile-only-dependency-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/compile-only-dependency-build.gradle.kts.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/kotlin-java11-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/kotlin-java11-build.gradle.gen
@@ -7,6 +7,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/kotlin-java11-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/kotlin-java11-build.gradle.kts.gen
@@ -7,6 +7,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-build.gradle.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-build.gradle.kts.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/repositories-milestone-build.gradle.kts.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/version-override-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/version-override-build.gradle.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/gradle/version-override-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/version-override-build.gradle.kts.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/groovy/next/build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/groovy/next/build.gradle.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/groovy/next/build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/groovy/next/build.gradle.kts.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/groovy/standard/build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/groovy/standard/build.gradle.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/groovy/standard/build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/groovy/standard/build.gradle.kts.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/groovy/standard/war-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/groovy/standard/war-build.gradle.gen
@@ -7,6 +7,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/groovy/standard/war-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/groovy/standard/war-build.gradle.kts.gen
@@ -7,6 +7,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/java/standard/build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/java/standard/build.gradle.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/java/standard/build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/java/standard/build.gradle.kts.gen
@@ -6,6 +6,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/java/standard/war-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/java/standard/war-build.gradle.gen
@@ -7,6 +7,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/java/standard/war-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/java/standard/war-build.gradle.kts.gen
@@ -7,6 +7,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/kotlin/standard/build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/standard/build.gradle.gen
@@ -7,6 +7,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/kotlin/standard/build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/standard/build.gradle.kts.gen
@@ -7,6 +7,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/kotlin/standard/war-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/standard/war-build.gradle.gen
@@ -8,6 +8,7 @@ plugins {
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
 
 java {
 	toolchain {

--- a/initializr-generator-spring/src/test/resources/project/kotlin/standard/war-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/kotlin/standard/war-build.gradle.kts.gen
@@ -8,6 +8,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
 
 java {
 	toolchain {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildSettings.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildSettings.java
@@ -33,10 +33,13 @@ public class GradleBuildSettings extends BuildSettings {
 
 	private final List<PluginMapping> pluginMappings;
 
+	private final String description;
+
 	protected GradleBuildSettings(Builder builder) {
 		super(builder);
 		this.sourceCompatibility = builder.sourceCompatibility;
 		this.pluginMappings = new ArrayList<>(builder.pluginMappings);
+		this.description = builder.description;
 	}
 
 	/**
@@ -56,6 +59,14 @@ public class GradleBuildSettings extends BuildSettings {
 	}
 
 	/**
+	 * Return a human-readable description of the project.
+	 * @return the description of the project or {@code null}
+	 */
+	public String getDescription() {
+		return this.description;
+	}
+
+	/**
 	 * Builder for {@link GradleBuildSettings}.
 	 */
 	public static class Builder extends BuildSettings.Builder<Builder> {
@@ -63,6 +74,8 @@ public class GradleBuildSettings extends BuildSettings {
 		private String sourceCompatibility;
 
 		private final List<PluginMapping> pluginMappings = new ArrayList<>();
+
+		private String description;
 
 		/**
 		 * Set the java version compatibility to use when compiling Java source.
@@ -86,6 +99,16 @@ public class GradleBuildSettings extends BuildSettings {
 				throw new IllegalArgumentException("Mapping for plugin '" + id + "' must have a version");
 			}
 			this.pluginMappings.add(new PluginMapping(id, pluginDependency));
+			return this;
+		}
+
+		/**
+		 * Set a human-readable description of the project.
+		 * @param description the description of the project
+		 * @return this for method chaining
+		 */
+		public Builder description(String description) {
+			this.description = description;
 			return this;
 		}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
@@ -67,6 +67,7 @@ public abstract class GradleBuildWriter {
 		writePlugins(writer, build);
 		writeProperty(writer, "group", settings.getGroup());
 		writeProperty(writer, "version", settings.getVersion());
+		writeProperty(writer, "description", settings.getDescription());
 		writer.println();
 		writeJavaSourceCompatibility(writer, settings);
 		writeToolchain(writer, settings);

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
@@ -611,6 +611,14 @@ class GroovyDslGradleBuildWriterTests extends GradleBuildWriterTests {
 				}""");
 	}
 
+	@Test
+	void gradleBuildWithDescription() {
+		GradleBuild build = new GradleBuild();
+		build.settings().description("Demo for test");
+		String written = write(build);
+		assertThat(written).contains("description = 'Demo for test'");
+	}
+
 	protected String write(GradleBuild build) {
 		return write(new GroovyDslGradleBuildWriter(), build);
 	}

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriterTests.java
@@ -620,6 +620,14 @@ class KotlinDslGradleBuildWriterTests extends GradleBuildWriterTests {
 				}""");
 	}
 
+	@Test
+	void gradleBuildWithDescription() {
+		GradleBuild build = new GradleBuild();
+		build.settings().description("Demo for test");
+		String written = write(build);
+		assertThat(written).contains("description = \"Demo for test\"");
+	}
+
 	protected String write(GradleBuild build) {
 		return write(new KotlinDslGradleBuildWriter(), build);
 	}


### PR DESCRIPTION
### Changes
- Add `description` field to `GradleBuildSettings`
- Update `GradleBuildWriter` to write `description` gradle property
- Configure `defaultGradleBuildCustomizer` to set `GradleBuildSettings#description`
- Fix broken compliance tests using files ending with `build.gradle.gen` or `build.gradle.kts.gen` by adding expected `description` gradle property
---
Fixes gh-1673