### PR TITLE
Fix incorrect project URLs in published Maven POMs

### DIFF
--- a/initializr-actuator/pom.xml
+++ b/initializr-actuator/pom.xml
@@ -14,6 +14,7 @@
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
 	</properties>
+	<url>${git.url}</url>
 	<scm>
 		<url>${git.url}</url>
 		<connection>${git.connection}</connection>

--- a/initializr-bom/pom.xml
+++ b/initializr-bom/pom.xml
@@ -15,6 +15,7 @@
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
 	</properties>
+	<url>${git.url}</url>
 	<scm>
 		<url>${git.url}</url>
 		<connection>${git.connection}</connection>

--- a/initializr-docs/pom.xml
+++ b/initializr-docs/pom.xml
@@ -17,6 +17,7 @@
 		<spring-asciidoctor-backends.version>0.0.6</spring-asciidoctor-backends.version>
 		<null-away.require-explicit-null-marking>OFF</null-away.require-explicit-null-marking>
 	</properties>
+	<url>${git.url}</url>
 	<scm>
 		<url>${git.url}</url>
 		<connection>${git.connection}</connection>

--- a/initializr-generator-spring/pom.xml
+++ b/initializr-generator-spring/pom.xml
@@ -14,6 +14,7 @@
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
 	</properties>
+	<url>${git.url}</url>
 	<scm>
 		<url>${git.url}</url>
 		<connection>${git.connection}</connection>

--- a/initializr-generator-test/pom.xml
+++ b/initializr-generator-test/pom.xml
@@ -14,6 +14,7 @@
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
 	</properties>
+	<url>${git.url}</url>
 	<scm>
 		<url>${git.url}</url>
 		<connection>${git.connection}</connection>

--- a/initializr-generator/pom.xml
+++ b/initializr-generator/pom.xml
@@ -30,6 +30,7 @@
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
 	</properties>
+	<url>${git.url}</url>
 	<scm>
 		<url>${git.url}</url>
 		<connection>${git.connection}</connection>

--- a/initializr-metadata/pom.xml
+++ b/initializr-metadata/pom.xml
@@ -14,6 +14,7 @@
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
 	</properties>
+	<url>${git.url}</url>
 	<scm>
 		<url>${git.url}</url>
 		<connection>${git.connection}</connection>

--- a/initializr-parent/pom.xml
+++ b/initializr-parent/pom.xml
@@ -41,6 +41,7 @@
 		<null-away.version>0.12.15</null-away.version>
 		<null-away.require-explicit-null-marking>ERROR</null-away.require-explicit-null-marking>
 	</properties>
+	<url>${git.url}</url>
 	<scm>
 		<url>${git.url}</url>
 		<connection>${git.connection}</connection>

--- a/initializr-service-sample/pom.xml
+++ b/initializr-service-sample/pom.xml
@@ -14,6 +14,7 @@
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
 	</properties>
+	<url>${git.url}</url>
 	<scm>
 		<url>${git.url}</url>
 		<connection>${git.connection}</connection>

--- a/initializr-version-resolver/pom.xml
+++ b/initializr-version-resolver/pom.xml
@@ -14,6 +14,7 @@
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
 	</properties>
+	<url>${git.url}</url>
 	<scm>
 		<url>${git.url}</url>
 		<connection>${git.connection}</connection>

--- a/initializr-web/pom.xml
+++ b/initializr-web/pom.xml
@@ -14,6 +14,7 @@
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
 	</properties>
+	<url>${git.url}</url>
 	<scm>
 		<url>${git.url}</url>
 		<connection>${git.connection}</connection>


### PR DESCRIPTION
### Problem

Maven appends a path adjustment, usually the child artifact ID, to inherited project URLs.  With multiple levels of inheritance, these adjustments accumulate.

For example, [initializr-actuator:0.24.0](https://central.sonatype.com/artifact/io.spring.initializr/initializr-actuator/0.24.0) contains: 
`https://github.com/spring-io/initializr/initializr-bom/initializr-parent/initializr-actuator`

### Changes

Add `<url>${git.url}</url>` to all 11 module POMs. 

Their flattened POMs now contain: `https://github.com/spring-io/initializr`

### Approach

Maven supports [`child.project.url.inherit.append.path="false"`](https://maven.apache.org/ref/3.9.16/maven-model/maven.html), and it works in a full reactor build. However, the [Flatten Maven Plugin](https://www.mojohaus.org/flatten-maven-plugin/) does not preserve the attribute in published parent POMs. A child that inherits from a flattened parent therefore appends its path again.

Declaring `<url>${git.url}</url>` in each module avoids this problem.

[Spring AI](https://github.com/spring-projects/spring-ai/blob/e5e277fd08a017c5a3efc57aef377d2a067e91dd/spring-ai-model/pom.xml#L14) and [Spring Batch](https://github.com/spring-projects/spring-batch/blob/v6.0.5/spring-batch-core/pom.xml#L13) also declare a URL in each module.