### PR TITLE
Fix deprecated RequestTrace usage in DefaultMavenVersionResolver

### DIFF
--- a/initializr-version-resolver/src/main/java/io/spring/initializr/versionresolver/DefaultMavenVersionResolver.java
+++ b/initializr-version-resolver/src/main/java/io/spring/initializr/versionresolver/DefaultMavenVersionResolver.java
@@ -149,7 +149,7 @@ class DefaultMavenVersionResolver implements MavenVersionResolver {
 	private Model buildEffectiveModel(String groupId, String artifactId, String version) {
 		try {
 			ArtifactResult bom = resolvePom(groupId, artifactId, version);
-			RequestTrace requestTrace = new RequestTrace(null);
+			RequestTrace requestTrace = RequestTrace.newChild(null, null);
 
 			ModelResolver modelResolver = new ProjectModelResolver(this.repositorySystemSession, requestTrace,
 					this.repositorySystem, this.remoteRepositoryManager, repositories,


### PR DESCRIPTION
This change replaces direct RequestTrace constructor usage with the supported static factory method, addressing the deprecation noted in #1515.

Fixes #1515 