### PR TITLE
Generic types don't use their raw type for imports

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriter.java
@@ -250,12 +250,20 @@ public class JavaSourceCodeWriter implements SourceCodeWriter<JavaSourceCode> {
 		}
 		return imports.stream()
 			.filter((candidate) -> isImportCandidate(compilationUnit, candidate))
+			.map(this::removeGenerics)
 			.sorted()
 			.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
 	private <T> List<String> appendImports(Stream<T> candidates, Function<T, Collection<String>> mapping) {
 		return candidates.map(mapping).flatMap(Collection::stream).toList();
+	}
+
+	private String removeGenerics(String name) {
+		if (!name.contains("<")) {
+			return name;
+		}
+		return name.substring(0, name.indexOf("<")).trim();
 	}
 
 	private String getUnqualifiedName(String name) {

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/language/java/JavaSourceCodeWriterTests.java
@@ -177,6 +177,49 @@ class JavaSourceCodeWriterTests {
 	}
 
 	@Test
+	void fieldImportWithGenerics() throws IOException {
+		JavaSourceCode sourceCode = new JavaSourceCode();
+		JavaCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		JavaTypeDeclaration test = compilationUnit.createTypeDeclaration("Test");
+		test.addFieldDeclaration(JavaFieldDeclaration.field("testString")
+			.modifiers(Modifier.PUBLIC)
+			.returning("com.another.One<String>"));
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.java");
+		assertThat(lines).containsExactly("package com.example;", "", "import com.another.One;", "", "class Test {", "",
+				"    public One<String> testString;", "", "}");
+	}
+
+	@Test
+	void methodParameterWithGenerics() throws IOException {
+		JavaSourceCode sourceCode = new JavaSourceCode();
+		JavaCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		JavaTypeDeclaration test = compilationUnit.createTypeDeclaration("Test");
+		test.addMethodDeclaration(JavaMethodDeclaration.method("trim")
+			.returning("java.lang.String")
+			.modifiers(Modifier.PUBLIC)
+			.parameters(Parameter.of("value", "com.another.One<String>"))
+			.body(CodeBlock.ofStatement("return value.trim()")));
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.java");
+		assertThat(lines).containsExactly("package com.example;", "", "import com.another.One;", "", "class Test {", "",
+				"    public String trim(One<String> value) {", "        return value.trim();", "    }", "", "}");
+	}
+
+	@Test
+	void methodReturningGenerics() throws IOException {
+		JavaSourceCode sourceCode = new JavaSourceCode();
+		JavaCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");
+		JavaTypeDeclaration test = compilationUnit.createTypeDeclaration("Test");
+		test.addMethodDeclaration(JavaMethodDeclaration.method("trim")
+			.returning("com.another.One<String>")
+			.modifiers(Modifier.PUBLIC)
+			.parameters(Parameter.of("value", String.class))
+			.body(CodeBlock.ofStatement("return null")));
+		List<String> lines = writeSingleType(sourceCode, "com/example/Test.java");
+		assertThat(lines).containsExactly("package com.example;", "", "import com.another.One;", "", "class Test {", "",
+				"    public One<String> trim(String value) {", "        return null;", "    }", "", "}");
+	}
+
+	@Test
 	void fieldAnnotation() throws IOException {
 		JavaSourceCode sourceCode = new JavaSourceCode();
 		JavaCompilationUnit compilationUnit = sourceCode.createCompilationUnit("com.example", "Test");


### PR DESCRIPTION
This little correction avoids a syntax error in the generated code whenever you have a javacode with generics type.

example:

```java
public one.One<String> method() {
  return null;
}
```

It generates

```java
import one.One<String>; (wrong!)
```

With this fix
it then generates

```java
import one.One;
```