### PR TITLE
Absence of services creates empty compose file leading to application startup failure

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/container/docker/compose/ComposeFileWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/container/docker/compose/ComposeFileWriter.java
@@ -40,6 +40,10 @@ public class ComposeFileWriter {
 	 * @param compose the compose file to write
 	 */
 	public void writeTo(IndentingWriter writer, ComposeFile compose) {
+		if (compose.services().isEmpty()) {
+			writer.println("services: {}");
+			return;
+		}
 		writer.println("services:");
 		compose.services()
 			.values()

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/container/docker/compose/ComposeFileWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/container/docker/compose/ComposeFileWriterTests.java
@@ -91,6 +91,14 @@ class ComposeFileWriterTests {
 				""");
 	}
 
+	@Test
+	void servicesWithNoEntriesWrittenAsEmptyMap() {
+		ComposeFile file = new ComposeFile();
+		assertThat(write(file)).isEqualToIgnoringNewLines("""
+				services: {}
+				""");
+	}
+
 	private Consumer<Builder> withSuffix(int suffix) {
 		return (builder) -> builder.image("image-" + suffix).imageTag("image-tag-" + suffix);
 	}


### PR DESCRIPTION
Fixes #1734 

The fix here is to generate the compose file with an empty list of services. This solves the issue of startup which we were seeing in the original issue while keeping the `docker-compose` support for future extensions. 