### PR TITLE
Creating a Spring Boot 4.x Kotlin project with JSON support still uses Jackson 2's Kotlin module

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJacksonBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJacksonBuildCustomizer.java
@@ -22,6 +22,8 @@ import io.spring.initializr.generator.language.kotlin.KotlinLanguage;
 import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 import io.spring.initializr.generator.spring.build.BuildMetadataResolver;
+import io.spring.initializr.generator.version.VersionParser;
+import io.spring.initializr.generator.version.VersionRange;
 import io.spring.initializr.metadata.InitializrMetadata;
 
 import org.springframework.util.ClassUtils;
@@ -39,6 +41,8 @@ public class KotlinJacksonBuildCustomizer implements BuildCustomizer<Build> {
 
 	private final ProjectDescription description;
 
+	private static final VersionRange SPRING_BOOT_4_OR_LATER = VersionParser.DEFAULT.parseRange("4.0.0");
+
 	public KotlinJacksonBuildCustomizer(InitializrMetadata metadata, ProjectDescription description) {
 		this.buildMetadataResolver = new BuildMetadataResolver(metadata, description.getPlatformVersion());
 		this.description = description;
@@ -48,9 +52,10 @@ public class KotlinJacksonBuildCustomizer implements BuildCustomizer<Build> {
 	public void customize(Build build) {
 		boolean isKotlin = ClassUtils.isAssignableValue(KotlinLanguage.class, this.description.getLanguage());
 		if (this.buildMetadataResolver.hasFacet(build, "json") && isKotlin) {
+			String groupId = SPRING_BOOT_4_OR_LATER.match(this.description.getPlatformVersion())
+					? "tools.jackson.module" : "com.fasterxml.jackson.module";
 			build.dependencies()
-				.add("jackson-module-kotlin", "com.fasterxml.jackson.module", "jackson-module-kotlin",
-						DependencyScope.COMPILE);
+				.add("jackson-module-kotlin", groupId, "jackson-module-kotlin", DependencyScope.COMPILE);
 		}
 	}
 

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJacksonBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinJacksonBuildCustomizerTests.java
@@ -41,16 +41,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 class KotlinJacksonBuildCustomizerTests {
 
 	@Test
-	void customizeWhenJsonFacetPresentShouldAddJacksonKotlinModule() {
+	void customizeWhenJsonFacetPresentShouldAddJackson2KotlinModuleBeforeSpringBoot4() {
 		Dependency dependency = Dependency.withId("foo");
 		dependency.setFacets(Collections.singletonList("json"));
 		MutableProjectDescription description = new MutableProjectDescription();
 		description.setLanguage(new KotlinLanguage());
+		description.setPlatformVersion(Version.parse("3.5.2"));
 		MavenBuild build = getCustomizedBuild(dependency, description);
 		io.spring.initializr.generator.buildsystem.Dependency jacksonKotlin = build.dependencies()
 			.get("jackson-module-kotlin");
 		assertThat(jacksonKotlin.getArtifactId()).isEqualTo("jackson-module-kotlin");
 		assertThat(jacksonKotlin.getGroupId()).isEqualTo("com.fasterxml.jackson.module");
+	}
+
+	@Test
+	void customizeWhenJsonFacetPresentShouldAddJackson3KotlinModuleStrtingAtSpringBoot4() {
+		Dependency dependency = Dependency.withId("foo");
+		dependency.setFacets(Collections.singletonList("json"));
+		MutableProjectDescription description = new MutableProjectDescription();
+		description.setLanguage(new KotlinLanguage());
+		description.setPlatformVersion(Version.parse("4.0.0"));
+		MavenBuild build = getCustomizedBuild(dependency, description);
+		io.spring.initializr.generator.buildsystem.Dependency jacksonKotlin = build.dependencies()
+			.get("jackson-module-kotlin");
+		assertThat(jacksonKotlin.getArtifactId()).isEqualTo("jackson-module-kotlin");
+		assertThat(jacksonKotlin.getGroupId()).isEqualTo("tools.jackson.module");
 	}
 
 	@Test

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/kotlin/KotlinProjectGenerationConfigurationTests.java
@@ -122,12 +122,24 @@ class KotlinProjectGenerationConfigurationTests {
 	}
 
 	@Test
-	void jacksonKotlinModuleShouldBeAddedWhenJsonFacetPresent() {
+	void jackson2KotlinModuleShouldBeAddedWhenJsonFacetPresentBeforeSpringBoot4() {
 		MutableProjectDescription description = new MutableProjectDescription();
+		description.setPlatformVersion(Version.parse("3.5.2"));
 		description.addDependency("foo", Dependency.withCoordinates("com.example", "foo"));
 		ProjectStructure project = this.projectTester.generate(description);
 		assertThat(project).textFile("pom.xml")
 			.contains("        <dependency>", "            <groupId>com.fasterxml.jackson.module</groupId>",
+					"            <artifactId>jackson-module-kotlin</artifactId>", "        </dependency>");
+	}
+
+	@Test
+	void jackson3KotlinModuleShouldBeAddedWhenJsonFacetPresentStartingAtSpringBoot4() {
+		MutableProjectDescription description = new MutableProjectDescription();
+		description.setPlatformVersion(Version.parse("4.0.0"));
+		description.addDependency("foo", Dependency.withCoordinates("com.example", "foo"));
+		ProjectStructure project = this.projectTester.generate(description);
+		assertThat(project).textFile("pom.xml")
+			.contains("        <dependency>", "            <groupId>tools.jackson.module</groupId>",
 					"            <artifactId>jackson-module-kotlin</artifactId>", "        </dependency>");
 	}
 


### PR DESCRIPTION
Starting at Spring Boot 4, the Jackson Kotlin module added to the dependencies of the project should use the `tools.jackson.module` groupId rather than `com.fasterxml.jackson.module`.