### PR TITLE
Replace Collectors.toList() with Stream.toList()

### DIFF
--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/DependenciesCapability.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/DependenciesCapability.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.spring.initializr.generator.version.VersionParser;
@@ -65,8 +64,7 @@ public class DependenciesCapability extends ServiceCapability<List<DependencyGro
 	 * @return all dependencies
 	 */
 	public Collection<Dependency> getAll() {
-		return Collections
-			.unmodifiableCollection(this.indexedDependencies.values().stream().distinct().collect(Collectors.toList()));
+		return Collections.unmodifiableCollection(this.indexedDependencies.values().stream().distinct().toList());
 	}
 
 	public void validate() {

--- a/initializr-web/src/main/java/io/spring/initializr/web/mapper/InitializrMetadataV2JsonMapper.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/mapper/InitializrMetadataV2JsonMapper.java
@@ -18,7 +18,6 @@ package io.spring.initializr.web.mapper;
 
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -136,7 +135,7 @@ public class InitializrMetadataV2JsonMapper implements InitializrMetadataJsonMap
 		ObjectNode dependencies = nodeFactory.objectNode();
 		dependencies.put("type", capability.getType().getName());
 		ArrayNode values = nodeFactory.arrayNode();
-		values.addAll(capability.getContent().stream().map(this::mapDependencyGroup).collect(Collectors.toList()));
+		values.addAll(capability.getContent().stream().map(this::mapDependencyGroup).toList());
 		dependencies.set("values", values);
 		parent.set(capability.getId(), dependencies);
 	}
@@ -149,7 +148,7 @@ public class InitializrMetadataV2JsonMapper implements InitializrMetadataJsonMap
 			type.put("default", defaultType.getId());
 		}
 		ArrayNode values = nodeFactory.arrayNode();
-		values.addAll(capability.getContent().stream().map(this::mapType).collect(Collectors.toList()));
+		values.addAll(capability.getContent().stream().map(this::mapType).toList());
 		type.set("values", values);
 		parent.set("type", type);
 	}
@@ -181,7 +180,7 @@ public class InitializrMetadataV2JsonMapper implements InitializrMetadataJsonMap
 			single.put("default", defaultMapper.apply(defaultType.getId()));
 		}
 		ArrayNode values = nodeFactory.arrayNode();
-		values.addAll(capability.getContent().stream().map(valueMapper).collect(Collectors.toList()));
+		values.addAll(capability.getContent().stream().map(valueMapper).toList());
 		single.set("values", values);
 		parent.set(capability.getId(), single);
 	}


### PR DESCRIPTION
Title:
  Replace Collectors.toList() with Stream.toList()

  Description:
  ## Summary
  Modernize stream collection operations by replacing `Collectors.toList()` with `Stream.toList()` introduced in Java 16.

  ## Changes
  - `InitializrMetadataV2JsonMapper.java`: 3 occurrences
  - `DependenciesCapability.java`: 1 occurrence
  - Removed unused `Collectors` import statements

  ## Motivation
  1. **Conciseness**: `stream.toList()` is shorter and more readable
  2. **Performance**: Avoids creating an intermediate Collector object
  3. **Immutability**: `toList()` returns an unmodifiable list, which aligns with existing usage patterns
  4. **Modern Java**: Aligns with Java 16+ idioms since the project requires Java 17