### PR TITLE
Allow annotation processors for tests

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleAnnotationProcessorScopeBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/gradle/GradleAnnotationProcessorScopeBuildCustomizer.java
@@ -39,6 +39,13 @@ public class GradleAnnotationProcessorScopeBuildCustomizer implements BuildCusto
 			build.configurations()
 				.customize("compileOnly", (configuration) -> configuration.extendsFrom("annotationProcessor"));
 		}
+		boolean testAnnotationProcessorUsed = build.dependencies()
+			.items()
+			.anyMatch((dependency) -> dependency.getScope() == DependencyScope.TEST_ANNOTATION_PROCESSOR);
+		if (testAnnotationProcessorUsed) {
+			build.configurations()
+				.customize("testCompileOnly", (configuration) -> configuration.extendsFrom("testAnnotationProcessor"));
+		}
 	}
 
 	@Override

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/BuildComplianceTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/BuildComplianceTests.java
@@ -19,6 +19,7 @@ package io.spring.initializr.generator.spring.build;
 import java.util.stream.Stream;
 
 import io.spring.initializr.generator.buildsystem.BuildSystem;
+import io.spring.initializr.generator.buildsystem.DependencyScope;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
 import io.spring.initializr.generator.language.Language;
@@ -205,6 +206,28 @@ class BuildComplianceTests extends AbstractComplianceTests {
 			description.addDependency("data-jpa", MetadataBuildItemMapper.toDependency(dataJpa));
 		}, metadata);
 		String path = "project/" + build + "/annotation-processor-dependency-" + getAssertFileName(fileName);
+		assertThat(project).textFile(fileName).as("Resource " + path).hasSameContentAs(new ClassPathResource(path));
+	}
+
+	@ParameterizedTest
+	@MethodSource("parameters")
+	void annotationProcessorForTestsDependency(BuildSystem build, String fileName) {
+		Dependency lombok = Dependency.withId("lombok", "org.projectlombok", "lombok");
+		lombok.setScope(Dependency.SCOPE_ANNOTATION_PROCESSOR);
+		lombok.setAnnotationProcessorForTests(true);
+		Dependency dataJpa = Dependency.withId("data-jpa", "org.springframework.boot", "spring-boot-starter-data-jpa");
+		InitializrMetadata metadata = InitializrMetadataTestBuilder.withDefaults()
+			.addDependencyGroup("core", "web", "data-jpa")
+			.addDependencyGroup("lombok", lombok)
+			.build();
+		ProjectStructure project = generateProject(java, build, "2.4.1", (description) -> {
+			description.addDependency("lombok", MetadataBuildItemMapper.toDependency(lombok));
+			description.addDependency("lombok-test",
+					MetadataBuildItemMapper.toDependency(lombok, DependencyScope.TEST_ANNOTATION_PROCESSOR));
+			description.addDependency("web", MetadataBuildItemMapper.toDependency(WEB));
+			description.addDependency("data-jpa", MetadataBuildItemMapper.toDependency(dataJpa));
+		}, metadata);
+		String path = "project/" + build + "/annotation-processor-for-tests-" + getAssertFileName(fileName);
 		assertThat(project).textFile(fileName).as("Resource " + path).hasSameContentAs(new ClassPathResource(path));
 	}
 

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleAnnotationProcessorScopeBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/gradle/GradleAnnotationProcessorScopeBuildCustomizerTests.java
@@ -50,6 +50,35 @@ class GradleAnnotationProcessorScopeBuildCustomizerTests {
 		assertThat(build.configurations().isEmpty()).isTrue();
 	}
 
+	@Test
+	void testCompileOnlyConfigurationIsAddedWithTestAnnotationProcessorDependency() {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("lib", "com.example", "lib", DependencyScope.COMPILE);
+		build.dependencies()
+			.add("lombok-test", "org.projectlombok", "lombok", DependencyScope.TEST_ANNOTATION_PROCESSOR);
+		customize(build);
+		assertThat(build.configurations().customizations()).singleElement().satisfies((configuration) -> {
+			assertThat(configuration.getName()).isEqualTo("testCompileOnly");
+			assertThat(configuration.getExtendsFrom()).containsOnly("testAnnotationProcessor");
+		});
+	}
+
+	@Test
+	void bothConfigurationsAreAddedWithAnnotationProcessorAndTestAnnotationProcessorDependencies() {
+		GradleBuild build = new GradleBuild();
+		build.dependencies()
+			.add("ap", "org.springframework.boot", "spring-boot-configuration-processor",
+					DependencyScope.ANNOTATION_PROCESSOR);
+		build.dependencies()
+			.add("lombok-test", "org.projectlombok", "lombok", DependencyScope.TEST_ANNOTATION_PROCESSOR);
+		customize(build);
+		assertThat(build.configurations().customizations()).hasSize(2);
+		assertThat(build.configurations().customizations())
+			.anyMatch((c) -> "compileOnly".equals(c.getName()) && c.getExtendsFrom().contains("annotationProcessor"));
+		assertThat(build.configurations().customizations()).anyMatch(
+				(c) -> "testCompileOnly".equals(c.getName()) && c.getExtendsFrom().contains("testAnnotationProcessor"));
+	}
+
 	private void customize(GradleBuild build) {
 		new GradleAnnotationProcessorScopeBuildCustomizer().customize(build);
 	}

--- a/initializr-generator-spring/src/test/resources/project/gradle/annotation-processor-for-tests-build.gradle.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/annotation-processor-for-tests-build.gradle.gen
@@ -1,0 +1,41 @@
+plugins {
+	id 'java'
+	id 'org.springframework.boot' version '2.4.1'
+	id 'io.spring.dependency-management' version '1.0.6.RELEASE'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(8)
+	}
+}
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	testCompileOnly {
+		extendsFrom testAnnotationProcessor
+	}
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+	useJUnitPlatform()
+}

--- a/initializr-generator-spring/src/test/resources/project/gradle/annotation-processor-for-tests-build.gradle.kts.gen
+++ b/initializr-generator-spring/src/test/resources/project/gradle/annotation-processor-for-tests-build.gradle.kts.gen
@@ -1,0 +1,41 @@
+plugins {
+	java
+	id("org.springframework.boot") version "2.4.1"
+	id("io.spring.dependency-management") version "1.0.6.RELEASE"
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+description = "Demo project for Spring Boot"
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(8)
+	}
+}
+
+configurations {
+	compileOnly {
+		extendsFrom(configurations.annotationProcessor.get())
+	}
+	testCompileOnly {
+		extendsFrom(configurations.testAnnotationProcessor.get())
+	}
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	implementation("org.springframework.boot:spring-boot-starter-web")
+	annotationProcessor("org.projectlombok:lombok")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testAnnotationProcessor("org.projectlombok:lombok")
+	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.withType<Test> {
+	useJUnitPlatform()
+}

--- a/initializr-generator-spring/src/test/resources/project/maven/annotation-processor-for-tests-pom.xml.gen
+++ b/initializr-generator-spring/src/test/resources/project/maven/annotation-processor-for-tests-pom.xml.gen
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.4.1</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.example</groupId>
+	<artifactId>demo</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>demo</name>
+	<description>Demo project for Spring Boot</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>1.8</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>test</scope>
+			<optional>true</optional>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/DependencyScope.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/DependencyScope.java
@@ -54,6 +54,12 @@ public enum DependencyScope {
 	TEST_COMPILE,
 
 	/**
+	 * A dependency that is used as an annotation processor when compiling a project's
+	 * tests.
+	 */
+	TEST_ANNOTATION_PROCESSOR,
+
+	/**
 	 * A dependency this is used to run a project's tests.
 	 */
 	TEST_RUNTIME

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
@@ -167,11 +167,13 @@ public abstract class GradleBuildWriter {
 		DependencyContainer dependencies = build.dependencies();
 		sortedDependencies
 			.addAll(filterDependencies(dependencies, (scope) -> scope == null || scope == DependencyScope.COMPILE));
-		sortedDependencies.addAll(filterDependencies(dependencies, hasScope(DependencyScope.COMPILE_ONLY)));
+		sortedDependencies.addAll(filterCompileOnlyDependencies(build, dependencies));
 		sortedDependencies.addAll(filterDependencies(dependencies, hasScope(DependencyScope.RUNTIME)));
 		sortedDependencies.addAll(filterDependencies(dependencies, hasScope(DependencyScope.ANNOTATION_PROCESSOR)));
 		sortedDependencies.addAll(filterDependencies(dependencies, hasScope(DependencyScope.PROVIDED_RUNTIME)));
 		sortedDependencies.addAll(filterDependencies(dependencies, hasScope(DependencyScope.TEST_COMPILE)));
+		sortedDependencies
+			.addAll(filterDependencies(dependencies, hasScope(DependencyScope.TEST_ANNOTATION_PROCESSOR)));
 		sortedDependencies.addAll(filterDependencies(dependencies, hasScope(DependencyScope.TEST_RUNTIME)));
 		if (!sortedDependencies.isEmpty()) {
 			writer.println();
@@ -179,6 +181,29 @@ public abstract class GradleBuildWriter {
 			writer.indented(() -> sortedDependencies.forEach((dependency) -> writeDependency(writer, dependency)));
 			writer.println("}");
 		}
+	}
+
+	private Collection<Dependency> filterCompileOnlyDependencies(GradleBuild build, DependencyContainer dependencies) {
+		Collection<Dependency> compileOnlyDeps = filterDependencies(dependencies,
+				hasScope(DependencyScope.COMPILE_ONLY));
+		if (!compileOnlyExtendsAnnotationProcessor(build)) {
+			return compileOnlyDeps;
+		}
+		Set<String> annotationProcessorCoordinates = dependencies.items()
+			.filter((dep) -> dep.getScope() == DependencyScope.ANNOTATION_PROCESSOR)
+			.map((dep) -> dep.getGroupId() + ":" + dep.getArtifactId())
+			.collect(Collectors.toSet());
+		return compileOnlyDeps.stream()
+			.filter((dep) -> !annotationProcessorCoordinates.contains(dep.getGroupId() + ":" + dep.getArtifactId()))
+			.sorted(getDependencyComparator())
+			.toList();
+	}
+
+	private boolean compileOnlyExtendsAnnotationProcessor(GradleBuild build) {
+		return build.configurations()
+			.customizations()
+			.anyMatch((config) -> "compileOnly".equals(config.getName())
+					&& config.getExtendsFrom().contains("annotationProcessor"));
 	}
 
 	private Predicate<@Nullable DependencyScope> hasScope(DependencyScope... validScopes) {
@@ -213,6 +238,7 @@ public abstract class GradleBuildWriter {
 			case PROVIDED_RUNTIME -> "providedRuntime";
 			case RUNTIME -> "runtimeOnly";
 			case TEST_COMPILE -> "testImplementation";
+			case TEST_ANNOTATION_PROCESSOR -> "testAnnotationProcessor";
 			case TEST_RUNTIME -> "testRuntimeOnly";
 		};
 	}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/maven/MavenBuildWriter.java
@@ -267,8 +267,8 @@ public class MavenBuildWriter {
 			writeDependencies(writer, dependencies, hasScope(DependencyScope.COMPILE_ONLY));
 			writeDependencies(writer, dependencies, hasScope(DependencyScope.ANNOTATION_PROCESSOR));
 			writeDependencies(writer, dependencies, hasScope(DependencyScope.PROVIDED_RUNTIME));
-			writeDependencies(writer, dependencies,
-					hasScope(DependencyScope.TEST_COMPILE, DependencyScope.TEST_RUNTIME));
+			writeDependencies(writer, dependencies, hasScope(DependencyScope.TEST_COMPILE,
+					DependencyScope.TEST_ANNOTATION_PROCESSOR, DependencyScope.TEST_RUNTIME));
 		});
 	}
 
@@ -316,7 +316,7 @@ public class MavenBuildWriter {
 			case ANNOTATION_PROCESSOR, COMPILE, COMPILE_ONLY -> null;
 			case PROVIDED_RUNTIME -> "provided";
 			case RUNTIME -> "runtime";
-			case TEST_COMPILE, TEST_RUNTIME -> "test";
+			case TEST_ANNOTATION_PROCESSOR, TEST_COMPILE, TEST_RUNTIME -> "test";
 		};
 	}
 
@@ -325,7 +325,8 @@ public class MavenBuildWriter {
 			return true;
 		}
 		return (dependency.getScope() == DependencyScope.ANNOTATION_PROCESSOR
-				|| dependency.getScope() == DependencyScope.COMPILE_ONLY);
+				|| dependency.getScope() == DependencyScope.COMPILE_ONLY
+				|| dependency.getScope() == DependencyScope.TEST_ANNOTATION_PROCESSOR);
 	}
 
 	private void writeDependencyManagement(IndentingWriter writer, BomContainer boms) {

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
@@ -417,6 +417,17 @@ class GroovyDslGradleBuildWriterTests extends GradleBuildWriterTests {
 	}
 
 	@Test
+	void gradleBuildWithTestAnnotationProcessorDependency() {
+		GradleBuild build = new GradleBuild();
+		build.dependencies()
+			.add("lombok-test", "org.projectlombok", "lombok", DependencyScope.TEST_ANNOTATION_PROCESSOR);
+		assertThat(write(build)).contains("""
+				dependencies {
+					testAnnotationProcessor 'org.projectlombok:lombok'
+				}""");
+	}
+
+	@Test
 	void gradleBuildWithCompileOnlyDependency() {
 		GradleBuild build = new GradleBuild();
 		build.dependencies()
@@ -425,6 +436,17 @@ class GroovyDslGradleBuildWriterTests extends GradleBuildWriterTests {
 				dependencies {
 					compileOnly 'org.springframework.boot:spring-boot-starter-foobar'
 				}""");
+	}
+
+	@Test
+	void gradleBuildOmitsRedundantCompileOnlyWhenExtendsAnnotationProcessor() {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("lombok-compile", "org.projectlombok", "lombok", DependencyScope.COMPILE_ONLY);
+		build.dependencies().add("lombok-ap", "org.projectlombok", "lombok", DependencyScope.ANNOTATION_PROCESSOR);
+		build.configurations().customize("compileOnly", (c) -> c.extendsFrom("annotationProcessor"));
+		String output = write(build);
+		assertThat(output).contains("annotationProcessor 'org.projectlombok:lombok'");
+		assertThat(output).doesNotContain("compileOnly 'org.projectlombok:lombok'");
 	}
 
 	@Test

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/KotlinDslGradleBuildWriterTests.java
@@ -421,6 +421,17 @@ class KotlinDslGradleBuildWriterTests extends GradleBuildWriterTests {
 	}
 
 	@Test
+	void gradleBuildWithTestAnnotationProcessorDependency() {
+		GradleBuild build = new GradleBuild();
+		build.dependencies()
+			.add("lombok-test", "org.projectlombok", "lombok", DependencyScope.TEST_ANNOTATION_PROCESSOR);
+		assertThat(write(build)).contains("""
+				dependencies {
+					testAnnotationProcessor("org.projectlombok:lombok")
+				}""");
+	}
+
+	@Test
 	void gradleBuildWithCompileOnlyDependency() {
 		GradleBuild build = new GradleBuild();
 		build.dependencies()
@@ -429,6 +440,17 @@ class KotlinDslGradleBuildWriterTests extends GradleBuildWriterTests {
 				dependencies {
 					compileOnly("org.springframework.boot:spring-boot-starter-foobar")
 				}""");
+	}
+
+	@Test
+	void gradleBuildOmitsRedundantCompileOnlyWhenExtendsAnnotationProcessor() {
+		GradleBuild build = new GradleBuild();
+		build.dependencies().add("lombok-compile", "org.projectlombok", "lombok", DependencyScope.COMPILE_ONLY);
+		build.dependencies().add("lombok-ap", "org.projectlombok", "lombok", DependencyScope.ANNOTATION_PROCESSOR);
+		build.configurations().customize("compileOnly", (c) -> c.extendsFrom("annotationProcessor"));
+		String output = write(build);
+		assertThat(output).contains("annotationProcessor(\"org.projectlombok:lombok\")");
+		assertThat(output).doesNotContain("compileOnly(\"org.projectlombok:lombok\")");
 	}
 
 	@Test

--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/Dependency.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/Dependency.java
@@ -117,6 +117,13 @@ public class Dependency extends MetadataElement implements Describable {
 	 */
 	private boolean starter = true;
 
+	/**
+	 * Specify if an annotation processor dependency should also be made available for
+	 * test compilation (Gradle only). Only valid when scope is
+	 * {@link #SCOPE_ANNOTATION_PROCESSOR}.
+	 */
+	private boolean annotationProcessorForTests = false;
+
 	private List<String> keywords = new ArrayList<>();
 
 	private List<Link> links = new ArrayList<>();
@@ -143,6 +150,7 @@ public class Dependency extends MetadataElement implements Describable {
 		this.repository = dependency.repository;
 		this.weight = dependency.weight;
 		this.starter = dependency.starter;
+		this.annotationProcessorForTests = dependency.annotationProcessorForTests;
 		this.keywords.addAll(dependency.keywords);
 		this.links.addAll(dependency.links);
 	}
@@ -425,6 +433,14 @@ public class Dependency extends MetadataElement implements Describable {
 
 	public void setStarter(boolean starter) {
 		this.starter = starter;
+	}
+
+	public boolean isAnnotationProcessorForTests() {
+		return this.annotationProcessorForTests;
+	}
+
+	public void setAnnotationProcessorForTests(boolean annotationProcessorForTests) {
+		this.annotationProcessorForTests = annotationProcessorForTests;
 	}
 
 	public List<String> getKeywords() {

--- a/initializr-metadata/src/main/java/io/spring/initializr/metadata/support/MetadataBuildItemMapper.java
+++ b/initializr-metadata/src/main/java/io/spring/initializr/metadata/support/MetadataBuildItemMapper.java
@@ -45,6 +45,19 @@ public final class MetadataBuildItemMapper {
 	@Contract("!null -> !null")
 	public static io.spring.initializr.generator.buildsystem.@Nullable Dependency toDependency(
 			@Nullable Dependency dependency) {
+		return toDependency(dependency, null);
+	}
+
+	/**
+	 * Return an {@link Build} dependency from a {@link Dependency dependency metadata},
+	 * optionally with a scope override.
+	 * @param dependency a dependency metadata
+	 * @param scopeOverride optional scope to use instead of mapping from metadata
+	 * @return an equivalent build dependency
+	 */
+	@Contract("!null, _ -> !null")
+	public static io.spring.initializr.generator.buildsystem.@Nullable Dependency toDependency(
+			@Nullable Dependency dependency, @Nullable DependencyScope scopeOverride) {
 		if (dependency == null) {
 			return null;
 		}
@@ -54,9 +67,10 @@ public final class MetadataBuildItemMapper {
 		Assert.state(groupId != null, "'groupId' must not be null");
 		String artifactId = dependency.getArtifactId();
 		Assert.state(artifactId != null, "'artifactId' must not be null");
+		DependencyScope scope = (scopeOverride != null) ? scopeOverride : toDependencyScope(dependency.getScope());
 		return io.spring.initializr.generator.buildsystem.Dependency.withCoordinates(groupId, artifactId)
 			.version(versionReference)
-			.scope(toDependencyScope(dependency.getScope()))
+			.scope(scope)
 			.classifier(dependency.getClassifier())
 			.type(dependency.getType())
 			.build();

--- a/initializr-web/src/main/java/io/spring/initializr/web/project/DefaultProjectRequestToDescriptionConverter.java
+++ b/initializr-web/src/main/java/io/spring/initializr/web/project/DefaultProjectRequestToDescriptionConverter.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.spring.initializr.generator.buildsystem.BuildSystem;
+import io.spring.initializr.generator.buildsystem.DependencyScope;
 import io.spring.initializr.generator.configuration.format.ConfigurationFileFormat;
 import io.spring.initializr.generator.language.Language;
 import io.spring.initializr.generator.packaging.Packaging;
@@ -103,6 +104,11 @@ public class DefaultProjectRequestToDescriptionConverter
 			String dependencyId = dependency.getId();
 			if (dependencyId != null) {
 				description.addDependency(dependencyId, MetadataBuildItemMapper.toDependency(dependency));
+				if (Dependency.SCOPE_ANNOTATION_PROCESSOR.equals(dependency.getScope())
+						&& dependency.isAnnotationProcessorForTests()) {
+					description.addDependency(dependencyId + "-test", MetadataBuildItemMapper.toDependency(dependency,
+							DependencyScope.TEST_ANNOTATION_PROCESSOR));
+				}
 			}
 		});
 	}

--- a/initializr-web/src/test/java/io/spring/initializr/web/project/DefaultProjectRequestToDescriptionConverterTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/project/DefaultProjectRequestToDescriptionConverterTests.java
@@ -17,7 +17,9 @@
 package io.spring.initializr.web.project;
 
 import java.util.Collections;
+import java.util.Objects;
 
+import io.spring.initializr.generator.buildsystem.DependencyScope;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
 import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.test.InitializrMetadataTestBuilder;
@@ -279,6 +281,24 @@ class DefaultProjectRequestToDescriptionConverterTests {
 		assertThat(description.getLanguage()).isNotNull();
 		assertThat(description.getLanguage().id()).isEqualTo("java");
 		assertThat(description.getLanguage().jvmVersion()).isEqualTo("1.8");
+	}
+
+	@Test
+	void convertWhenAnnotationProcessorForTestsAddsTestAnnotationProcessorDependency() {
+		Dependency lombok = Dependency.withId("lombok", "org.projectlombok", "lombok");
+		lombok.setScope(Dependency.SCOPE_ANNOTATION_PROCESSOR);
+		lombok.setAnnotationProcessorForTests(true);
+		InitializrMetadata metadata = InitializrMetadataTestBuilder.withDefaults()
+			.addDependencyGroup("tools", lombok)
+			.build();
+		ProjectRequest request = createProjectRequest();
+		request.setDependencies(Collections.singletonList("lombok"));
+		ProjectDescription description = this.converter.convert(request, metadata);
+		assertThat(description.getRequestedDependencies()).containsKeys("lombok", "lombok-test");
+		assertThat(Objects.requireNonNull(description.getRequestedDependencies().get("lombok")).getScope())
+			.isEqualTo(DependencyScope.ANNOTATION_PROCESSOR);
+		assertThat(Objects.requireNonNull(description.getRequestedDependencies().get("lombok-test")).getScope())
+			.isEqualTo(DependencyScope.TEST_ANNOTATION_PROCESSOR);
 	}
 
 	private ProjectRequest createProjectRequest() {

--- a/initializr-web/src/test/resources/metadata/config/test-default.json
+++ b/initializr-web/src/test/resources/metadata/config/test-default.json
@@ -152,6 +152,7 @@
             "id": "web",
             "name": "Web",
             "scope": "compile",
+            "annotationProcessorForTests": false,
             "links": [
               {
                 "rel": "guide",
@@ -170,7 +171,8 @@
             "groupId": "org.springframework.boot",
             "id": "security",
             "name": "Security",
-            "scope": "compile"
+            "scope": "compile",
+            "annotationProcessorForTests": false
           },
           {
             "aliases": ["jpa"],
@@ -179,7 +181,8 @@
             "groupId": "org.springframework.boot",
             "id": "data-jpa",
             "name": "Data JPA",
-            "scope": "compile"
+            "scope": "compile",
+            "annotationProcessorForTests": false
           }
         ],
         "name": "Core"
@@ -196,6 +199,7 @@
             "keywords": ["thefoo", "dafoo"],
             "scope": "compile",
             "version": "1.3.5",
+            "annotationProcessorForTests": false,
             "links": [
               {
                 "rel": "guide",
@@ -220,7 +224,8 @@
             "id": "org.acme:bar",
             "name": "Bar",
             "scope": "compile",
-            "version": "2.1.0"
+            "version": "2.1.0",
+            "annotationProcessorForTests": false
           },
           {
             "starter": true,
@@ -230,7 +235,8 @@
             "name": "Biz",
             "scope": "runtime",
             "version": "1.3.5",
-            "compatibilityRange": "2.6.0-SNAPSHOT"
+            "compatibilityRange": "2.6.0-SNAPSHOT",
+            "annotationProcessorForTests": false
           },
           {
             "starter": true,
@@ -240,7 +246,8 @@
             "name": "Bur",
             "scope": "test",
             "version": "2.1.0",
-            "compatibilityRange": "[2.4.4,2.5.0-SNAPSHOT)"
+            "compatibilityRange": "[2.4.4,2.5.0-SNAPSHOT)",
+            "annotationProcessorForTests": false
           },
           {
             "starter": true,
@@ -249,7 +256,8 @@
             "id": "my-api",
             "name": "My API",
             "scope": "provided",
-            "bom": "my-api-bom"
+            "bom": "my-api-bom",
+            "annotationProcessorForTests": false
           }
         ],
         "name": "Other"


### PR DESCRIPTION
Add opt-in support for annotation processor dependencies (e.g. Lombok) to be available for test compilation when using Gradle. When metadata sets annotationProcessorForTests: true, the dependency is added to both annotationProcessor and testAnnotationProcessor configurations.

- Add annotationProcessorForTests flag to Dependency metadata
- Add TEST_ANNOTATION_PROCESSOR scope to DependencyScope
- Map scope in GradleBuildWriter and MavenBuildWriter
- Add testCompileOnly.extendsFrom(testAnnotationProcessor) in Gradle customizer
- Resolve test annotation processor dependency in DefaultProjectRequestToDescriptionConverter
- Add MetadataBuildItemMapper.toDependency overload with scope override
- Add tests and BuildComplianceTests for end-to-end verification

Closes gh-1380