### PR TITLE
ConfigurationFileFormat isn't copied in the description copy and is missing in the diff

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/project/MutableProjectDescription.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/project/MutableProjectDescription.java
@@ -79,6 +79,7 @@ public class MutableProjectDescription implements ProjectDescription {
 		this.buildSystem = source.getBuildSystem();
 		this.packaging = source.getPackaging();
 		this.language = source.getLanguage();
+		this.configurationFileFormat = source.getConfigurationFileFormat();
 		this.requestedDependencies.putAll(source.getRequestedDependencies());
 		this.groupId = source.getGroupId();
 		this.artifactId = source.getArtifactId();

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/project/ProjectDescriptionDiff.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/project/ProjectDescriptionDiff.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 
 import io.spring.initializr.generator.buildsystem.BuildSystem;
+import io.spring.initializr.generator.configuration.format.ConfigurationFileFormat;
 import io.spring.initializr.generator.language.Language;
 import io.spring.initializr.generator.packaging.Packaging;
 import io.spring.initializr.generator.version.Version;
@@ -97,6 +98,19 @@ public class ProjectDescriptionDiff {
 	public void ifLanguageChanged(ProjectDescription current, BiConsumer<Language, Language> consumer) {
 		if (!Objects.equals(this.original.getLanguage(), current.getLanguage())) {
 			consumer.accept(this.original.getLanguage(), current.getLanguage());
+		}
+	}
+
+	/**
+	 * Calls the specified consumer if the {@code configurationFileFormat} is different on
+	 * the original source project description than the specified project description.
+	 * @param current the description to test against
+	 * @param consumer to call if the property has changed
+	 */
+	public void ifConfigurationFileFormatChanged(ProjectDescription current,
+			BiConsumer<ConfigurationFileFormat, ConfigurationFileFormat> consumer) {
+		if (!Objects.equals(this.original.getConfigurationFileFormat(), current.getConfigurationFileFormat())) {
+			consumer.accept(this.original.getConfigurationFileFormat(), current.getConfigurationFileFormat());
 		}
 	}
 

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/project/ProjectDescriptionDiffTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/project/ProjectDescriptionDiffTests.java
@@ -22,6 +22,9 @@ import java.util.function.Consumer;
 import io.spring.initializr.generator.buildsystem.BuildSystem;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
+import io.spring.initializr.generator.configuration.format.ConfigurationFileFormat;
+import io.spring.initializr.generator.configuration.format.properties.PropertiesFormat;
+import io.spring.initializr.generator.configuration.format.yaml.YamlFormat;
 import io.spring.initializr.generator.language.Language;
 import io.spring.initializr.generator.language.java.JavaLanguage;
 import io.spring.initializr.generator.packaging.Packaging;
@@ -58,6 +61,8 @@ class ProjectDescriptionDiffTests {
 		diff.ifBuildSystemChanged(description, (original, actual) -> fail("Values should not have changed"));
 		diff.ifPackagingChanged(description, (original, actual) -> fail("Values should not have changed"));
 		diff.ifLanguageChanged(description, (original, actual) -> fail("Values should not have changed"));
+		diff.ifConfigurationFileFormatChanged(description,
+				(original, actual) -> fail("Values should not have changed"));
 		diff.ifGroupIdChanged(description, (original, actual) -> fail("Values should not have changed"));
 		diff.ifArtifactIdChanged(description, (original, actual) -> fail("Values should not have changed"));
 		diff.ifVersionChanged(description, (original, actual) -> fail("Values should not have changed"));
@@ -110,6 +115,17 @@ class ProjectDescriptionDiffTests {
 		ProjectDescriptionDiff diff = new ProjectDescriptionDiff(description);
 		description.setLanguage(actual);
 		validateConsumer(original, actual, (consumer) -> diff.ifLanguageChanged(description, consumer));
+	}
+
+	@Test
+	void projectDescriptionDiffWithModifiedConfigurationFileFormatInvokesConsumer() {
+		ConfigurationFileFormat original = ConfigurationFileFormat.forId(YamlFormat.ID);
+		ConfigurationFileFormat actual = ConfigurationFileFormat.forId(PropertiesFormat.ID);
+		MutableProjectDescription description = new MutableProjectDescription();
+		description.setConfigurationFileFormat(original);
+		ProjectDescriptionDiff diff = new ProjectDescriptionDiff(description);
+		description.setConfigurationFileFormat(actual);
+		validateConsumer(original, actual, (consumer) -> diff.ifConfigurationFileFormatChanged(description, consumer));
 	}
 
 	@Test


### PR DESCRIPTION
The `ConfigurationFileFormat` introduced in gh-1682 is not handled in the copy constructor of `MutableProjectDescription` and in `ProjectDescriptionDiff`.

This PR adds the missing logic along with the corresponding tests.
