### PR TITLE
Lombok and spring-boot-configuration-processor are ordered contrary to Boot's docs

### DIFF
--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/maven/ConvertAnnotationProcessorsToPluginConfigBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/maven/ConvertAnnotationProcessorsToPluginConfigBuildCustomizer.java
@@ -17,11 +17,13 @@
 package io.spring.initializr.generator.spring.build.maven;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.DependencyScope;
 import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
 import io.spring.initializr.generator.buildsystem.maven.MavenPluginContainer;
 import io.spring.initializr.generator.language.Language;
@@ -49,6 +51,8 @@ class ConvertAnnotationProcessorsToPluginConfigBuildCustomizer implements BuildC
 		this.projectDescription = projectDescription;
 	}
 
+	private static final List<String> LAST_ANNOTATION_PROCESSORS = Collections.singletonList("configuration-processor");
+
 	@Override
 	public void customize(MavenBuild build) {
 		if (!isJava()) {
@@ -57,10 +61,16 @@ class ConvertAnnotationProcessorsToPluginConfigBuildCustomizer implements BuildC
 		Set<String> ids = build.dependencies().ids().collect(Collectors.toSet());
 		List<Dependency> annotationProcessors = new ArrayList<>();
 		List<Dependency> testAnnotationProcessors = new ArrayList<>();
+		Dependency configurationProcessor = null;
 		for (String id : ids) {
 			Dependency dependency = build.dependencies().get(id);
 			Assert.state(dependency != null, "'dependency' must not be null");
 			if (dependency.getScope() == null) {
+				continue;
+			}
+			if (LAST_ANNOTATION_PROCESSORS.contains(id)) {
+				configurationProcessor = dependency;
+				build.dependencies().remove(id);
 				continue;
 			}
 			switch (dependency.getScope()) {
@@ -72,6 +82,14 @@ class ConvertAnnotationProcessorsToPluginConfigBuildCustomizer implements BuildC
 					build.dependencies().remove(id);
 					testAnnotationProcessors.add(dependency);
 				}
+			}
+		}
+		if (configurationProcessor != null && configurationProcessor.getScope() != null) {
+			if (configurationProcessor.getScope().equals(DependencyScope.ANNOTATION_PROCESSOR)) {
+				annotationProcessors.add(configurationProcessor);
+			}
+			else {
+				testAnnotationProcessors.add(configurationProcessor);
 			}
 		}
 		configureCompilerPlugin(build.plugins(), annotationProcessors, "default-compile", "compile", "compile");

--- a/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/maven/ConvertAnnotationProcessorsToPluginConfigBuildCustomizer.java
+++ b/initializr-generator-spring/src/main/java/io/spring/initializr/generator/spring/build/maven/ConvertAnnotationProcessorsToPluginConfigBuildCustomizer.java
@@ -88,7 +88,7 @@ class ConvertAnnotationProcessorsToPluginConfigBuildCustomizer implements BuildC
 			if (configurationProcessor.getScope().equals(DependencyScope.ANNOTATION_PROCESSOR)) {
 				annotationProcessors.add(configurationProcessor);
 			}
-			else {
+			else if (configurationProcessor.getScope().equals(DependencyScope.TEST_ANNOTATION_PROCESSOR)) {
 				testAnnotationProcessors.add(configurationProcessor);
 			}
 		}

--- a/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/maven/ConvertAnnotationProcessorsToPluginConfigBuildCustomizerTests.java
+++ b/initializr-generator-spring/src/test/java/io/spring/initializr/generator/spring/build/maven/ConvertAnnotationProcessorsToPluginConfigBuildCustomizerTests.java
@@ -403,6 +403,34 @@ class ConvertAnnotationProcessorsToPluginConfigBuildCustomizerTests {
 		assertThat(pom).doesNotContain("<annotationProcessorPaths>");
 	}
 
+	@Test
+	void configurationProcessorIsAddedLast() throws IOException {
+		MavenBuild build = new MavenBuild();
+		build.dependencies()
+			.add("lombok", Dependency.withCoordinates("org.projectlombok", "lombok")
+				.scope(DependencyScope.ANNOTATION_PROCESSOR));
+		build.dependencies()
+			.add("configuration-processor",
+					Dependency.withCoordinates("org.springframework.boot", "spring-boot-configuration-processor")
+						.scope(DependencyScope.ANNOTATION_PROCESSOR));
+		this.customizer.customize(build);
+		String pom = generatePom(build);
+		assertThat(pom).containsIgnoringWhitespaces("""
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+						<path>
+							<groupId>org.springframework.boot</groupId>
+							<artifactId>spring-boot-configuration-processor</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>""");
+
+	}
+
 	private String generatePom(MavenBuild build) throws IOException {
 		StringWriter writer = new StringWriter();
 		new MavenBuildProjectContributor(build, IndentingWriterFactory.withDefaultSettings()).writeBuild(writer);

--- a/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/buildsystem/gradle/GradleBuildWriter.java
@@ -174,7 +174,7 @@ public abstract class GradleBuildWriter {
 			.addAll(filterDependencies(dependencies, (scope) -> scope == null || scope == DependencyScope.COMPILE));
 		sortedDependencies.addAll(filterDependencies(dependencies, hasScope(DependencyScope.COMPILE_ONLY)));
 		sortedDependencies.addAll(filterDependencies(dependencies, hasScope(DependencyScope.RUNTIME)));
-		sortedDependencies.addAll(filterDependencies(dependencies, hasScope(DependencyScope.ANNOTATION_PROCESSOR)));
+		sortedDependencies.addAll(generateAnnotationProcessors(dependencies));
 		sortedDependencies.addAll(filterDependencies(dependencies, hasScope(DependencyScope.PROVIDED_RUNTIME)));
 		sortedDependencies.addAll(filterDependencies(dependencies, hasScope(DependencyScope.TEST_COMPILE)));
 		sortedDependencies.addAll(filterDependencies(dependencies, hasScope(DependencyScope.TEST_COMPILE_ONLY)));
@@ -187,6 +187,21 @@ public abstract class GradleBuildWriter {
 			writer.indented(() -> sortedDependencies.forEach((dependency) -> writeDependency(writer, dependency)));
 			writer.println("}");
 		}
+	}
+
+	private Collection<Dependency> generateAnnotationProcessors(DependencyContainer dependencies) {
+		Dependency configurationProcessor = dependencies.get("configuration-processor");
+		Collection<Dependency> annotationProcessors = filterDependencies(dependencies,
+				hasScope(DependencyScope.ANNOTATION_PROCESSOR))
+			.stream()
+			.filter((dependency) -> dependency != configurationProcessor)
+			.collect(Collectors.toList());
+
+		if (configurationProcessor != null
+				&& configurationProcessor.getScope() == (DependencyScope.ANNOTATION_PROCESSOR)) {
+			annotationProcessors.add(configurationProcessor);
+		}
+		return annotationProcessors;
 	}
 
 	private Predicate<@Nullable DependencyScope> hasScope(DependencyScope... validScopes) {

--- a/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
+++ b/initializr-generator/src/test/java/io/spring/initializr/generator/buildsystem/gradle/GroovyDslGradleBuildWriterTests.java
@@ -361,6 +361,37 @@ class GroovyDslGradleBuildWriterTests extends GradleBuildWriterTests {
 	}
 
 	@Test
+	void gradleBuildWithAnnotationProcessorPlaceConfigurationProcessorLast() {
+		GradleBuild build = new GradleBuild();
+		build.dependencies()
+			.add("lombok", Dependency.withCoordinates("org.projectlombok", "lombok")
+				.scope(DependencyScope.ANNOTATION_PROCESSOR));
+		build.dependencies()
+			.add("configuration-processor",
+					Dependency.withCoordinates("org.springframework.boot", "spring-boot-configuration-processor")
+						.scope(DependencyScope.ANNOTATION_PROCESSOR));
+		String result = write(build);
+		assertThat(result).containsSubsequence("annotationProcessor 'org.projectlombok:lombok'",
+				"annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'");
+		assertThat(result)
+			.containsOnlyOnce("annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'");
+	}
+
+	@Test
+	void gradleBuildAnnotationProcessorOrderIgnoredWhenScopeDiffers() {
+		GradleBuild build = new GradleBuild();
+		build.dependencies()
+			.add("lombok", Dependency.withCoordinates("org.projectlombok", "lombok")
+				.scope(DependencyScope.ANNOTATION_PROCESSOR));
+		build.dependencies()
+			.add("configuration-processor",
+					Dependency.withCoordinates("org.springframework.boot", "spring-boot-configuration-processor")
+						.scope(DependencyScope.COMPILE_ONLY));
+		assertThat(write(build))
+			.doesNotContain("annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'");
+	}
+
+	@Test
 	void gradleBuildWithTestAnnotationProcessorDependency() {
 		GradleBuild build = new GradleBuild();
 		build.dependencies()


### PR DESCRIPTION
Closes #1794

### Changes

- Updated `GradleBuildWriter` to ensure `configuration-processor` is excluded from the initial annotation processor collection and appended last when present.
- Updated `ConvertAnnotationProcessorsToPluginConfigBuildCustomizer` to apply the same ordering logic for annotation processors.