### PR TITLE
MustacheTemplateRenderer doesn't close the reader

### DIFF
--- a/initializr-generator/src/main/java/io/spring/initializr/generator/io/template/MustacheTemplateRenderer.java
+++ b/initializr-generator/src/main/java/io/spring/initializr/generator/io/template/MustacheTemplateRenderer.java
@@ -17,7 +17,6 @@
 package io.spring.initializr.generator.io.template;
 
 import java.io.InputStreamReader;
-import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.function.Function;
@@ -106,8 +105,7 @@ public class MustacheTemplateRenderer implements TemplateRenderer {
 	}
 
 	private Template loadTemplate(String name) throws Exception {
-		Reader template = this.mustache.loader.getTemplate(name);
-		return this.mustache.compile(template);
+		return this.mustache.loadTemplate(name);
 	}
 
 }


### PR DESCRIPTION
The [TemplateLoader contract](https://github.com/samskivert/jmustache/blob/3193938ea18eb22ca3e3a3fa56f8ed5894d5c40c/src/main/java/com/samskivert/mustache/Mustache.java#L322-L329) states that the returned Reader will be closed. MustacheTemplateRenderer currently calls getTemplate and compile separately, leaving it open.

Use [Compiler.loadTemplate(String)](https://github.com/samskivert/jmustache/blob/3193938ea18eb22ca3e3a3fa56f8ed5894d5c40c/src/main/java/com/samskivert/mustache/Mustache.java#L234-L251), which performs both operations and closes the reader in a finally block.