### PR TITLE
Add JVM version adjustment recording and HELP documentation

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/documentation/HelpDocumentProjectGenerationDefaultContributorsConfiguration.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/documentation/HelpDocumentProjectGenerationDefaultContributorsConfiguration.java
@@ -32,6 +32,12 @@ import org.springframework.context.annotation.Configuration;
 public class HelpDocumentProjectGenerationDefaultContributorsConfiguration {
 
 	@Bean
+	public JvmVersionAdjustmentsHelpDocumentCustomizer jvmVersionAdjustmentsHelpDocumentCustomizer(
+			ProjectDescription description) {
+		return new JvmVersionAdjustmentsHelpDocumentCustomizer(description);
+	}
+
+	@Bean
 	public RequestedDependenciesHelpDocumentCustomizer dependenciesHelpDocumentCustomizer(
 			ProjectDescription description, InitializrMetadata metadata) {
 		return new RequestedDependenciesHelpDocumentCustomizer(description, metadata);

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/documentation/JvmVersionAdjustmentsHelpDocumentCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/documentation/JvmVersionAdjustmentsHelpDocumentCustomizer.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2012 - present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.documentation;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.spring.initializr.generator.project.JvmVersionAdjustment;
+import io.spring.initializr.generator.project.ProjectDescription;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.core.Ordered;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@link HelpDocumentCustomizer} that documents {@link JvmVersionAdjustment}s recorded on
+ * the {@link ProjectDescription}.
+ *
+ * @author Moritz Halbritter
+ */
+public class JvmVersionAdjustmentsHelpDocumentCustomizer implements HelpDocumentCustomizer {
+
+	private final ProjectDescription description;
+
+	public JvmVersionAdjustmentsHelpDocumentCustomizer(ProjectDescription description) {
+		this.description = description;
+	}
+
+	@Override
+	public void customize(HelpDocument document) {
+		List<JvmVersionAdjustment> adjustments = this.description.getJvmVersionAdjustments();
+		if (adjustments.isEmpty()) {
+			return;
+		}
+		Map<String, Object> model = new HashMap<>();
+		model.put("items", adjustments.stream().map(this::toBulletLine).toList());
+		document.addSection("documentation/jvm-version-adjustments", model);
+	}
+
+	@Override
+	public int getOrder() {
+		return Ordered.LOWEST_PRECEDENCE - 10;
+	}
+
+	private String toBulletLine(JvmVersionAdjustment adjustment) {
+		String from = adjustment.fromVersion();
+		String to = adjustment.toVersion();
+		return switch (adjustment.reason()) {
+			case SPRING_BOOT ->
+				"The JVM level was changed from %s to %s to match the requirements of the selected Spring Boot version."
+					.formatted(from, to);
+			case KOTLIN_COMPILER -> formatKotlin(from, to, adjustment.detail());
+			case SELECTED_DEPENDENCY -> formatDependency(from, to, adjustment.dependencyId(), adjustment.detail());
+		};
+	}
+
+	private String formatKotlin(String from, String to, @Nullable String kotlinVersion) {
+		if (StringUtils.hasText(kotlinVersion)) {
+			return ("The JVM level was changed from %s to %s because Kotlin %s does not support the previously selected JVM level for this project.")
+				.formatted(from, to, kotlinVersion);
+		}
+		return ("The JVM level was changed from %s to %s because the selected Kotlin version does not support the previously selected JVM level for this project.")
+			.formatted(from, to);
+	}
+
+	private String formatDependency(String from, String to, @Nullable String dependencyId, @Nullable String detail) {
+		String label = firstNonEmpty(detail, dependencyId);
+		if (StringUtils.hasText(label)) {
+			return ("The JVM level was changed from %s to %s because the dependency \"%s\" requires a newer JVM level.")
+				.formatted(from, to, label);
+		}
+		return ("The JVM level was changed from %s to %s because a selected dependency requires a newer JVM level.")
+			.formatted(from, to);
+	}
+
+	private static @Nullable String firstNonEmpty(@Nullable String a, @Nullable String b) {
+		if (StringUtils.hasText(a)) {
+			return a;
+		}
+		if (StringUtils.hasText(b)) {
+			return b;
+		}
+		return null;
+	}
+
+}

--- a/initializr-generator-spring/src/main/resources/templates/documentation/jvm-version-adjustments.mustache
+++ b/initializr-generator-spring/src/main/resources/templates/documentation/jvm-version-adjustments.mustache
@@ -1,0 +1,7 @@
+### JVM version
+
+The following changes were made to the selected JVM level:
+
+{{#items}}
+* {{.}}
+{{/items}}

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/documentation/HelpDocumentProjectGenerationConfigurationTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/documentation/HelpDocumentProjectGenerationConfigurationTests.java
@@ -16,9 +16,12 @@
 
 package io.spring.initializr.generator.spring.documentation;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import io.spring.initializr.generator.io.template.MustacheTemplateRenderer;
+import io.spring.initializr.generator.project.JvmVersionAdjustment;
+import io.spring.initializr.generator.project.JvmVersionAdjustmentReason;
 import io.spring.initializr.generator.project.MutableProjectDescription;
 import io.spring.initializr.generator.spring.scm.git.GitIgnoreCustomizer;
 import io.spring.initializr.generator.test.InitializrMetadataTestBuilder;
@@ -58,6 +61,17 @@ class HelpDocumentProjectGenerationConfigurationTests {
 	void helpDocumentIsNotContributedWithoutLinks() {
 		ProjectStructure project = this.projectTester.generate(new MutableProjectDescription());
 		assertThat(project).filePaths().isEmpty();
+	}
+
+	@Test
+	void helpDocumentIsContributedWithJvmVersionAdjustmentsOnly() throws Exception {
+		MutableProjectDescription description = new MutableProjectDescription();
+		description
+			.addJvmVersionAdjustment(new JvmVersionAdjustment("1.8", "17", JvmVersionAdjustmentReason.SPRING_BOOT));
+		ProjectStructure project = this.projectTester.generate(description);
+		assertThat(project).filePaths().containsOnly("HELP.md");
+		assertThat(Files.readString(project.getProjectDirectory().resolve("HELP.md"))).contains("### JVM version",
+				"Spring Boot");
 	}
 
 	@Test

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/documentation/JvmVersionAdjustmentsHelpDocumentCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/documentation/JvmVersionAdjustmentsHelpDocumentCustomizerTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2012 - present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.spring.documentation;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import io.spring.initializr.generator.io.template.MustacheTemplateRenderer;
+import io.spring.initializr.generator.project.JvmVersionAdjustment;
+import io.spring.initializr.generator.project.JvmVersionAdjustmentReason;
+import io.spring.initializr.generator.project.MutableProjectDescription;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link JvmVersionAdjustmentsHelpDocumentCustomizer}.
+ *
+ * @author Moritz Halbritter
+ */
+class JvmVersionAdjustmentsHelpDocumentCustomizerTests {
+
+	private final MustacheTemplateRenderer templateRenderer = new MustacheTemplateRenderer("classpath:/templates");
+
+	@Test
+	void noAdjustmentsDoesNotAddSection() {
+		MutableProjectDescription description = new MutableProjectDescription();
+		HelpDocument document = new HelpDocument(this.templateRenderer);
+		new JvmVersionAdjustmentsHelpDocumentCustomizer(description).customize(document);
+		assertThat(document.getSections()).isEmpty();
+	}
+
+	@Test
+	void recordsSpringBootAndDependencyAdjustmentsInOrder() {
+		MutableProjectDescription description = new MutableProjectDescription();
+		description
+			.addJvmVersionAdjustment(new JvmVersionAdjustment("1.8", "17", JvmVersionAdjustmentReason.SPRING_BOOT));
+		description.addJvmVersionAdjustment(new JvmVersionAdjustment("17", "21",
+				JvmVersionAdjustmentReason.SELECTED_DEPENDENCY, "vaadin", "Vaadin"));
+		HelpDocument document = new HelpDocument(this.templateRenderer);
+		new JvmVersionAdjustmentsHelpDocumentCustomizer(description).customize(document);
+		assertThat(document.getSections()).hasSize(1);
+		String out = write(document);
+		assertThat(out).contains("### JVM version", "JVM level was changed from 1.8 to 17", "Spring Boot",
+				"JVM level was changed from 17 to 21", "Vaadin");
+	}
+
+	@Test
+	void kotlinMessageWithVersionInDetail() {
+		MutableProjectDescription description = new MutableProjectDescription();
+		description.addJvmVersionAdjustment(
+				new JvmVersionAdjustment("25", "21", JvmVersionAdjustmentReason.KOTLIN_COMPILER, null, "2.2.0"));
+		HelpDocument document = new HelpDocument(this.templateRenderer);
+		new JvmVersionAdjustmentsHelpDocumentCustomizer(description).customize(document);
+		String out = write(document);
+		assertThat(out).contains("Kotlin 2.2.0 does not support the previously selected JVM level");
+	}
+
+	@Test
+	void getOrderIsBeforeLowestPrecedence() {
+		assertThat(new JvmVersionAdjustmentsHelpDocumentCustomizer(new MutableProjectDescription()).getOrder())
+			.isLessThan(org.springframework.core.Ordered.LOWEST_PRECEDENCE);
+	}
+
+	private String write(HelpDocument document) {
+		try {
+			StringWriter out = new StringWriter();
+			document.write(new PrintWriter(out));
+			return out.toString();
+		}
+		catch (IOException ex) {
+			throw new IllegalStateException(ex);
+		}
+	}
+
+}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/project/JvmVersionAdjustment.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/project/JvmVersionAdjustment.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2012 - present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.project;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.Assert;
+
+/**
+ * A single JVM level change applied while customizing a {@link ProjectDescription}, with
+ * enough context to explain the change to the user.
+ *
+ * @param fromVersion JVM level before the change (as in
+ * {@link io.spring.initializr.generator.language.Language#jvmVersion()})
+ * @param toVersion JVM level after the change
+ * @param reason the cause of the adjustment
+ * @param dependencyId optional dependency id when
+ * {@link JvmVersionAdjustmentReason#SELECTED_DEPENDENCY}
+ * @param detail optional extra text (e.g. Kotlin version, or a human-readable dependency
+ * name)
+ * @author Moritz Halbritter
+ */
+public record JvmVersionAdjustment(String fromVersion, String toVersion, JvmVersionAdjustmentReason reason,
+		@Nullable String dependencyId, @Nullable String detail) {
+
+	public JvmVersionAdjustment {
+		Assert.hasText(fromVersion, "'fromVersion' must not be empty");
+		Assert.hasText(toVersion, "'toVersion' must not be empty");
+		Assert.notNull(reason, "'reason' must not be null");
+	}
+
+	/**
+	 * Create an adjustment with no optional fields.
+	 */
+	public JvmVersionAdjustment(String fromVersion, String toVersion, JvmVersionAdjustmentReason reason) {
+		this(fromVersion, toVersion, reason, null, null);
+	}
+
+}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/project/JvmVersionAdjustmentReason.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/project/JvmVersionAdjustmentReason.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012 - present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.initializr.generator.project;
+
+/**
+ * Why a project {@link ProjectDescription} had its JVM level adjusted during
+ * customization.
+ *
+ * @author Moritz Halbritter
+ */
+public enum JvmVersionAdjustmentReason {
+
+	/**
+	 * The selected Spring Boot / platform version requires a higher JVM level.
+	 */
+	SPRING_BOOT,
+
+	/**
+	 * The selected Kotlin version does not support the requested JVM level.
+	 */
+	KOTLIN_COMPILER,
+
+	/**
+	 * A selected dependency requires a higher JVM level than was in effect.
+	 */
+	SELECTED_DEPENDENCY
+
+}

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/project/MutableProjectDescription.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/project/MutableProjectDescription.java
@@ -16,8 +16,10 @@
 
 package io.spring.initializr.generator.project;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import io.spring.initializr.generator.buildsystem.BuildSystem;
@@ -28,6 +30,7 @@ import io.spring.initializr.generator.packaging.Packaging;
 import io.spring.initializr.generator.version.Version;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
@@ -65,6 +68,8 @@ public class MutableProjectDescription implements ProjectDescription {
 
 	private @Nullable String baseDirectory;
 
+	private final List<JvmVersionAdjustment> jvmVersionAdjustments = new ArrayList<>();
+
 	/**
 	 * Creates a new instance.
 	 */
@@ -90,6 +95,7 @@ public class MutableProjectDescription implements ProjectDescription {
 		this.applicationName = source.getApplicationName();
 		this.packageName = source.getPackageName();
 		this.baseDirectory = source.getBaseDirectory();
+		this.jvmVersionAdjustments.addAll(source.getJvmVersionAdjustments());
 	}
 
 	@Override
@@ -304,6 +310,22 @@ public class MutableProjectDescription implements ProjectDescription {
 	 */
 	public void setBaseDirectory(@Nullable String baseDirectory) {
 		this.baseDirectory = baseDirectory;
+	}
+
+	@Override
+	public List<JvmVersionAdjustment> getJvmVersionAdjustments() {
+		return Collections.unmodifiableList(this.jvmVersionAdjustments);
+	}
+
+	/**
+	 * Record that the effective JVM level was changed during customization. Callers
+	 * should append an entry each time they change the JVM level (for example by
+	 * replacing {@link #setLanguage(io.spring.initializr.generator.language.Language)}).
+	 * @param adjustment the change to record
+	 */
+	public void addJvmVersionAdjustment(JvmVersionAdjustment adjustment) {
+		Assert.notNull(adjustment, "'adjustment' must not be null");
+		this.jvmVersionAdjustments.add(adjustment);
 	}
 
 }

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/project/ProjectDescription.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/project/ProjectDescription.java
@@ -16,6 +16,8 @@
 
 package io.spring.initializr.generator.project;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import io.spring.initializr.generator.buildsystem.BuildSystem;
@@ -126,5 +128,14 @@ public interface ProjectDescription {
 	 * @return the base directory
 	 */
 	@Nullable String getBaseDirectory();
+
+	/**
+	 * Return adjustments applied to the JVM level while customizing the project, in
+	 * chronological order, or an empty list when none were recorded.
+	 * @return an unmodifiable list (never {@code null})
+	 */
+	default List<JvmVersionAdjustment> getJvmVersionAdjustments() {
+		return Collections.emptyList();
+	}
 
 }

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/project/MutableProjectDescriptionTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/project/MutableProjectDescriptionTests.java
@@ -20,6 +20,7 @@ import io.spring.initializr.generator.buildsystem.Dependency;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -45,6 +46,43 @@ class MutableProjectDescriptionTests {
 		description.addDependency("core", mock(Dependency.class));
 		assertThat(description.removeDependency("unknown")).isNull();
 		assertThat(description.getRequestedDependencies()).containsOnlyKeys("core");
+	}
+
+	@Test
+	void jvmVersionAdjustmentsAreInitiallyEmpty() {
+		MutableProjectDescription description = new MutableProjectDescription();
+		assertThat(description.getJvmVersionAdjustments()).isEmpty();
+	}
+
+	@Test
+	@SuppressWarnings("NullAway") // deliberate null for contract test
+	void addJvmVersionAdjustmentRejectsNull() {
+		MutableProjectDescription description = new MutableProjectDescription();
+		assertThatThrownBy(() -> description.addJvmVersionAdjustment(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("'adjustment' must not be null");
+	}
+
+	@Test
+	void getJvmVersionAdjustmentsIsUnmodifiable() {
+		MutableProjectDescription description = new MutableProjectDescription();
+		description
+			.addJvmVersionAdjustment(new JvmVersionAdjustment("1.8", "17", JvmVersionAdjustmentReason.SPRING_BOOT));
+		assertThatThrownBy(() -> description.getJvmVersionAdjustments().clear())
+			.isInstanceOf(UnsupportedOperationException.class);
+	}
+
+	@Test
+	void createCopyIncludesJvmVersionAdjustments() {
+		MutableProjectDescription source = new MutableProjectDescription();
+		source.addJvmVersionAdjustment(new JvmVersionAdjustment("1.8", "17", JvmVersionAdjustmentReason.SPRING_BOOT));
+		source.addJvmVersionAdjustment(
+				new JvmVersionAdjustment("17", "21", JvmVersionAdjustmentReason.SELECTED_DEPENDENCY, "jooq", "jOOQ"));
+		MutableProjectDescription copy = source.createCopy();
+		assertThat(copy.getJvmVersionAdjustments()).hasSize(2).isEqualTo(source.getJvmVersionAdjustments());
+		assertThat(source.getJvmVersionAdjustments().get(0).toVersion()).isEqualTo("17");
+		source.addJvmVersionAdjustment(
+				new JvmVersionAdjustment("21", "25", JvmVersionAdjustmentReason.KOTLIN_COMPILER, null, "2.2.0"));
+		assertThat(copy.getJvmVersionAdjustments()).hasSize(2);
 	}
 
 }


### PR DESCRIPTION
## Summary

This change adds infrastructure for [spring-io/initializr#1742](https://github.com/spring-io/initializr/issues/1742): a way to **record** why the effective JVM level was adjusted during project customization, and to **surface** those reasons in generated `HELP.md`.

## What is included

- `JvmVersionAdjustment` record and `JvmVersionAdjustmentReason` enum (Spring Boot, Kotlin compiler, selected dependency)
- `ProjectDescription#getJvmVersionAdjustments()` with storage on `MutableProjectDescription` and `addJvmVersionAdjustment`
- `JvmVersionAdjustmentsHelpDocumentCustomizer` + Mustache template
- Bean registration in `HelpDocumentProjectGenerationDefaultContributorsConfiguration`
- Unit / configuration tests

## Follow - up (not in this PR)

Nothing in production code yet calls `addJvmVersionAdjustment` when the JVM level is actually changed (e.g. Boot compatibility, Kotlin, dependency baselines). A follow-up should wire those call sites - possibly including start.spring.io-specific customizers - so users see accurate HELP for real requests.