### PR TITLE
Update documentation and tests for the v2.3 metadata format

### DIFF
--- a/initializr-docs/src/main/asciidoc/configuration-guide.adoc
+++ b/initializr-docs/src/main/asciidoc/configuration-guide.adoc
@@ -53,7 +53,7 @@ generate assets based on available candidates.
 A project is defined by `ProjectDescription` which consists of the following properties:
 
 * Basic coordinates such as `groupId`, `artifactId`, `name`, `description`
-* The `BuildSystem` and `Packaging`
+* The `BuildSystem`, `Packaging` and `ConfigurationFileFormat`
 * The JVM `Language`
 * The requested dependencies, indexed by ID
 * A platform `Version` used by the project. This can be used to tune available
@@ -340,6 +340,25 @@ The available packagings are also configurable that way:
 NOTE: `Jar` and `War` packaging types are available out-of-the-box. For additional
 packaging formats, you need to implement the `Packaging` abstraction and provide a
 `PackagingFactory` that corresponds to it.
+
+Configuration file formats are configurable in the same way as above:
+
+[source,yaml,indent=0]
+----
+    initializr:
+      configuration-file-formats:
+        - name: Properties
+          id: properties
+          default: true
+        - name: YAML
+          id: yaml
+          default: false
+----
+
+NOTE: `Properties` and `YAML` configuration file formats are supported out-of-the-box.
+If you need to support additional configuration formats, you must implement the
+`ConfigurationFileFormat` abstraction and provide a `ConfigurationFileFormatFactory` that can
+generate it.
 
 
 

--- a/initializr-docs/src/main/asciidoc/metadata-format.adoc
+++ b/initializr-docs/src/main/asciidoc/metadata-format.adoc
@@ -14,7 +14,7 @@ sent to the service. A good structure for a user agent is `clientId/clientVersio
 == Service Capabilities
 Any third party client can retrieve the capabilities of the service by issuing a
 `GET` on the root URL using the following `Accept` header:
-`application/vnd.initializr.v2.2+json`. Please note that the metadata may evolve in a
+`application/vnd.initializr.v2.3+json`. Please note that the metadata may evolve in a
 non backward compatible way in the future so adding this header ensures the service
 returns the metadata format you expect.
 
@@ -22,7 +22,8 @@ The following versions are supported:
 
 * `v2` initial version, with support of V1 version format only
 * `v2.1` support compatibility range and dependencies links
-* `v2.2` (current) support for V1 and V2 version formats.
+* `v2.2` support for V1 and V2 version formats.
+* `v2.3` (current) support for selecting the configuration file format.
 
 This is an example output for a service running at `start.example.com`:
 
@@ -45,6 +46,8 @@ component responsible to generate the project (for instance, generate an executa
 _jar_ project).
 * Java version: the supported java versions
 * Language: the language to use (e.g. Java)
+* Configuration file format: the supported configuration formats for the generated
+project (e.g. `application.properties`, `application.yml`)
 * Boot version: the platform version to use
 * Additional basic information such as: `groupId`, `artifactId`,  `version`, `name`,
 `description` and `packageName`.
@@ -165,6 +168,14 @@ The `language` element provides a list of possible languages for the project:
 
 .Language example
 include::{snippets}/metadataWithCurrentAcceptHeader/response-fields/language.values.0.adoc[]
+
+
+
+=== Configuration file format
+The `configurationFileFormat` element provides a list of possible configuration file formats for the project:
+
+.Configuration file format example
+include::{snippets}/metadataWithCurrentAcceptHeader/response-fields/configurationFileFormat.values.0.adoc[]
 
 
 

--- a/initializr-web/src/test/java/io/spring/initializr/web/AbstractInitializrIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/AbstractInitializrIntegrationTests.java
@@ -72,7 +72,7 @@ public abstract class AbstractInitializrIntegrationTests {
 
 	protected static final MediaType DEFAULT_METADATA_MEDIA_TYPE = InitializrMetadataVersion.V2_1.getMediaType();
 
-	protected static final MediaType CURRENT_METADATA_MEDIA_TYPE = InitializrMetadataVersion.V2_2.getMediaType();
+	protected static final MediaType CURRENT_METADATA_MEDIA_TYPE = InitializrMetadataVersion.V2_3.getMediaType();
 
 	private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -133,7 +133,7 @@ public abstract class AbstractInitializrIntegrationTests {
 
 	protected void validateCurrentMetadata(ResponseEntity<String> response) {
 		validateContentType(response, CURRENT_METADATA_MEDIA_TYPE);
-		validateMetadata(response.getBody(), "2.2.0");
+		validateMetadata(response.getBody(), "2.3.0");
 	}
 
 	protected void validateDefaultMetadata(String json) {

--- a/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerCustomDefaultsIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerCustomDefaultsIntegrationTests.java
@@ -20,6 +20,7 @@ import io.spring.initializr.metadata.InitializrMetadata;
 import io.spring.initializr.metadata.InitializrMetadataBuilder;
 import io.spring.initializr.metadata.InitializrMetadataProvider;
 import io.spring.initializr.web.AbstractFullStackInitializrIntegrationTests;
+import io.spring.initializr.web.mapper.InitializrMetadataVersion;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -100,7 +101,13 @@ class ProjectMetadataControllerCustomDefaultsIntegrationTests extends AbstractFu
 
 	@Test
 	void dependenciesV22WithNoBootVersion() throws JSONException {
-		validateDependenciesMetadata("application/vnd.initializr.v2.2+json", CURRENT_METADATA_MEDIA_TYPE);
+		validateDependenciesMetadata("application/vnd.initializr.v2.2+json",
+				InitializrMetadataVersion.V2_2.getMediaType());
+	}
+
+	@Test
+	void dependenciesV23WithNoBootVersion() throws JSONException {
+		validateDependenciesMetadata("application/vnd.initializr.v2.3+json", CURRENT_METADATA_MEDIA_TYPE);
 	}
 
 	private void validateDependenciesMetadata(String acceptHeader, MediaType expectedMediaType) throws JSONException {

--- a/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerIntegrationTests.java
@@ -96,15 +96,13 @@ class ProjectMetadataControllerIntegrationTests extends AbstractInitializrContro
 				"javaVersion.values[0]", "packaging.values[0]", "bootVersion.values[0]", "language.values[0]");
 		ResponseEntity<String> response = invokeHome(null, "application/vnd.initializr.v2.2+json");
 		assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG)).isNotNull();
-		validateContentType(response, AbstractInitializrIntegrationTests.CURRENT_METADATA_MEDIA_TYPE);
-		validateMetadata(response.getBody(), "2.2.0");
+		validateCurrentMetadata(response);
 	}
 
 	@Test
 	void metadataWithSeveralVersionsAndQualifier() {
 		ResponseEntity<String> response = invokeHome(null, "application/vnd.initializr.v2+json;q=0.9",
 				"application/vnd.initializr.v2.2+json");
-		validateContentType(response, AbstractInitializrIntegrationTests.CURRENT_METADATA_MEDIA_TYPE);
 		validateCurrentMetadata(response);
 	}
 
@@ -112,7 +110,6 @@ class ProjectMetadataControllerIntegrationTests extends AbstractInitializrContro
 	void metadataWithSeveralVersionAndPreferenceOnInvalidVersion() {
 		ResponseEntity<String> response = invokeHome(null, "application/vnd.initializr.v5.4+json",
 				"application/vnd.initializr.v2.2+json;q=0.9");
-		validateContentType(response, AbstractInitializrIntegrationTests.CURRENT_METADATA_MEDIA_TYPE);
 		validateCurrentMetadata(response);
 	}
 

--- a/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerIntegrationTests.java
@@ -93,8 +93,9 @@ class ProjectMetadataControllerIntegrationTests extends AbstractInitializrContro
 	@Test
 	void metadataWithCurrentAcceptHeader() {
 		getRequests().setFields("_links.maven-project", "dependencies.values[0]", "type.values[0]",
-				"javaVersion.values[0]", "packaging.values[0]", "bootVersion.values[0]", "language.values[0]");
-		ResponseEntity<String> response = invokeHome(null, "application/vnd.initializr.v2.2+json");
+				"javaVersion.values[0]", "packaging.values[0]", "bootVersion.values[0]", "language.values[0]",
+				"configurationFileFormat.values[0]");
+		ResponseEntity<String> response = invokeHome(null, "application/vnd.initializr.v2.3+json");
 		assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG)).isNotNull();
 		validateCurrentMetadata(response);
 	}
@@ -102,14 +103,14 @@ class ProjectMetadataControllerIntegrationTests extends AbstractInitializrContro
 	@Test
 	void metadataWithSeveralVersionsAndQualifier() {
 		ResponseEntity<String> response = invokeHome(null, "application/vnd.initializr.v2+json;q=0.9",
-				"application/vnd.initializr.v2.2+json");
+				"application/vnd.initializr.v2.3+json");
 		validateCurrentMetadata(response);
 	}
 
 	@Test
 	void metadataWithSeveralVersionAndPreferenceOnInvalidVersion() {
 		ResponseEntity<String> response = invokeHome(null, "application/vnd.initializr.v5.4+json",
-				"application/vnd.initializr.v2.2+json;q=0.9");
+				"application/vnd.initializr.v2.3+json;q=0.9");
 		validateCurrentMetadata(response);
 	}
 


### PR DESCRIPTION
### Changes
- Update documentation and tests for v2.3 metadata format.
- Remove redundant `validateContentType()` in `ProjectMetadataControllerIntegrationTests` - it's followed immediately by `validateCurrentMetadata()` which includes the same validation.

---
Sorry for another follow-up PR. I found leftover documentation tasks from gh-1682.