### PR TITLE
Apply Java modernization idioms across the codebase

### DIFF
--- a/initializr-actuator/src/main/java/io/spring/initializr/actuate/stat/ProjectGenerationStatPublisher.java
+++ b/initializr-actuator/src/main/java/io/spring/initializr/actuate/stat/ProjectGenerationStatPublisher.java
@@ -88,7 +88,7 @@ public class ProjectGenerationStatPublisher {
 			});
 		}
 		catch (Exception ex) {
-			logger.warn(String.format("Failed to publish stat to index, document follows %n%n%s%n", json), ex);
+			logger.warn("Failed to publish stat to index, document follows %n%n%s%n".formatted(json), ex);
 		}
 	}
 

--- a/initializr-actuator/src/main/java/io/spring/initializr/actuate/stat/ProjectRequestDocument.java
+++ b/initializr-actuator/src/main/java/io/spring/initializr/actuate/stat/ProjectRequestDocument.java
@@ -211,8 +211,8 @@ public class ProjectRequestDocument {
 
 		public VersionInformation(Version version) {
 			this.id = version.toString();
-			this.major = String.format("%s", version.getMajor());
-			this.minor = (version.getMinor() != null) ? String.format("%s.%s", version.getMajor(), version.getMinor())
+			this.major = "%s".formatted(version.getMajor());
+			this.minor = (version.getMinor() != null) ? "%s.%s".formatted(version.getMajor(), version.getMinor())
 					: null;
 		}
 

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/scm/git/GitIgnore.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/scm/git/GitIgnore.java
@@ -139,7 +139,7 @@ public class GitIgnore {
 			if (!this.items.isEmpty()) {
 				if (this.name != null) {
 					writer.println();
-					writer.println(String.format("### %s ###", this.name));
+					writer.println("### %s ###".formatted(this.name));
 				}
 				this.items.forEach(writer::println);
 			}

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleKtsProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleKtsProjectGenerationConfigurationTests.java
@@ -104,7 +104,7 @@ class GradleKtsProjectGenerationConfigurationTests {
 		assertThat(project).containsFiles("gradlew", "gradlew.bat", "gradle/wrapper/gradle-wrapper.properties",
 				"gradle/wrapper/gradle-wrapper.jar");
 		assertThat(project).textFile("gradle/wrapper/gradle-wrapper.properties")
-			.containsOnlyOnce(String.format("gradle-%s-bin.zip", expectedGradleVersion));
+			.containsOnlyOnce("gradle-%s-bin.zip".formatted(expectedGradleVersion));
 	}
 
 	@Test

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleProjectGenerationConfigurationTests.java
@@ -103,7 +103,7 @@ class GradleProjectGenerationConfigurationTests {
 		assertThat(project).containsFiles("gradlew", "gradlew.bat", "gradle/wrapper/gradle-wrapper.properties",
 				"gradle/wrapper/gradle-wrapper.jar");
 		assertThat(project).textFile("gradle/wrapper/gradle-wrapper.properties")
-			.containsOnlyOnce(String.format("gradle-%s-bin.zip", expectedGradleVersion));
+			.containsOnlyOnce("gradle-%s-bin.zip".formatted(expectedGradleVersion));
 	}
 
 	@Test

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleWrapperContributorTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleWrapperContributorTests.java
@@ -54,7 +54,7 @@ class GradleWrapperContributorTests {
 	private Consumer<Path> isNotExecutable() {
 		return (path) -> {
 			if (supportsExecutableFlag() && Files.isExecutable(path)) {
-				throw Failures.instance().failure(String.format("%nExpecting:%n  <%s>%nto not be executable.", path));
+				throw Failures.instance().failure("%nExpecting:%n  <%s>%nto not be executable.".formatted(path));
 			}
 		};
 	}

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/maven/MavenWrapperContributorTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/maven/MavenWrapperContributorTests.java
@@ -52,7 +52,7 @@ class MavenWrapperContributorTests {
 	private Consumer<Path> isNotExecutable() {
 		return (path) -> {
 			if (supportsExecutableFlag() && Files.isExecutable(path)) {
-				throw Failures.instance().failure(String.format("%nExpecting:%n  <%s>%nto not be executable.", path));
+				throw Failures.instance().failure("%nExpecting:%n  <%s>%nto not be executable.".formatted(path));
 			}
 		};
 	}

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/CodeComplianceTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/code/CodeComplianceTests.java
@@ -56,9 +56,9 @@ class CodeComplianceTests extends AbstractComplianceTests {
 		ProjectStructure project = generateProject(language, maven, "2.4.1");
 		assertThat(project).filePaths()
 			.contains(
-					String.format("src/main/%s/com/example/demo/DemoApplication.%s", language.id(),
+					"src/main/%s/com/example/demo/DemoApplication.%s".formatted(language.id(),
 							language.sourceFileExtension()),
-					String.format("src/test/%s/com/example/demo/DemoApplicationTests.%s", language.id(),
+					"src/test/%s/com/example/demo/DemoApplicationTests.%s".formatted(language.id(),
 							language.sourceFileExtension()));
 	}
 
@@ -69,9 +69,9 @@ class CodeComplianceTests extends AbstractComplianceTests {
 				(description) -> description.setPackaging(Packaging.forId("war")));
 		assertThat(project).filePaths()
 			.contains(
-					String.format("src/main/%s/com/example/demo/DemoApplication.%s", language.id(),
+					"src/main/%s/com/example/demo/DemoApplication.%s".formatted(language.id(),
 							language.sourceFileExtension()),
-					String.format("src/test/%s/com/example/demo/DemoApplicationTests.%s", language.id(),
+					"src/test/%s/com/example/demo/DemoApplicationTests.%s".formatted(language.id(),
 							language.sourceFileExtension()));
 	}
 

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/documentation/HelpDocumentProjectContributorTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/documentation/HelpDocumentProjectContributorTests.java
@@ -89,7 +89,7 @@ class HelpDocumentProjectContributorTests {
 	@Test
 	void helpDocumentWithSimpleSection() throws IOException {
 		HelpDocument document = new HelpDocument(this.templateRenderer);
-		document.addSection((writer) -> writer.println(String.format("# My test section%n%n    * Test")));
+		document.addSection((writer) -> writer.println("# My test section%n%n    * Test".formatted()));
 		assertHelpDocument(document).containsExactly("# My test section", "", "    * Test");
 	}
 
@@ -98,7 +98,7 @@ class HelpDocumentProjectContributorTests {
 		HelpDocument document = new HelpDocument(this.templateRenderer);
 		document.gettingStarted()
 			.addGuideLink("https://test.example.com", "test")
-			.addSection((writer) -> writer.println(String.format("# My test section%n%n    * Test")));
+			.addSection((writer) -> writer.println("# My test section%n%n    * Test".formatted()));
 		assertHelpDocument(document).containsExactly("# Getting Started", "", "### Guides",
 				"The following guides illustrate how to use some features concretely:", "",
 				"* [test](https://test.example.com)", "", "# My test section", "", "    * Test");

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/properties/ApplicationPropertiesComplianceTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/properties/ApplicationPropertiesComplianceTests.java
@@ -57,7 +57,7 @@ class ApplicationPropertiesComplianceTests extends AbstractComplianceTests {
 	void applicationPropertiesGenerated(ConfigurationFileFormat format, String fileName) {
 		ProjectStructure project = generateProject(java, maven, "2.4.1",
 				(description) -> description.setConfigurationFileFormat(format));
-		assertThat(project).filePaths().contains(String.format("src/main/resources/%s", fileName));
+		assertThat(project).filePaths().contains("src/main/resources/%s".formatted(fileName));
 	}
 
 	@ParameterizedTest
@@ -69,7 +69,7 @@ class ApplicationPropertiesComplianceTests extends AbstractComplianceTests {
 						ApplicationPropertiesCustomizer.class,
 						() -> (properties) -> properties.add("spring.application.name", "app-name")));
 		String path = "project/properties/" + format + "/" + getAssertFileName(fileName);
-		assertThat(project).textFile(String.format("src/main/resources/%s", fileName))
+		assertThat(project).textFile("src/main/resources/%s".formatted(fileName))
 			.as("Resource " + path)
 			.hasSameContentAs(new ClassPathResource(path));
 	}

--- a/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/GradleBuildAssert.java
+++ b/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/GradleBuildAssert.java
@@ -67,7 +67,7 @@ public abstract class GradleBuildAssert<SELF extends GradleBuildAssert<SELF>> ex
 	 * @return {@code this} assertion object
 	 */
 	public SELF hasProperty(String name, String value) {
-		return contains(String.format("%s = %s", name, quote(value)));
+		return contains("%s = %s".formatted(name, quote(value)));
 	}
 
 	/**
@@ -76,12 +76,12 @@ public abstract class GradleBuildAssert<SELF extends GradleBuildAssert<SELF>> ex
 	 * @return {@code this} assertion object
 	 */
 	public SELF containsOnlyExtProperties(String... values) {
-		StringBuilder builder = new StringBuilder(String.format("ext {%n"));
+		StringBuilder builder = new StringBuilder("ext {%n".formatted());
 		if (values.length % 2 == 1) {
 			throw new IllegalArgumentException("Size must be even, it is a set of property=value pairs");
 		}
 		for (int i = 0; i < values.length; i += 2) {
-			builder.append(String.format("\tset(%s, \"%s\")%n", quote(values[i]), values[i + 1]));
+			builder.append("\tset(%s, \"%s\")%n".formatted(quote(values[i]), values[i + 1]));
 		}
 		builder.append("}");
 		return contains(builder.toString());

--- a/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/GradleSettingsAssert.java
+++ b/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/GradleSettingsAssert.java
@@ -47,7 +47,7 @@ public class GradleSettingsAssert<SELF extends GradleSettingsAssert<SELF>> exten
 	 * @return {@code this} assertion object
 	 */
 	public SELF hasProperty(String name, String value) {
-		return contains(String.format("%s = '%s", name, value));
+		return contains("%s = '%s".formatted(name, value));
 	}
 
 }

--- a/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/GroovyDslGradleBuildAssert.java
+++ b/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/GroovyDslGradleBuildAssert.java
@@ -47,7 +47,7 @@ public class GroovyDslGradleBuildAssert extends GradleBuildAssert<GroovyDslGradl
 	 * @return {@code this} assertion object
 	 */
 	public GroovyDslGradleBuildAssert hasPlugin(String id, String version) {
-		return contains(String.format("id %s version %s", quote(id), quote(version)));
+		return contains("id %s version %s".formatted(quote(id), quote(version)));
 	}
 
 	/**
@@ -56,7 +56,7 @@ public class GroovyDslGradleBuildAssert extends GradleBuildAssert<GroovyDslGradl
 	 * @return {@code this} assertion object
 	 */
 	public GroovyDslGradleBuildAssert hasPlugin(String id) {
-		return contains(String.format("id %s", quote(id)));
+		return contains("id %s".formatted(quote(id)));
 	}
 
 }

--- a/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/KotlinDslGradleBuildAssert.java
+++ b/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/buildsystem/gradle/KotlinDslGradleBuildAssert.java
@@ -48,7 +48,7 @@ public class KotlinDslGradleBuildAssert extends GradleBuildAssert<KotlinDslGradl
 	 * @return {@code this} assertion object
 	 */
 	public KotlinDslGradleBuildAssert hasPlugin(String id, String version) {
-		return contains(String.format("id(%s) version %s", quote(id), quote(version)));
+		return contains("id(%s) version %s".formatted(quote(id), quote(version)));
 	}
 
 	/**
@@ -57,7 +57,7 @@ public class KotlinDslGradleBuildAssert extends GradleBuildAssert<KotlinDslGradl
 	 * @return {@code this} assertion object
 	 */
 	public KotlinDslGradleBuildAssert hasPlugin(String id) {
-		return contains(String.format("id(%s)", quote(id)));
+		return contains("id(%s)".formatted(quote(id)));
 	}
 
 }

--- a/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/project/ProjectStructure.java
+++ b/initializr-generator-test/src/main/java/io/spring/initializr/generator/test/project/ProjectStructure.java
@@ -61,7 +61,7 @@ public final class ProjectStructure implements AssertProvider<ModuleAssert> {
 		Path projectDir = this.projectDirectory.resolve(name);
 		if (!Files.isDirectory(projectDir)) {
 			throw new IllegalArgumentException(
-					String.format("No directory '%s' found in '%s'", name, this.projectDirectory));
+					"No directory '%s' found in '%s'".formatted(name, this.projectDirectory));
 		}
 		return new ProjectStructure(projectDir);
 	}

--- a/initializr-generator-test/src/test/java/io/spring/initializr/generator/test/project/JvmModuleAssertTests.java
+++ b/initializr-generator-test/src/test/java/io/spring/initializr/generator/test/project/JvmModuleAssertTests.java
@@ -57,7 +57,7 @@ class JvmModuleAssertTests {
 		createFile(root, "src/main/java/com/example/Test.other");
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forJavaProject(root)).hasMainSource("com.example", "Test"))
-			.withMessageContaining(String.format("Source '%s' not found in package '%s'", "Test.java", "com.example"));
+			.withMessageContaining("Source '%s' not found in package '%s'".formatted("Test.java", "com.example"));
 	}
 
 	@Test
@@ -65,7 +65,7 @@ class JvmModuleAssertTests {
 		createFile(root, "src/main/groovy/com/example/Test.java");
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forJavaProject(root)).hasMainSource("com.example", "Test"))
-			.withMessageContaining(String.format("Source '%s' not found in package '%s'", "Test.java", "com.example"));
+			.withMessageContaining("Source '%s' not found in package '%s'".formatted("Test.java", "com.example"));
 	}
 
 	@Test
@@ -109,7 +109,7 @@ class JvmModuleAssertTests {
 		createFile(root, "src/test/java/com/example/Test.other");
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forJavaProject(root)).hasTestSource("com.example", "Test"))
-			.withMessageContaining(String.format("Source '%s' not found in package '%s'", "Test.java", "com.example"));
+			.withMessageContaining("Source '%s' not found in package '%s'".formatted("Test.java", "com.example"));
 	}
 
 	@Test
@@ -117,7 +117,7 @@ class JvmModuleAssertTests {
 		createFile(root, "src/test/groovy/com/example/Test.java");
 		assertThatExceptionOfType(AssertionError.class)
 			.isThrownBy(() -> assertThat(forJavaProject(root)).hasTestSource("com.example", "Test"))
-			.withMessageContaining(String.format("Source '%s' not found in package '%s'", "Test.java", "com.example"));
+			.withMessageContaining("Source '%s' not found in package '%s'".formatted("Test.java", "com.example"));
 	}
 
 	@Test

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
@@ -267,7 +267,7 @@ public abstract class GradleBuildWriter {
 
 	private String attributeAsString(Attribute attribute) {
 		String separator = (attribute.getType() == Attribute.Type.SET) ? "=" : "+=";
-		return String.format("%s %s %s", attribute.getName(), separator, attribute.getValue());
+		return "%s %s %s".formatted(attribute.getName(), separator, attribute.getValue());
 	}
 
 	protected abstract String invocationAsString(Invocation invocation);

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleSettingsWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleSettingsWriter.java
@@ -90,7 +90,7 @@ public abstract class GradleSettingsWriter {
 		writer.println("if (requested.id.id == " + wrapWithQuotes(pluginMapping.getId()) + ") {");
 		Dependency dependency = pluginMapping.getDependency();
 		Assert.state(dependency.getVersion() != null, "'dependency.getVersion()' must not be null");
-		String module = String.format("%s:%s:%s", dependency.getGroupId(), dependency.getArtifactId(),
+		String module = "%s:%s:%s".formatted(dependency.getGroupId(), dependency.getArtifactId(),
 				dependency.getVersion().getValue());
 		writer.indented(() -> writer.println("useModule(" + wrapWithQuotes(module) + ")"));
 		writer.println("}");

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriter.java
@@ -102,7 +102,7 @@ public class GroovyDslGradleBuildWriter extends GradleBuildWriter {
 	}
 
 	private String getFormattedExtraProperty(String key, String value) {
-		return String.format("set('%s', %s)", key, value);
+		return "set('%s', %s)".formatted(key, value);
 	}
 
 	@Override
@@ -126,8 +126,8 @@ public class GroovyDslGradleBuildWriter extends GradleBuildWriter {
 	 */
 	protected void writeConfiguration(IndentingWriter writer, GradleConfiguration configuration) {
 		writer.println(configuration.getName() + " {");
-		writer.indented(() -> writer
-			.println(String.format("extendsFrom %s", String.join(", ", configuration.getExtendsFrom()))));
+		writer.indented(
+				() -> writer.println("extendsFrom %s".formatted(String.join(", ", configuration.getExtendsFrom()))));
 		writer.println("}");
 	}
 
@@ -207,7 +207,7 @@ public class GroovyDslGradleBuildWriter extends GradleBuildWriter {
 	@Override
 	protected void writeProperty(IndentingWriter writer, String name, @Nullable String value) {
 		if (value != null) {
-			writer.println(String.format("%s = '%s'", name, value));
+			writer.println("%s = '%s'".formatted(name, value));
 		}
 	}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriter.java
@@ -116,11 +116,10 @@ public class KotlinDslGradleBuildWriter extends GradleBuildWriter {
 		}
 		else {
 			writer.println(configuration.getName() + " {");
-			writer.indented(() -> writer.println(String.format("extendsFrom(%s)",
-					configuration.getExtendsFrom()
-						.stream()
-						.map((name) -> configurationReference(name, customConfigurations))
-						.collect(Collectors.joining(", ")))));
+			writer.indented(() -> writer.println("extendsFrom(%s)".formatted(configuration.getExtendsFrom()
+				.stream()
+				.map((name) -> configurationReference(name, customConfigurations))
+				.collect(Collectors.joining(", ")))));
 			writer.println("}");
 		}
 	}
@@ -155,7 +154,7 @@ public class KotlinDslGradleBuildWriter extends GradleBuildWriter {
 	}
 
 	private String getFormattedExtraProperty(String key, String value) {
-		return String.format("extra[\"%s\"] = %s", key, value);
+		return "extra[\"%s\"] = %s".formatted(key, value);
 	}
 
 	@Override
@@ -200,7 +199,7 @@ public class KotlinDslGradleBuildWriter extends GradleBuildWriter {
 	@Override
 	protected void writeProperty(IndentingWriter writer, String name, @Nullable String value) {
 		if (value != null) {
-			writer.println(String.format("%s = \"%s\"", name, value));
+			writer.println("%s = \"%s\"".formatted(name, value));
 		}
 	}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
@@ -630,26 +630,26 @@ public class MavenBuildWriter {
 
 	private void writeSingleElement(IndentingWriter writer, String name, @Nullable Object value) {
 		if (value != null) {
-			CharSequence text = (value instanceof CharSequence) ? (CharSequence) value : value.toString();
+			CharSequence text = (value instanceof CharSequence cs) ? cs : value.toString();
 			if (!StringUtils.hasLength(text)) {
-				writer.println(String.format("<%s/>", name));
+				writer.println("<%s/>".formatted(name));
 			}
 			else {
-				writer.print(String.format("<%s>", name));
+				writer.print("<%s>".formatted(name));
 				writer.print(encodeText(text));
-				writer.println(String.format("</%s>", name));
+				writer.println("</%s>".formatted(name));
 			}
 		}
 	}
 
 	private void writeProcessingInstruction(IndentingWriter writer, String content) {
-		writer.println(String.format("<?%s?>", content));
+		writer.println("<?%s?>".formatted(content));
 	}
 
 	private void writeElement(IndentingWriter writer, String name, Runnable withContent) {
-		writer.println(String.format("<%s>", name));
+		writer.println("<%s>".formatted(name));
 		writer.indented(withContent);
-		writer.println(String.format("</%s>", name));
+		writer.println("</%s>".formatted(name));
 	}
 
 	private <T> void writeCollectionElement(IndentingWriter writer, String name, Stream<T> items,

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenExtensionContainer.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenExtensionContainer.java
@@ -101,7 +101,7 @@ public class MavenExtensionContainer {
 	}
 
 	private String extensionKey(String groupId, String artifactId) {
-		return String.format("%s:%s", groupId, artifactId);
+		return "%s:%s".formatted(groupId, artifactId);
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenPlugin.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenPlugin.java
@@ -414,8 +414,9 @@ public class MavenPlugin {
 				})
 				.getValue();
 			if (!(value instanceof ConfigurationBuilder nestedConfiguration)) {
-				throw new IllegalArgumentException(String.format(
-						"Could not customize parameter '%s', a single value %s is already registered", name, value));
+				throw new IllegalArgumentException(
+						"Could not customize parameter '%s', a single value %s is already registered".formatted(name,
+								value));
 			}
 			consumer.accept(nestedConfiguration);
 			return this;

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenPluginContainer.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenPluginContainer.java
@@ -99,7 +99,7 @@ public class MavenPluginContainer {
 	}
 
 	private String pluginKey(String groupId, String artifactId) {
-		return String.format("%s:%s", groupId, artifactId);
+		return "%s:%s".formatted(groupId, artifactId);
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/io/template/MustacheTemplateRenderer.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/io/template/MustacheTemplateRenderer.java
@@ -58,7 +58,7 @@ public class MustacheTemplateRenderer implements TemplateRenderer {
 	public MustacheTemplateRenderer(String resourcePrefix, @Nullable Cache templateCache) {
 		String prefix = (resourcePrefix.endsWith("/") ? resourcePrefix : resourcePrefix + "/");
 		this.mustache = Mustache.compiler().withLoader(mustacheTemplateLoader(prefix)).escapeHTML(false);
-		this.keyGenerator = (name) -> String.format("%s%s", prefix, name);
+		this.keyGenerator = (name) -> "%s%s".formatted(prefix, name);
 		this.templateCache = templateCache;
 	}
 

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/language/CodeBlock.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/language/CodeBlock.java
@@ -268,8 +268,8 @@ public final class CodeBlock {
 				case 'L' -> this.args.add(arg(arg));
 				case 'S' -> this.args.add(argToString(arg));
 				case 'T' -> this.args.add(argToType(arg));
-				default -> throw new IllegalArgumentException(
-						String.format("Unsupported placeholder '$%s' for '%s'", c, format));
+				default ->
+					throw new IllegalArgumentException("Unsupported placeholder '$%s' for '%s'".formatted(c, format));
 			}
 		}
 

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/io/text/MustacheSectionTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/io/text/MustacheSectionTests.java
@@ -43,7 +43,7 @@ class MustacheSectionTests {
 		MustacheSection section = new MustacheSection(this.renderer, "test", Collections.singletonMap("key", "hello"));
 		StringWriter writer = new StringWriter();
 		section.write(new PrintWriter(writer));
-		assertThat(writer.toString()).isEqualTo(String.format("hello%n"));
+		assertThat(writer.toString()).isEqualTo("hello%n".formatted());
 	}
 
 	@Test
@@ -65,7 +65,7 @@ class MustacheSectionTests {
 		};
 		StringWriter writer = new StringWriter();
 		section.write(new PrintWriter(writer));
-		assertThat(writer.toString()).isEqualTo(String.format("custom%n"));
+		assertThat(writer.toString()).isEqualTo("custom%n".formatted());
 	}
 
 }

--- a/initializr-web/src/main/java/io/spring/initializr/web/controller/ProjectGenerationController.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/controller/ProjectGenerationController.java
@@ -224,7 +224,7 @@ public abstract class ProjectGenerationController<R extends ProjectRequest> {
 	private ResponseEntity<byte[]> upload(Path archive, Path dir, String fileName, String contentType)
 			throws IOException {
 		byte[] bytes = Files.readAllBytes(archive);
-		logger.info(String.format("Uploading: %s (%s bytes)", archive, bytes.length));
+		logger.info("Uploading: %s (%s bytes)".formatted(archive, bytes.length));
 		ResponseEntity<byte[]> result = createResponseEntity(bytes, contentType, fileName);
 		this.projectGenerationInvoker.cleanTempFiles(dir);
 		return result;

--- a/initializr-web/src/main/java/io/spring/initializr/web/mapper/InitializrMetadataV2JsonMapper.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/mapper/InitializrMetadataV2JsonMapper.java
@@ -201,8 +201,8 @@ public class InitializrMetadataV2JsonMapper implements InitializrMetadataJsonMap
 	protected ObjectNode mapDependencyGroup(DependencyGroup group) {
 		ObjectNode result = nodeFactory.objectNode();
 		result.put("name", group.getName());
-		if ((group instanceof Describable) && ((Describable) group).getDescription() != null) {
-			result.put("description", ((Describable) group).getDescription());
+		if (group instanceof Describable describable && describable.getDescription() != null) {
+			result.put("description", describable.getDescription());
 		}
 		ArrayNode items = nodeFactory.arrayNode();
 		group.getContent().forEach((it) -> {
@@ -252,8 +252,8 @@ public class InitializrMetadataV2JsonMapper implements InitializrMetadataJsonMap
 		Assert.state(id != null, "'id' must not be null");
 		result.put("id", id);
 		result.put("name", value.getName());
-		if ((value instanceof Describable) && ((Describable) value).getDescription() != null) {
-			result.put("description", ((Describable) value).getDescription());
+		if (value instanceof Describable describable && describable.getDescription() != null) {
+			result.put("description", describable.getDescription());
 		}
 		return result;
 	}

--- a/initializr-web/src/test/java/io/spring/initializr/web/AbstractInitializrIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/AbstractInitializrIntegrationTests.java
@@ -331,8 +331,8 @@ public abstract class AbstractInitializrIntegrationTests {
 			try (InputStream in = resource.getInputStream()) {
 				String json = StreamUtils.copyToString(in, StandardCharsets.UTF_8);
 				String placeholder = "";
-				if (this instanceof AbstractInitializrControllerIntegrationTests) {
-					placeholder = ((AbstractInitializrControllerIntegrationTests) this).host;
+				if (this instanceof AbstractInitializrControllerIntegrationTests controller) {
+					placeholder = controller.host;
 				}
 				if (this instanceof AbstractFullStackInitializrIntegrationTests test) {
 					placeholder = test.host + ":" + test.port;

--- a/initializr-web/src/test/java/io/spring/initializr/web/test/JsonFieldProcessor.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/test/JsonFieldProcessor.java
@@ -66,7 +66,7 @@ final class JsonFieldProcessor {
 				handleListPayload(context, matchCallback);
 			}
 		}
-		else if (context.getPayload() instanceof Map && ((Map<?, ?>) context.getPayload()).containsKey(segment)) {
+		else if (context.getPayload() instanceof Map<?, ?> map && map.containsKey(segment)) {
 			handleMapPayload(context, matchCallback);
 		}
 	}


### PR DESCRIPTION
## Title: Apply Java modernization idioms across the codebase
Apply Java modernization idioms across the codebase

## Summary
- Replace `String.format()` with `String.formatted()` to align with the convention already established by project maintainers since May 2023
- Apply `instanceof` pattern matching (Java 16+) to remaining old-style `instanceof` checks with explicit casts, consistent with the 38 instances already using the modern syntax

## Details
- **31 files** changed, **66 insertions, 66 deletions** (pure refactoring, no behavioral changes)
- All changes are mechanical replacements with identical semantics
- Spring JavaFormat applied and all tests pass

## Test plan
- [x] `./mvnw clean install` passes
- [x] `./mvnw spring-javaformat:apply` produces no additional changes
- [x] `./mvnw validate` (checkstyle) passes