### PR TITLE
Use AssertJ to assert on exceptions

### DIFF
--- a/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectGenerationControllerCustomEnvIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectGenerationControllerCustomEnvIntegrationTests.java
@@ -26,6 +26,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.HttpClientErrorException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * Integration tests for {@link ProjectGenerationController} with custom environment.
@@ -51,27 +52,25 @@ class ProjectGenerationControllerCustomEnvIntegrationTests extends AbstractIniti
 
 	@Test
 	void generateProjectWithUnsupportedPlatformVersion() {
-		try {
-			execute("/starter.zip?bootVersion=1.5.12.RELEASE", byte[].class, null, (String[]) null);
-		}
-		catch (HttpClientErrorException ex) {
-			assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-			assertThat(ex.getMessage()).contains("Invalid Spring Boot version",
-					"Spring Boot compatibility range is >=2.0.0.RELEASE");
-		}
+		assertThatExceptionOfType(HttpClientErrorException.class)
+			.isThrownBy(() -> execute("/starter.zip?bootVersion=1.5.12.RELEASE", byte[].class, null, (String[]) null))
+			.satisfies((ex) -> {
+				assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+				assertThat(ex.getMessage()).contains("Invalid Spring Boot version",
+						"Spring Boot compatibility range is >=2.0.0.RELEASE");
+			});
 	}
 
 	@Test
 	void getDependenciesMetadataWithUnsupportedPlatformVersion() {
-		try {
-			execute("/dependencies?bootVersion=1.5.12.RELEASE", String.class, "application/vnd.initializr.v2.1+json",
-					"application/json");
-		}
-		catch (HttpClientErrorException ex) {
-			assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-			assertThat(ex.getMessage()).contains("Invalid Spring Boot version",
-					"Spring Boot compatibility range is >=2.0.0.RELEASE");
-		}
+		assertThatExceptionOfType(HttpClientErrorException.class)
+			.isThrownBy(() -> execute("/dependencies?bootVersion=1.5.12.RELEASE", String.class,
+					"application/vnd.initializr.v2.1+json", "application/json"))
+			.satisfies((ex) -> {
+				assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+				assertThat(ex.getMessage()).contains("Invalid Spring Boot version",
+						"Spring Boot compatibility range is >=2.0.0.RELEASE");
+			});
 	}
 
 }

--- a/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectGenerationControllerIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectGenerationControllerIntegrationTests.java
@@ -155,12 +155,14 @@ class ProjectGenerationControllerIntegrationTests extends AbstractInitializrCont
 
 	@Test
 	void dependencyNotInRange() {
-		try {
-			execute("/starter.tgz?dependencies=org.acme:bur", byte[].class, null, (String[]) null);
-		}
-		catch (HttpClientErrorException ex) {
-			assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE);
-		}
+		assertThatExceptionOfType(HttpClientErrorException.class)
+			.isThrownBy(() -> execute("/starter.tgz?dependencies=org.acme:bur&bootVersion=2.3.10.RELEASE", byte[].class,
+					null, (String[]) null))
+			.satisfies((ex) -> {
+				assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+				assertStandardErrorBody(ex.getResponseBodyAsString(),
+						"Dependency 'org.acme:bur' is not compatible with Spring Boot 2.3.10.RELEASE");
+			});
 	}
 
 	@Test

--- a/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerCustomDefaultsIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerCustomDefaultsIntegrationTests.java
@@ -38,6 +38,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.HttpClientErrorException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * Integration tests for {@link ProjectMetadataController} on a real http server.
@@ -67,12 +68,9 @@ class ProjectMetadataControllerCustomDefaultsIntegrationTests extends AbstractFu
 
 	@Test
 	void textPlainNotAccepted() {
-		try {
-			execute("/metadata/config", String.class, null, "text/plain");
-		}
-		catch (HttpClientErrorException ex) {
-			assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE);
-		}
+		assertThatExceptionOfType(HttpClientErrorException.class)
+			.isThrownBy(() -> execute("/metadata/config", String.class, null, "text/plain"))
+			.satisfies((ex) -> assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE));
 	}
 
 	@Test

--- a/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerIntegrationTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/controller/ProjectMetadataControllerIntegrationTests.java
@@ -84,14 +84,13 @@ class ProjectMetadataControllerIntegrationTests extends AbstractInitializrContro
 
 	@Test
 	void metadataWithInvalidPlatformVersion() {
-		try {
-			execute("/dependencies?bootVersion=2.2.17.RELEASE", String.class, "application/vnd.initializr.v2.1+json",
-					"application/json");
-		}
-		catch (HttpClientErrorException ex) {
-			assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-			assertThat(ex.getResponseBodyAsString()).contains("2.2.17.RELEASE");
-		}
+		assertThatExceptionOfType(HttpClientErrorException.class)
+			.isThrownBy(() -> execute("/dependencies?bootVersion=2.2.17.RELEASE", String.class,
+					"application/vnd.initializr.v2.1+json", "application/json"))
+			.satisfies((ex) -> {
+				assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+				assertThat(ex.getResponseBodyAsString()).contains("2.2.17.RELEASE");
+			});
 	}
 
 	@Test
@@ -161,12 +160,9 @@ class ProjectMetadataControllerIntegrationTests extends AbstractInitializrContro
 
 	@Test
 	void metadataWithUnknownAcceptHeader() {
-		try {
-			invokeHome(null, "application/vnd.initializr.v5.4+json");
-		}
-		catch (HttpClientErrorException ex) {
-			assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE);
-		}
+		assertThatExceptionOfType(HttpClientErrorException.class)
+			.isThrownBy(() -> invokeHome(null, "application/vnd.initializr.v5.4+json"))
+			.satisfies((ex) -> assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE));
 	}
 
 	@Test

--- a/initializr-web/src/test/java/io/spring/initializr/web/project/ProjectGenerationInvokerTests.java
+++ b/initializr-web/src/test/java/io/spring/initializr/web/project/ProjectGenerationInvokerTests.java
@@ -48,6 +48,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -103,12 +104,9 @@ class ProjectGenerationInvokerTests {
 		WebProjectRequest request = new WebProjectRequest();
 		request.initialize(metadata);
 		request.setType("foo-bar");
-		try {
-			this.invoker.invokeProjectStructureGeneration(request);
-		}
-		catch (Exception ex) {
-			verifyProjectFailedEventFor(request, ex);
-		}
+		assertThatExceptionOfType(InvalidProjectRequestException.class)
+			.isThrownBy(() -> this.invoker.invokeProjectStructureGeneration(request))
+			.satisfies((ex) -> verifyProjectFailedEventFor(request, ex));
 	}
 
 	@Test
@@ -167,12 +165,9 @@ class ProjectGenerationInvokerTests {
 		WebProjectRequest request = new WebProjectRequest();
 		request.initialize(metadata);
 		request.setType("foo-bar");
-		try {
-			this.invoker.invokeBuildGeneration(request);
-		}
-		catch (Exception ex) {
-			verifyProjectFailedEventFor(request, ex);
-		}
+		assertThatExceptionOfType(InvalidProjectRequestException.class)
+			.isThrownBy(() -> this.invoker.invokeBuildGeneration(request))
+			.satisfies((ex) -> verifyProjectFailedEventFor(request, ex));
 	}
 
 	@Test


### PR DESCRIPTION
Ensure web tests fail when expected exceptions are not thrown.

Some tests used `try`/`catch` blocks and could pass when no exception was thrown. They now use explicit AssertJ exception assertions.

`dependencyNotInRange` previously omitted `bootVersion`, so it fell back to the [default Spring Boot version, `2.4.4`](https://github.com/spring-io/initializr/blob/efe004bc5499663b3a6e66468bb9e7d111599c75/initializr-web/src/test/resources/application-test-default.yml#L160-L168), which is within the [compatibility range for `org.acme:bur`](https://github.com/spring-io/initializr/blob/efe004bc5499663b3a6e66468bb9e7d111599c75/initializr-web/src/test/resources/application-test-default.yml#L89-L93). It now explicitly requests the out-of-range version `2.3.10.RELEASE` and asserts the `400 Bad Request` status and error message.