### PR TITLE
Replace Collectors.toList() with Stream.toList()

### DIFF
--- a/initializr-actuator/src/main/java/io/spring/initializr/actuate/stat/ProjectRequestDocumentFactory.java
+++ b/initializr-actuator/src/main/java/io/spring/initializr/actuate/stat/ProjectRequestDocumentFactory.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import io.spring.initializr.actuate.stat.ProjectRequestDocument.ClientInformation;
 import io.spring.initializr.actuate.stat.ProjectRequestDocument.DependencyInformation;
@@ -90,11 +89,11 @@ public class ProjectRequestDocumentFactory {
 		List<String> dependencies = new ArrayList<>(request.getDependencies());
 		List<String> validDependencies = dependencies.stream()
 			.filter((id) -> metadata.getDependencies().get(id) != null)
-			.collect(Collectors.toList());
+			.toList();
 		document.setDependencies(new DependencyInformation(validDependencies));
 		List<String> invalidDependencies = dependencies.stream()
 			.filter((id) -> (!validDependencies.contains(id)))
-			.collect(Collectors.toList());
+			.toList();
 		if (!invalidDependencies.isEmpty()) {
 			document.triggerError().triggerInvalidDependencies(invalidDependencies);
 		}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfiguration.java
@@ -17,7 +17,6 @@
 package io.spring.initializr.generator.spring.build.gradle;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.spring.initializr.generator.buildsystem.BuildItemResolver;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
@@ -71,8 +70,7 @@ public class GradleProjectGenerationConfiguration {
 	@Bean
 	public GradleBuild gradleBuild(ObjectProvider<BuildItemResolver> buildItemResolver,
 			ObjectProvider<BuildCustomizer<?>> buildCustomizers) {
-		return createGradleBuild(buildItemResolver.getIfAvailable(),
-				buildCustomizers.orderedStream().collect(Collectors.toList()));
+		return createGradleBuild(buildItemResolver.getIfAvailable(), buildCustomizers.orderedStream().toList());
 	}
 
 	@SuppressWarnings("unchecked")

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/maven/MavenProjectGenerationConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/maven/MavenProjectGenerationConfiguration.java
@@ -17,7 +17,6 @@
 package io.spring.initializr.generator.spring.build.maven;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.spring.initializr.generator.buildsystem.BuildItemResolver;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
@@ -59,8 +58,7 @@ public class MavenProjectGenerationConfiguration {
 	@Bean
 	public MavenBuild mavenBuild(ObjectProvider<BuildItemResolver> buildItemResolver,
 			ObjectProvider<BuildCustomizer<?>> buildCustomizers) {
-		return createBuild(buildItemResolver.getIfAvailable(),
-				buildCustomizers.orderedStream().collect(Collectors.toList()));
+		return createBuild(buildItemResolver.getIfAvailable(), buildCustomizers.orderedStream().toList());
 	}
 
 	@SuppressWarnings("unchecked")

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/MainSourceCodeProjectContributor.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/MainSourceCodeProjectContributor.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import io.spring.initializr.generator.language.CompilationUnit;
 import io.spring.initializr.generator.language.SourceCode;
@@ -84,8 +83,7 @@ public class MainSourceCodeProjectContributor<T extends TypeDeclaration, C exten
 
 	@SuppressWarnings("unchecked")
 	private void customizeMainApplicationType(T mainApplicationType) {
-		List<MainApplicationTypeCustomizer<?>> customizers = this.mainTypeCustomizers.orderedStream()
-			.collect(Collectors.toList());
+		List<MainApplicationTypeCustomizer<?>> customizers = this.mainTypeCustomizers.orderedStream().toList();
 		LambdaSafe.callbacks(MainApplicationTypeCustomizer.class, customizers, mainApplicationType)
 			.invoke((customizer) -> customizer.customize(mainApplicationType));
 	}
@@ -93,15 +91,14 @@ public class MainSourceCodeProjectContributor<T extends TypeDeclaration, C exten
 	@SuppressWarnings("unchecked")
 	private void customizeMainCompilationUnit(C compilationUnit) {
 		List<MainCompilationUnitCustomizer<?, ?>> customizers = this.mainCompilationUnitCustomizers.orderedStream()
-			.collect(Collectors.toList());
+			.toList();
 		LambdaSafe.callbacks(MainCompilationUnitCustomizer.class, customizers, compilationUnit)
 			.invoke((customizer) -> customizer.customize(compilationUnit));
 	}
 
 	@SuppressWarnings("unchecked")
 	private void customizeMainSourceCode(S sourceCode) {
-		List<MainSourceCodeCustomizer<?, ?, ?>> customizers = this.mainSourceCodeCustomizers.orderedStream()
-			.collect(Collectors.toList());
+		List<MainSourceCodeCustomizer<?, ?, ?>> customizers = this.mainSourceCodeCustomizers.orderedStream().toList();
 		LambdaSafe.callbacks(MainSourceCodeCustomizer.class, customizers, sourceCode)
 			.invoke((customizer) -> customizer.customize(sourceCode));
 	}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/ServletInitializerContributor.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/ServletInitializerContributor.java
@@ -17,7 +17,6 @@
 package io.spring.initializr.generator.spring.code;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.spring.initializr.generator.language.CompilationUnit;
 import io.spring.initializr.generator.language.SourceCode;
@@ -59,8 +58,7 @@ class ServletInitializerContributor implements
 
 	@SuppressWarnings("unchecked")
 	private void customizeServletInitializer(TypeDeclaration servletInitializer) {
-		List<ServletInitializerCustomizer<?>> customizers = this.servletInitializerCustomizers.orderedStream()
-			.collect(Collectors.toList());
+		List<ServletInitializerCustomizer<?>> customizers = this.servletInitializerCustomizers.orderedStream().toList();
 		LambdaSafe.callbacks(ServletInitializerCustomizer.class, customizers, servletInitializer)
 			.invoke((customizer) -> customizer.customize(servletInitializer));
 	}

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/TestSourceCodeProjectContributor.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/code/TestSourceCodeProjectContributor.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import io.spring.initializr.generator.language.CompilationUnit;
 import io.spring.initializr.generator.language.SourceCode;
@@ -80,15 +79,14 @@ public class TestSourceCodeProjectContributor<T extends TypeDeclaration, C exten
 	@SuppressWarnings("unchecked")
 	private void customizeTestApplicationType(TypeDeclaration testApplicationType) {
 		List<TestApplicationTypeCustomizer<?>> customizers = this.testApplicationTypeCustomizers.orderedStream()
-			.collect(Collectors.toList());
+			.toList();
 		LambdaSafe.callbacks(TestApplicationTypeCustomizer.class, customizers, testApplicationType)
 			.invoke((customizer) -> customizer.customize(testApplicationType));
 	}
 
 	@SuppressWarnings("unchecked")
 	private void customizeTestSourceCode(S sourceCode) {
-		List<TestSourceCodeCustomizer<?, ?, ?>> customizers = this.testSourceCodeCustomizers.orderedStream()
-			.collect(Collectors.toList());
+		List<TestSourceCodeCustomizer<?, ?, ?>> customizers = this.testSourceCodeCustomizers.orderedStream().toList();
 		LambdaSafe.callbacks(TestSourceCodeCustomizer.class, customizers, sourceCode)
 			.invoke((customizer) -> customizer.customize(sourceCode));
 	}

--- a/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/project/ProjectAssetTester.java
+++ b/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/project/ProjectAssetTester.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import io.spring.initializr.generator.project.MutableProjectDescription;
 import io.spring.initializr.generator.project.ProjectAssetGenerator;
@@ -122,7 +121,7 @@ public class ProjectAssetTester extends AbstractProjectGenerationTester<ProjectA
 				.createProjectDirectory(context.getBean(ProjectDescription.class));
 			List<ProjectContributor> projectContributors = context.getBeanProvider(ProjectContributor.class)
 				.orderedStream()
-				.collect(Collectors.toList());
+				.toList();
 			for (ProjectContributor projectContributor : projectContributors) {
 				projectContributor.contribute(projectDirectory);
 			}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
@@ -101,7 +101,7 @@ public abstract class GradleBuildWriter {
 			.values()
 			.filter(StandardGradlePlugin.class::isInstance)
 			.map(StandardGradlePlugin.class::cast)
-			.collect(Collectors.toList());
+			.toList();
 	}
 
 	/**
@@ -138,8 +138,7 @@ public abstract class GradleBuildWriter {
 	}
 
 	protected final void writeRepositories(IndentingWriter writer, GradleBuild build) {
-		writeNestedCollection(writer, "repositories", build.repositories().items().collect(Collectors.toList()),
-				this::repositoryAsString);
+		writeNestedCollection(writer, "repositories", build.repositories().items().toList(), this::repositoryAsString);
 	}
 
 	protected abstract String repositoryAsString(MavenRepository repository);
@@ -224,7 +223,7 @@ public abstract class GradleBuildWriter {
 		List<BillOfMaterials> boms = build.boms()
 			.items()
 			.sorted(Comparator.comparingInt(BillOfMaterials::getOrder).reversed())
-			.collect(Collectors.toList());
+			.toList();
 		writer.println();
 		writer.println("dependencyManagement {");
 		writer.indented(() -> writeNestedCollection(writer, "imports", boms, this::bomAsString));
@@ -326,7 +325,7 @@ public abstract class GradleBuildWriter {
 		return dependencies.items()
 			.filter((dep) -> filter.test(dep.getScope()))
 			.sorted(getDependencyComparator())
-			.collect(Collectors.toList());
+			.toList();
 	}
 
 	@SafeVarargs

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriter.java
@@ -19,7 +19,6 @@ package io.spring.initializr.generator.buildsystem.gradle;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 import io.spring.initializr.generator.buildsystem.BillOfMaterials;
 import io.spring.initializr.generator.buildsystem.Dependency;
@@ -76,7 +75,7 @@ public class GroovyDslGradleBuildWriter extends GradleBuildWriter {
 	}
 
 	private List<GradlePlugin> extractApplyPlugins(GradleBuild build) {
-		return build.plugins().values().filter(GradlePlugin::isApply).collect(Collectors.toList());
+		return build.plugins().values().filter(GradlePlugin::isApply).toList();
 	}
 
 	private String pluginAsString(StandardGradlePlugin plugin) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriter.java
@@ -101,7 +101,7 @@ public class KotlinDslGradleBuildWriter extends GradleBuildWriter {
 			return;
 		}
 		writer.println("configurations {");
-		List<String> customConfigurations = configurations.names().collect(Collectors.toList());
+		List<String> customConfigurations = configurations.names().toList();
 		writer.indented(() -> configurations.customizations()
 			.forEach((configuration) -> writeConfiguration(writer, configuration, customConfigurations)));
 		writer.println("}");

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.spring.initializr.generator.buildsystem.BillOfMaterials;
@@ -333,8 +332,7 @@ public class MavenBuildWriter {
 			return;
 		}
 		writeElement(writer, "dependencyManagement", () -> writeCollectionElement(writer, "dependencies",
-				boms.items().sorted(Comparator.comparing(BillOfMaterials::getOrder)).collect(Collectors.toList()),
-				this::writeBom));
+				boms.items().sorted(Comparator.comparing(BillOfMaterials::getOrder)).toList(), this::writeBom));
 	}
 
 	private void writeBom(IndentingWriter writer, BillOfMaterials bom) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovySourceCodeWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/groovy/GroovySourceCodeWriter.java
@@ -256,7 +256,7 @@ public class GroovySourceCodeWriter implements SourceCodeWriter<GroovySourceCode
 	}
 
 	private <T> List<String> appendImports(Stream<T> candidates, Function<T, Collection<String>> mapping) {
-		return candidates.map(mapping).flatMap(Collection::stream).collect(Collectors.toList());
+		return candidates.map(mapping).flatMap(Collection::stream).toList();
 	}
 
 	private String getUnqualifiedName(String name) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriter.java
@@ -254,7 +254,7 @@ public class JavaSourceCodeWriter implements SourceCodeWriter<JavaSourceCode> {
 	}
 
 	private <T> List<String> appendImports(Stream<T> candidates, Function<T, Collection<String>> mapping) {
-		return candidates.map(mapping).flatMap(Collection::stream).collect(Collectors.toList());
+		return candidates.map(mapping).flatMap(Collection::stream).toList();
 	}
 
 	private String getUnqualifiedName(String name) {

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/kotlin/KotlinSourceCodeWriter.java
@@ -292,7 +292,7 @@ public class KotlinSourceCodeWriter implements SourceCodeWriter<KotlinSourceCode
 	}
 
 	private <T> List<String> appendImports(Stream<T> candidates, Function<T, Collection<String>> mapping) {
-		return candidates.map(mapping).flatMap(Collection::stream).collect(Collectors.toList());
+		return candidates.map(mapping).flatMap(Collection::stream).toList();
 	}
 
 	private String getUnqualifiedName(String name) {

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/version/VersionTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/version/VersionTests.java
@@ -18,7 +18,6 @@ package io.spring.initializr.generator.version;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.spring.initializr.generator.version.Version.Format;
@@ -136,7 +135,7 @@ class VersionTests {
 			.map(this::parse)
 			.sorted()
 			.map(Version::toString)
-			.collect(Collectors.toList());
+			.toList();
 		assertThat(sortedVersions).containsExactly("2.3.0.M1", "2.3.0.M2", "2.3.0.RC1", "2.3.0.RC2",
 				"2.3.0.BUILD-SNAPSHOT", "2.3.0.RELEASE");
 	}
@@ -148,7 +147,7 @@ class VersionTests {
 			.map(this::parse)
 			.sorted()
 			.map(Version::toString)
-			.collect(Collectors.toList());
+			.toList();
 		assertThat(sortedVersions).containsExactly("2.3.0-M1", "2.3.0-M2", "2.3.0-RC1", "2.3.0-RC2", "2.3.0-SNAPSHOT",
 				"2.3.0");
 	}
@@ -160,7 +159,7 @@ class VersionTests {
 			.map(this::parse)
 			.sorted()
 			.map(Version::toString)
-			.collect(Collectors.toList());
+			.toList();
 		assertThat(sortedVersions).containsExactly("2020.0.0-M1", "2020.0.0-M2", "2020.0.0-RC1", "2020.0.0-RC2",
 				"2020.0.0-SNAPSHOT", "2020.0.0");
 	}

--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/DependenciesCapability.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/DependenciesCapability.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.spring.initializr.generator.version.VersionParser;
@@ -65,8 +64,7 @@ public class DependenciesCapability extends ServiceCapability<List<DependencyGro
 	 * @return all dependencies
 	 */
 	public Collection<Dependency> getAll() {
-		return Collections
-			.unmodifiableCollection(this.indexedDependencies.values().stream().distinct().collect(Collectors.toList()));
+		return Collections.unmodifiableCollection(this.indexedDependencies.values().stream().distinct().toList());
 	}
 
 	public void validate() {

--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/InitializrMetadata.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/InitializrMetadata.java
@@ -19,7 +19,6 @@ package io.spring.initializr.metadata;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import io.spring.initializr.generator.version.Version;
 import io.spring.initializr.generator.version.VersionParser;
@@ -212,7 +211,7 @@ public class InitializrMetadata {
 		List<Version> bootVersions = this.bootVersions.getContent()
 			.stream()
 			.map((it) -> Version.parse(it.getId()))
-			.collect(Collectors.toList());
+			.toList();
 		VersionParser parser = new VersionParser(bootVersions);
 		this.dependencies.updateCompatibilityRange(parser);
 		this.configuration.getEnv().updateCompatibilityRange(parser);

--- a/initializr-web/src/main/java/io/spring/initializr/web/mapper/InitializrMetadataV2JsonMapper.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/mapper/InitializrMetadataV2JsonMapper.java
@@ -18,7 +18,6 @@ package io.spring.initializr.web.mapper;
 
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -136,7 +135,7 @@ public class InitializrMetadataV2JsonMapper implements InitializrMetadataJsonMap
 		ObjectNode dependencies = nodeFactory.objectNode();
 		dependencies.put("type", capability.getType().getName());
 		ArrayNode values = nodeFactory.arrayNode();
-		values.addAll(capability.getContent().stream().map(this::mapDependencyGroup).collect(Collectors.toList()));
+		values.addAll(capability.getContent().stream().map(this::mapDependencyGroup).toList());
 		dependencies.set("values", values);
 		parent.set(capability.getId(), dependencies);
 	}
@@ -149,7 +148,7 @@ public class InitializrMetadataV2JsonMapper implements InitializrMetadataJsonMap
 			type.put("default", defaultType.getId());
 		}
 		ArrayNode values = nodeFactory.arrayNode();
-		values.addAll(capability.getContent().stream().map(this::mapType).collect(Collectors.toList()));
+		values.addAll(capability.getContent().stream().map(this::mapType).toList());
 		type.set("values", values);
 		parent.set("type", type);
 	}
@@ -181,7 +180,7 @@ public class InitializrMetadataV2JsonMapper implements InitializrMetadataJsonMap
 			single.put("default", defaultMapper.apply(defaultType.getId()));
 		}
 		ArrayNode values = nodeFactory.arrayNode();
-		values.addAll(capability.getContent().stream().map(valueMapper).collect(Collectors.toList()));
+		values.addAll(capability.getContent().stream().map(valueMapper).toList());
 		single.set("values", values);
 		parent.set(capability.getId(), single);
 	}

--- a/initializr-web/src/main/java/io/spring/initializr/web/project/DefaultProjectRequestToDescriptionConverter.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/project/DefaultProjectRequestToDescriptionConverter.java
@@ -19,7 +19,6 @@ package io.spring.initializr.web.project;
 import java.text.Normalizer;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import io.spring.initializr.generator.buildsystem.BuildSystem;
 import io.spring.initializr.generator.configuration.format.ConfigurationFileFormat;
@@ -212,7 +211,7 @@ public class DefaultProjectRequestToDescriptionConverter
 		return depIds.stream().map((it) -> {
 			Dependency dependency = metadata.getDependencies().get(it);
 			return dependency.resolve(platformVersion);
-		}).collect(Collectors.toList());
+		}).toList();
 	}
 
 }


### PR DESCRIPTION
# Title: Replace Collectors.toList() with Stream.toList()

## Summary
Modernize stream collection operations by replacing `Collectors.toList()` with `Stream.toList()` introduced in Java 16.

## Changes
- **17 files updated** across multiple modules
- Removed unused `Collectors` import statements where applicable
- Retained `Collectors` import where `joining()` or `toCollection()` is still used

## Motivation
- **Conciseness**: `stream.toList()` is shorter and more readable
- **Performance**: Avoids creating an intermediate Collector object
- **Immutability**: `toList()` returns an unmodifiable list
- **Modern Java**: Aligns with Java 16+ idioms since the project requires Java 17